### PR TITLE
use ExName while Marshal JSON output

### DIFF
--- a/schema/gettype.go
+++ b/schema/gettype.go
@@ -69,6 +69,7 @@ func (sh *SchemaHandler) GetTypes() []reflect.Type {
 						fields = append(fields, reflect.StructField{
 							Name: sh.Infos[ci].InName,
 							Type: elementTypes[ci],
+							Tag:  reflect.StructTag(`json:"` + sh.Infos[ci].InName + `"`),
 						})
 					}
 


### PR DESCRIPTION
This is for https://github.com/hangxie/parquet-tools/issues/589.

It makes sense to have JSON output using original field name instead of go field name, which has to be starting with upper case.