### PR TITLE
Fix excessive memory usage in SkipRows

### DIFF
--- a/reader/columnbuffer.go
+++ b/reader/columnbuffer.go
@@ -201,7 +201,18 @@ func (cbt *ColumnBufferType) SkipRows(num int64) int64 {
 	)
 
 	for cbt.DataTableNumRows < num && err == nil {
+		if cbt.DataTableNumRows >= 0 {
+			num -= cbt.DataTableNumRows + 1
+			index := cbt.SchemaHandler.MapIndex[cbt.PathStr]
+			cbt.DataTable = layout.NewEmptyTable()
+			cbt.DataTable.Schema = cbt.SchemaHandler.SchemaElements[index]
+			cbt.DataTable.Path = common.StrToPath(cbt.PathStr)
+			cbt.DataTableNumRows = -1
+		}
 		page, err = cbt.ReadPageForSkip()
+		if err != nil {
+			return 0
+		}
 	}
 
 	if num > cbt.DataTableNumRows {

--- a/reader/reader_test.go
+++ b/reader/reader_test.go
@@ -1,0 +1,112 @@
+package reader
+
+import (
+	"bytes"
+	"runtime"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hangxie/parquet-go/v2/source/buffer"
+	"github.com/hangxie/parquet-go/v2/source/writerfile"
+	"github.com/hangxie/parquet-go/v2/writer"
+)
+
+type Record struct {
+	Str1 string `parquet:"name=str1, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	Str2 string `parquet:"name=str2, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	Str3 string `parquet:"name=str3, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	Str4 string `parquet:"name=str4, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	Int1 int64  `parquet:"name=int1, type=INT64, convertedtype=INT_64, encoding=PLAIN"`
+	Int2 int64  `parquet:"name=int2, type=INT64, convertedtype=INT_64, encoding=PLAIN"`
+	Int3 int64  `parquet:"name=int3, type=INT64, convertedtype=INT_64, encoding=PLAIN"`
+	Int4 int64  `parquet:"name=int4, type=INT64, convertedtype=INT_64, encoding=PLAIN"`
+}
+
+var numRecord = int64(500_000)
+
+var parquetBuf []byte
+
+func parquetReader() (*ParquetReader, error) {
+	var once sync.Once
+	var err error
+	once.Do(func() {
+		var buf bytes.Buffer
+		fw := writerfile.NewWriterFile(&buf)
+		var pw *writer.ParquetWriter
+		pw, err = writer.NewParquetWriter(fw, new(Record), 1)
+		if err != nil {
+			return
+		}
+		pw.RowGroupSize = 1 * 1024 * 1024 // 1M
+		pw.PageSize = 4 * 1024            // 4K
+		for i := range numRecord {
+			strVal := strconv.FormatInt(i, 10)
+			err = pw.Write(Record{strVal, strVal, strVal, strVal, i, i, i, i})
+			if err != nil {
+				return
+			}
+		}
+		if err = pw.WriteStop(); err != nil {
+			return
+		}
+		err = pw.WriteStop()
+		parquetBuf = buf.Bytes()
+	})
+	if err != nil {
+		return nil, err
+	}
+	buf := buffer.NewBufferReaderFromBytesNoAlloc(parquetBuf)
+	return NewParquetReader(buf, new(Record), int64(runtime.NumCPU()))
+}
+
+func rowsLeft(pr *ParquetReader) (int64, error) {
+	result := 0
+	for {
+		rows, err := pr.ReadByNumber(1000)
+		if err != nil {
+			return 0, err
+		}
+		if len(rows) == 0 {
+			break
+		}
+		result += len(rows)
+	}
+	return int64(result), nil
+}
+
+func Test_ParquetReader_SkipRows(t *testing.T) {
+	testCases := map[string]struct {
+		skip int64
+	}{
+		"100":    {100},
+		"1000":   {1000},
+		"10000":  {10000},
+		"100000": {100000},
+		"max":    {numRecord},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			pr, err := parquetReader()
+			require.NoError(t, err)
+			err = pr.SkipRows(tc.skip)
+			require.NoError(t, err)
+			num, err := rowsLeft(pr)
+			require.NoError(t, err)
+			require.Equal(t, numRecord-tc.skip, num)
+		})
+	}
+}
+
+func Benchmark_ParquetReader_SkipRows(b *testing.B) {
+	// avoid spending time on data generation
+	_, _ = parquetReader()
+
+	for b.Loop() {
+		pr, _ := parquetReader()
+		_ = pr.SkipRows(numRecord / 2)
+	}
+}


### PR DESCRIPTION
This is to address https://github.com/xitongsys/parquet-go/issues/545, I don't have original test program but using the same file with following code, it seems the problem is solved:

```
package main

import (
	"fmt"
	"log"
	"os"
	"runtime"
	"strconv"

	"github.com/hangxie/parquet-go/v2/reader"
	"github.com/hangxie/parquet-go/v2/source/local"
)

func main() {
	if len(os.Args) != 2 {
		fmt.Printf("Usage: %s <rows to skip>\n", os.Args[0])
		os.Exit(1)
	}
	nums, err := strconv.ParseInt(os.Args[1], 10, 64)
	if err != nil || nums <= 0 {
		fmt.Printf("invalid value: %s", os.Args[1])
		os.Exit(1)
	}

	fr, err := local.NewLocalFileReader("/tmp/part-00000-471427c6-8097-428d-9703-a751a6572cca-c000.snappy.parquet")
	if err != nil {
		log.Println("cannot open file")
		return
	}

	pr, err := reader.NewParquetReader(fr, nil, int64(runtime.NumCPU()))
	if err != nil {
		log.Println("cannot create parquet reader", err)
		return
	}

	err = pr.SkipRows(nums)
	if err != nil {
		log.Println("cannot skip rows", err)
		return
	}

	pr.ReadStop()
	_ = fr.Close()
}
```