### PR TITLE
replace string with ByteArray for BYTE_ARRAY and FIXED_LEN_BYTE_ARRAY based types

### DIFF
--- a/common/arrow.go
+++ b/common/arrow.go
@@ -76,7 +76,7 @@ func ArrowColToParquetCol(field arrow.Field, col arrow.Array) ([]any, error) {
 	case *arrow.Date64Type:
 		recs, err = arrowArrayToParquetList(field, col, func(v arrow.Date64) any { return int32(v) })
 	case *arrow.BinaryType:
-		recs, err = arrowArrayToParquetList(field, col, func(v []byte) any { return string(v) })
+		recs, err = arrowArrayToParquetList(field, col, func(v []byte) any { return ByteArray(v) })
 	case *arrow.StringType:
 		recs, err = arrowArrayToParquetList(field, col, func(v string) any { return v })
 	case *arrow.BooleanType:

--- a/common/arrow_test.go
+++ b/common/arrow_test.go
@@ -142,7 +142,7 @@ func Test_ArrowColToParquetCol(t *testing.T) {
 		"binary_to_string": {
 			field:    arrow.Field{Name: "test", Type: &arrow.BinaryType{}, Nullable: true},
 			col:      buildBinaryArray(mem, [][]byte{[]byte("hello"), []byte("world")}, []bool{true, true}),
-			expected: []any{"hello", "world"},
+			expected: []any{ByteArray("hello"), ByteArray("world")},
 		},
 		"string_direct": {
 			field:    arrow.Field{Name: "test", Type: &arrow.StringType{}, Nullable: true},

--- a/common/common.go
+++ b/common/common.go
@@ -1,6 +1,8 @@
 package common
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
@@ -14,6 +16,22 @@ const (
 	DefaultPageSize       = 8 * 1024
 	DefaultRowGroupSize   = 128 * 1024 * 1024
 )
+
+type ByteArray string
+
+func (d ByteArray) MarshalJSON() ([]byte, error) {
+	encoded := base64.StdEncoding.EncodeToString([]byte(d))
+	return json.Marshal(encoded)
+}
+
+func (d *ByteArray) UnmarshalJSON(data []byte) error {
+	decoded, err := base64.StdEncoding.DecodeString(string(data))
+	if err != nil {
+		return err
+	}
+	*d = ByteArray(decoded)
+	return nil
+}
 
 type fieldAttr struct {
 	Type           string

--- a/common/functable_test.go
+++ b/common/functable_test.go
@@ -23,8 +23,8 @@ func Test_FindFuncTable(t *testing.T) {
 		"INT96-nil-nil":                     {ToPtr(parquet.Type_INT96), nil, nil, int96FuncTable{}},
 		"FLOAT-nil-nil":                     {ToPtr(parquet.Type_FLOAT), nil, nil, float32FuncTable{}},
 		"DOUBLE-nil-nil":                    {ToPtr(parquet.Type_DOUBLE), nil, nil, float64FuncTable{}},
-		"BYTE_ARRAY-nil-nil":                {ToPtr(parquet.Type_BYTE_ARRAY), nil, nil, stringFuncTable{}},
-		"FIXED_LEN_BYTE_ARRAY-nil-nil":      {ToPtr(parquet.Type_FIXED_LEN_BYTE_ARRAY), nil, nil, stringFuncTable{}},
+		"BYTE_ARRAY-nil-nil":                {ToPtr(parquet.Type_BYTE_ARRAY), nil, nil, byteArrayFuncTable{}},
+		"FIXED_LEN_BYTE_ARRAY-nil-nil":      {ToPtr(parquet.Type_FIXED_LEN_BYTE_ARRAY), nil, nil, byteArrayFuncTable{}},
 		"BYTE_ARRAY-UTF8-nil":               {ToPtr(parquet.Type_BYTE_ARRAY), ToPtr(parquet.ConvertedType_UTF8), nil, stringFuncTable{}},
 		"BYTE_ARRAY-BSON-nil":               {ToPtr(parquet.Type_BYTE_ARRAY), ToPtr(parquet.ConvertedType_BSON), nil, stringFuncTable{}},
 		"BYTE_ARRAY-JSON-nil":               {ToPtr(parquet.Type_BYTE_ARRAY), ToPtr(parquet.ConvertedType_JSON), nil, stringFuncTable{}},
@@ -112,7 +112,7 @@ func Test_LessThan(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			require.Equal(t, tc.expected, tc.f.LessThan(tc.a, tc.b))
+			require.Equal(t, tc.expected, tc.f.lessThan(tc.a, tc.b))
 		})
 	}
 }
@@ -134,7 +134,7 @@ func Test_Max(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			funcTable, err := FindFuncTable(tc.PT, tc.CT, nil)
 			require.NoError(t, err)
-			res := Max(funcTable, tc.Num1, tc.Num2)
+			res := max(funcTable, tc.Num1, tc.Num2)
 			require.Equal(t, tc.Expected, res)
 		})
 	}
@@ -157,7 +157,7 @@ func Test_Min(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			funcTable, err := FindFuncTable(tc.PT, tc.CT, nil)
 			require.NoError(t, err)
-			res := Min(funcTable, tc.Num1, tc.Num2)
+			res := min(funcTable, tc.Num1, tc.Num2)
 			require.Equal(t, tc.Expected, res)
 		})
 	}
@@ -429,7 +429,7 @@ func Test_Int96FuncTable_LessThan_NilChecks(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := table.LessThan(tt.a, tt.b)
+			result := table.lessThan(tt.a, tt.b)
 			require.Equal(t, tt.expect, result)
 		})
 	}
@@ -520,7 +520,7 @@ func Test_IntervalFuncTable_LessThan_NilChecks(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := table.LessThan(tt.a, tt.b)
+			result := table.lessThan(tt.a, tt.b)
 			require.Equal(t, tt.expect, result)
 		})
 	}
@@ -534,10 +534,10 @@ func Test_Int96FuncTable_BoundsChecking(t *testing.T) {
 	shortString := "12345678901"  // 11 bytes
 	validString := "123456789012" // 12 bytes
 
-	result := table.LessThan(shortString, validString)
+	result := table.lessThan(shortString, validString)
 	require.False(t, result)
 
-	result = table.LessThan(validString, shortString)
+	result = table.lessThan(validString, shortString)
 	require.False(t, result)
 }
 
@@ -548,9 +548,9 @@ func Test_IntervalFuncTable_BoundsChecking(t *testing.T) {
 	shortString := "12345678901"  // 11 bytes
 	validString := "123456789012" // 12 bytes
 
-	result := table.LessThan(shortString, validString)
+	result := table.lessThan(shortString, validString)
 	require.False(t, result)
 
-	result = table.LessThan(validString, shortString)
+	result = table.lessThan(validString, shortString)
 	require.False(t, result)
 }

--- a/encoding/encodingread_test.go
+++ b/encoding/encodingread_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/hangxie/parquet-go/v2/common"
 	"github.com/hangxie/parquet-go/v2/parquet"
 )
 
@@ -206,7 +207,7 @@ func Test_ReadPlain(t *testing.T) {
 		{
 			name:     "int96_type",
 			dataType: parquet.Type_INT96,
-			data:     []any{"helloworldab", "abcdefghijkl"},
+			data:     []any{common.ByteArray("helloworldab"), common.ByteArray("abcdefghijkl")},
 		},
 		{
 			name:     "float_type",

--- a/encoding/encodingwrite_test.go
+++ b/encoding/encodingwrite_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/hangxie/parquet-go/v2/common"
 	"github.com/hangxie/parquet-go/v2/parquet"
 )
 
@@ -278,7 +279,7 @@ func Test_WritePlain(t *testing.T) {
 		},
 		{
 			name:     "int96_type",
-			src:      []any{"helloworldab", "abcdefghijkl"},
+			src:      []any{common.ByteArray("helloworldab"), common.ByteArray("abcdefghijkl")},
 			dataType: parquet.Type_INT96,
 		},
 		{
@@ -583,12 +584,12 @@ func Test_WritePlainINT96(t *testing.T) {
 		expected []byte
 	}{
 		{[]any{}, []byte{}},
-		{[]any{string([]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0})}, []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}},
+		{[]any{common.ByteArray([]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0})}, []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}},
 		{
 			[]any{
-				string([]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}),
-				string([]byte{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}),
-				string([]byte{2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}),
+				common.ByteArray([]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}),
+				common.ByteArray([]byte{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}),
+				common.ByteArray([]byte{2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}),
 			},
 
 			[]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},

--- a/layout/chunk.go
+++ b/layout/chunk.go
@@ -62,8 +62,7 @@ func PagesToChunk(pages []*Page) (*Chunk, error) {
 		totalUncompressedSize += int64(pages[i].Header.UncompressedPageSize) + int64(len(pages[i].RawData)) - int64(pages[i].Header.CompressedPageSize)
 		totalCompressedSize += int64(len(pages[i].RawData))
 		if !omitStats {
-			minVal = common.Min(funcTable, minVal, pages[i].MinVal)
-			maxVal = common.Max(funcTable, maxVal, pages[i].MaxVal)
+			minVal, maxVal, _ = funcTable.MinMaxSize(minVal, maxVal, pages[i].MinVal)
 			if pages[i].NullCount != nil {
 				nullCount += *pages[i].NullCount
 			}
@@ -156,8 +155,7 @@ func PagesToDictChunk(pages []*Page) (*Chunk, error) {
 		totalUncompressedSize += int64(pages[i].Header.UncompressedPageSize) + int64(len(pages[i].RawData)) - int64(pages[i].Header.CompressedPageSize)
 		totalCompressedSize += int64(len(pages[i].RawData))
 		if !omitStats && i > 0 {
-			minVal = common.Min(funcTable, minVal, pages[i].MinVal)
-			maxVal = common.Max(funcTable, maxVal, pages[i].MaxVal)
+			minVal, maxVal, _ = funcTable.MinMaxSize(minVal, maxVal, pages[i].MinVal)
 			if pages[i].NullCount != nil {
 				nullCount += *pages[i].NullCount
 			}

--- a/marshal/unmarshal.go
+++ b/marshal/unmarshal.go
@@ -237,10 +237,12 @@ func Unmarshal(tableMap *map[string]*layout.Table, bgn, end int, dstInterface an
 
 				default:
 					value := reflect.ValueOf(val)
-					if po.Type() != value.Type() {
-						value = value.Convert(poType)
+					if value.IsValid() {
+						if po.Type() != value.Type() {
+							value = value.Convert(poType)
+						}
+						po.Set(value)
 					}
-					po.Set(value)
 					break OuterLoop
 				}
 			}


### PR DESCRIPTION
Trying to solve the problem that BYTE_ARRAY-like values are being encoded as string, which causes problem when the value is not a valid UTF8 type.

The idea is to add a ByteArray type and control the behavior of JSON Marshal/Unmarshal.