### PR TITLE
avoid try-catch style of code

### DIFF
--- a/encoding/binarywrite.go
+++ b/encoding/binarywrite.go
@@ -1,28 +1,38 @@
 package encoding
 
 import (
+	"fmt"
 	"io"
 	"math"
 )
 
 // LittleEndian
-func BinaryWriteINT32(w io.Writer, nums []interface{}) {
+func BinaryWriteINT32(w io.Writer, nums []interface{}) error {
 	buf := make([]byte, len(nums)*4)
 	for i, n := range nums {
-		v := uint32(n.(int32))
+		tmp, ok := n.(int32)
+		if !ok {
+			return fmt.Errorf("[%v] is not int32", n)
+		}
+		v := uint32(tmp)
 		buf[i*4+0] = byte(v)
 		buf[i*4+1] = byte(v >> 8)
 		buf[i*4+2] = byte(v >> 16)
 		buf[i*4+3] = byte(v >> 24)
 	}
-	// return error till we can change function signature
-	_, _ = w.Write(buf)
+
+	_, err := w.Write(buf)
+	return err
 }
 
-func BinaryWriteINT64(w io.Writer, nums []interface{}) {
+func BinaryWriteINT64(w io.Writer, nums []interface{}) error {
 	buf := make([]byte, len(nums)*8)
 	for i, n := range nums {
-		v := uint64(n.(int64))
+		tmp, ok := n.(int64)
+		if !ok {
+			return fmt.Errorf("[%v] is not int64", n)
+		}
+		v := uint64(tmp)
 		buf[i*8+0] = byte(v)
 		buf[i*8+1] = byte(v >> 8)
 		buf[i*8+2] = byte(v >> 16)
@@ -32,27 +42,37 @@ func BinaryWriteINT64(w io.Writer, nums []interface{}) {
 		buf[i*8+6] = byte(v >> 48)
 		buf[i*8+7] = byte(v >> 56)
 	}
-	// return error till we can change function signature
-	_, _ = w.Write(buf)
+
+	_, err := w.Write(buf)
+	return err
 }
 
-func BinaryWriteFLOAT32(w io.Writer, nums []interface{}) {
+func BinaryWriteFLOAT32(w io.Writer, nums []interface{}) error {
 	buf := make([]byte, len(nums)*4)
 	for i, n := range nums {
-		v := math.Float32bits(n.(float32))
+		tmp, ok := n.(float32)
+		if !ok {
+			return fmt.Errorf("[%v] is not float32", n)
+		}
+		v := math.Float32bits(tmp)
 		buf[i*4+0] = byte(v)
 		buf[i*4+1] = byte(v >> 8)
 		buf[i*4+2] = byte(v >> 16)
 		buf[i*4+3] = byte(v >> 24)
 	}
-	// return error till we can change function signature
-	_, _ = w.Write(buf)
+
+	_, err := w.Write(buf)
+	return err
 }
 
-func BinaryWriteFLOAT64(w io.Writer, nums []interface{}) {
+func BinaryWriteFLOAT64(w io.Writer, nums []interface{}) error {
 	buf := make([]byte, len(nums)*8)
 	for i, n := range nums {
-		v := math.Float64bits(n.(float64))
+		tmp, ok := n.(float64)
+		if !ok {
+			return fmt.Errorf("[%v] is not float32", n)
+		}
+		v := math.Float64bits(tmp)
 		buf[i*8+0] = byte(v)
 		buf[i*8+1] = byte(v >> 8)
 		buf[i*8+2] = byte(v >> 16)
@@ -62,6 +82,7 @@ func BinaryWriteFLOAT64(w io.Writer, nums []interface{}) {
 		buf[i*8+6] = byte(v >> 48)
 		buf[i*8+7] = byte(v >> 56)
 	}
-	// return error till we can change function signature
-	_, _ = w.Write(buf)
+
+	_, err := w.Write(buf)
+	return err
 }

--- a/encoding/encodingread_test.go
+++ b/encoding/encodingread_test.go
@@ -21,7 +21,12 @@ func TestReadPlainBOOLEAN(t *testing.T) {
 	}
 
 	for _, data := range testData {
-		res, _ := ReadPlainBOOLEAN(bytes.NewReader(WritePlainBOOLEAN(data)), uint64(len(data)))
+		buf, err := WritePlainBOOLEAN(data)
+		if err != nil {
+			t.Errorf("WritePlainBOOLEAN err, %v", err)
+			continue
+		}
+		res, _ := ReadPlainBOOLEAN(bytes.NewReader(buf), uint64(len(data)))
 		if fmt.Sprintf("%v", data) != fmt.Sprintf("%v", res) {
 			t.Errorf("ReadPlainBOOLEAN err, expect %v, get %v", data, res)
 		}
@@ -71,7 +76,12 @@ func TestReadPlainBYTE_ARRAY(t *testing.T) {
 	}
 
 	for _, data := range testData {
-		res, _ := ReadPlainBYTE_ARRAY(bytes.NewReader(WritePlainBYTE_ARRAY(data)), uint64(len(data)))
+		buf, err := WritePlainBYTE_ARRAY(data)
+		if err != nil {
+			t.Errorf("WritePlainBYTE_ARRAY err, %v", err)
+			continue
+		}
+		res, _ := ReadPlainBYTE_ARRAY(bytes.NewReader(buf), uint64(len(data)))
 		if fmt.Sprintf("%v", data) != fmt.Sprintf("%v", res) {
 			t.Errorf("ReadPlainBYTE_ARRAY err, %v", data)
 		}
@@ -85,7 +95,12 @@ func TestReadPlainFIXED_LEN_BYTE_ARRAY(t *testing.T) {
 	}
 
 	for _, data := range testData {
-		res, _ := ReadPlainFIXED_LEN_BYTE_ARRAY(bytes.NewReader(WritePlainFIXED_LEN_BYTE_ARRAY(data)), uint64(len(data)), uint64(len(data[0].(string))))
+		buf, err := WritePlainFIXED_LEN_BYTE_ARRAY(data)
+		if err != nil {
+			t.Errorf("WritePlainFIXED_LEN_BYTE_ARRAY err, %v", err)
+			continue
+		}
+		res, _ := ReadPlainFIXED_LEN_BYTE_ARRAY(bytes.NewReader(buf), uint64(len(data)), uint64(len(data[0].(string))))
 		if fmt.Sprintf("%v", data) != fmt.Sprintf("%v", res) {
 			t.Errorf("ReadPlainFIXED_LEN_BYTE_ARRAY err, %v", data)
 		}
@@ -99,7 +114,12 @@ func TestReadPlainFLOAT(t *testing.T) {
 	}
 
 	for _, data := range testData {
-		res, _ := ReadPlainFLOAT(bytes.NewReader(WritePlainFLOAT(data)), uint64(len(data)))
+		buf, err := WritePlainFLOAT(data)
+		if err != nil {
+			t.Errorf("WritePlainFLOAT err, %v", err)
+			continue
+		}
+		res, _ := ReadPlainFLOAT(bytes.NewReader(buf), uint64(len(data)))
 		if fmt.Sprintf("%v", data) != fmt.Sprintf("%v", res) {
 			t.Errorf("ReadPlainFLOAT err, %v", data)
 		}
@@ -113,7 +133,12 @@ func TestReadPlainDOUBLE(t *testing.T) {
 	}
 
 	for _, data := range testData {
-		res, _ := ReadPlainDOUBLE(bytes.NewReader(WritePlainDOUBLE(data)), uint64(len(data)))
+		buf, err := WritePlainDOUBLE(data)
+		if err != nil {
+			t.Errorf("WritePlainDOUBLE err, %v", err)
+			continue
+		}
+		res, _ := ReadPlainDOUBLE(bytes.NewReader(buf), uint64(len(data)))
 		if fmt.Sprintf("%v", data) != fmt.Sprintf("%v", res) {
 			t.Errorf("ReadPlainDOUBLE err, %v", data)
 		}
@@ -139,8 +164,12 @@ func TestReadRLEBitPackedHybrid(t *testing.T) {
 	}
 	for _, data := range testData {
 		maxVal := uint64(data[len(data)-1].(int64))
-
-		res, err := ReadRLEBitPackedHybrid(bytes.NewReader(WriteRLEBitPackedHybrid(data, int32(bits.Len64(maxVal)), parquet.Type_INT64)), uint64(bits.Len64(maxVal)), 0)
+		buf, err := WriteRLEBitPackedHybrid(data, int32(bits.Len64(maxVal)), parquet.Type_INT64)
+		if err != nil {
+			t.Errorf("WriteRLEBitPackedHybrid err, %v", err)
+			continue
+		}
+		res, err := ReadRLEBitPackedHybrid(bytes.NewReader(buf), uint64(bits.Len64(maxVal)), 0)
 		if fmt.Sprintf("%v", data) != fmt.Sprintf("%v", res) {
 			t.Errorf("ReadRLEBitpackedHybrid error, expect %v, get %v, err info:%v", data, res, err)
 		}

--- a/encoding/encodingwrite_test.go
+++ b/encoding/encodingwrite_test.go
@@ -77,8 +77,10 @@ func TestWriteRLE(t *testing.T) {
 	}
 
 	for _, data := range testData {
-		res := WriteRLE(data.nums, int32(bits.Len64(uint64(data.nums[len(data.nums)-1].(int64)))), parquet.Type_INT64)
-		if string(res) != string(data.expected) {
+		res, err := WriteRLE(data.nums, int32(bits.Len64(uint64(data.nums[len(data.nums)-1].(int64)))), parquet.Type_INT64)
+		if err != nil {
+			t.Errorf("WriteRLE error, expect %v, get %v", data.expected, err)
+		} else if string(res) != string(data.expected) {
 			t.Errorf("WriteRLE error, expect %v, get %v", data.expected, res)
 		}
 	}
@@ -113,8 +115,10 @@ func TestWritePlainBOOLEAN(t *testing.T) {
 	}
 
 	for _, data := range testData {
-		res := WritePlainBOOLEAN(data.nums)
-		if string(res) != string(data.expected) {
+		res, err := WritePlainBOOLEAN(data.nums)
+		if err != nil {
+			t.Errorf("WritePlainBOOLEAN error, expect <nil>, get %v", err)
+		} else if string(res) != string(data.expected) {
 			t.Errorf("WritePlainBOOLEAN error, expect %v, get %v", data.expected, res)
 		}
 	}
@@ -131,8 +135,10 @@ func TestWritePlainINT32(t *testing.T) {
 	}
 
 	for _, data := range testData {
-		res := WritePlainINT32(data.nums)
-		if string(res) != string(data.expected) {
+		res, err := WritePlainINT32(data.nums)
+		if err != nil {
+			t.Errorf("WritePlainINT32 error, expect %v, get %v", data.expected, err)
+		} else if string(res) != string(data.expected) {
 			t.Errorf("WritePlainINT32 error, expect %v, get %v", data.expected, res)
 		}
 	}
@@ -149,8 +155,10 @@ func TestWritePlainINT64(t *testing.T) {
 	}
 
 	for _, data := range testData {
-		res := WritePlainINT64(data.nums)
-		if string(res) != string(data.expected) {
+		res, err := WritePlainINT64(data.nums)
+		if err != nil {
+			t.Errorf("WritePlainINT64 error, expect %v, get %v", data.expected, err)
+		} else if string(res) != string(data.expected) {
 			t.Errorf("WritePlainINT64 error, expect %v, get %v", data.expected, res)
 		}
 	}
@@ -192,8 +200,10 @@ func TestWritePlainBYTE_ARRAY(t *testing.T) {
 	}
 
 	for _, data := range testData {
-		res := WritePlainBYTE_ARRAY(data.nums)
-		if string(res) != string(data.expected) {
+		res, err := WritePlainBYTE_ARRAY(data.nums)
+		if err != nil {
+			t.Errorf("WritePlainBYTE_ARRAY error, expect <nil>, get %v", err)
+		} else if string(res) != string(data.expected) {
 			t.Errorf("WritePlainBYTE_ARRAY error, expect %v, get %v", data.expected, res)
 		}
 	}
@@ -209,8 +219,10 @@ func TestWritePlainFIXED_LEN_BYTE_ARRAY(t *testing.T) {
 	}
 
 	for _, data := range testData {
-		res := WritePlainFIXED_LEN_BYTE_ARRAY(data.nums)
-		if string(res) != string(data.expected) {
+		res, err := WritePlainFIXED_LEN_BYTE_ARRAY(data.nums)
+		if err != nil {
+			t.Errorf("WritePlainFIXED_LEN_BYTE_ARRAY error, expect <nil>, get %v", err)
+		} else if string(res) != string(data.expected) {
 			t.Errorf("WritePlainFIXED_LEN_BYTE_ARRAY error, expect %v, get %v", data.expected, res)
 		}
 	}

--- a/layout/chunk.go
+++ b/layout/chunk.go
@@ -16,7 +16,7 @@ type Chunk struct {
 }
 
 // Convert several pages to one chunk
-func PagesToChunk(pages []*Page) *Chunk {
+func PagesToChunk(pages []*Page) (*Chunk, error) {
 	ln := len(pages)
 	var numValues int64 = 0
 	var totalUncompressedSize int64 = 0
@@ -60,8 +60,14 @@ func PagesToChunk(pages []*Page) *Chunk {
 	metaData.Statistics = parquet.NewStatistics()
 
 	if !omitStats && maxVal != nil && minVal != nil {
-		tmpBufMax := encoding.WritePlain([]interface{}{maxVal}, *pT)
-		tmpBufMin := encoding.WritePlain([]interface{}{minVal}, *pT)
+		tmpBufMax, err := encoding.WritePlain([]interface{}{maxVal}, *pT)
+		if err != nil {
+			return nil, err
+		}
+		tmpBufMin, err := encoding.WritePlain([]interface{}{minVal}, *pT)
+		if err != nil {
+			return nil, err
+		}
 		if *pT == parquet.Type_BYTE_ARRAY {
 			tmpBufMax = tmpBufMax[4:]
 			tmpBufMin = tmpBufMin[4:]
@@ -77,13 +83,13 @@ func PagesToChunk(pages []*Page) *Chunk {
 	}
 
 	chunk.ChunkHeader.MetaData = metaData
-	return chunk
+	return chunk, nil
 }
 
 // Convert several pages to one chunk with dict page first
-func PagesToDictChunk(pages []*Page) *Chunk {
+func PagesToDictChunk(pages []*Page) (*Chunk, error) {
 	if len(pages) < 2 {
-		return nil
+		return nil, nil
 	}
 	var numValues int64 = 0
 	var totalUncompressedSize int64 = 0
@@ -129,8 +135,14 @@ func PagesToDictChunk(pages []*Page) *Chunk {
 	metaData.Statistics = parquet.NewStatistics()
 
 	if !omitStats && maxVal != nil && minVal != nil {
-		tmpBufMax := encoding.WritePlain([]interface{}{maxVal}, *pT)
-		tmpBufMin := encoding.WritePlain([]interface{}{minVal}, *pT)
+		tmpBufMax, err := encoding.WritePlain([]interface{}{maxVal}, *pT)
+		if err != nil {
+			return nil, err
+		}
+		tmpBufMin, err := encoding.WritePlain([]interface{}{minVal}, *pT)
+		if err != nil {
+			return nil, err
+		}
 		if *pT == parquet.Type_BYTE_ARRAY {
 			tmpBufMax = tmpBufMax[4:]
 			tmpBufMin = tmpBufMin[4:]
@@ -146,7 +158,7 @@ func PagesToDictChunk(pages []*Page) *Chunk {
 	}
 
 	chunk.ChunkHeader.MetaData = metaData
-	return chunk
+	return chunk, nil
 }
 
 // Decode a dict chunk


### PR DESCRIPTION
The goal is go get rid of try-catch type of code at https://github.com/hangxie/parquet-go/blob/v1.8.2/writer/writer.go#L288-L299, and I have to change lots of function signatures to let the error esclate all the way to the caller.