### PR TITLE
refactor

### DIFF
--- a/common/functable.go
+++ b/common/functable.go
@@ -59,11 +59,12 @@ func FindFuncTable(pT *parquet.Type, cT *parquet.ConvertedType, logT *parquet.Lo
 		if table, ok := convertedTypeFuncTable[*cT]; ok {
 			return table, nil
 		} else if *cT == parquet.ConvertedType_DECIMAL {
-			if *pT == parquet.Type_BYTE_ARRAY || *pT == parquet.Type_FIXED_LEN_BYTE_ARRAY {
+			switch *pT {
+			case parquet.Type_BYTE_ARRAY, parquet.Type_FIXED_LEN_BYTE_ARRAY:
 				return decimalStringFuncTable{}, nil
-			} else if *pT == parquet.Type_INT32 {
+			case parquet.Type_INT32:
 				return int32FuncTable{}, nil
-			} else if *pT == parquet.Type_INT64 {
+			case parquet.Type_INT64:
 				return int64FuncTable{}, nil
 			}
 		}
@@ -78,18 +79,20 @@ func FindFuncTable(pT *parquet.Type, cT *parquet.ConvertedType, logT *parquet.Lo
 			if logT.INTEGER.IsSigned {
 				return FindFuncTable(pT, nil, nil)
 			} else {
-				if *pT == parquet.Type_INT32 {
+				switch *pT {
+				case parquet.Type_INT32:
 					return uint32FuncTable{}, nil
-				} else if *pT == parquet.Type_INT64 {
+				case parquet.Type_INT64:
 					return uint64FuncTable{}, nil
 				}
 			}
 		} else if logT.DECIMAL != nil {
-			if *pT == parquet.Type_BYTE_ARRAY || *pT == parquet.Type_FIXED_LEN_BYTE_ARRAY {
+			switch *pT {
+			case parquet.Type_BYTE_ARRAY, parquet.Type_FIXED_LEN_BYTE_ARRAY:
 				return decimalStringFuncTable{}, nil
-			} else if *pT == parquet.Type_INT32 {
+			case parquet.Type_INT32:
 				return int32FuncTable{}, nil
-			} else if *pT == parquet.Type_INT64 {
+			case parquet.Type_INT64:
 				return int64FuncTable{}, nil
 			}
 		} else if logT.BSON != nil || logT.JSON != nil || logT.STRING != nil || logT.UUID != nil {

--- a/compress/gzip.go
+++ b/compress/gzip.go
@@ -17,7 +17,7 @@ var gzipWriterPool sync.Pool
 
 func init() {
 	gzipWriterPool = sync.Pool{
-		New: func() interface{} {
+		New: func() any {
 			return gzip.NewWriter(nil)
 		},
 	}

--- a/compress/lz4.go
+++ b/compress/lz4.go
@@ -15,7 +15,7 @@ import (
 
 func init() {
 	lz4WriterPool := sync.Pool{
-		New: func() interface{} {
+		New: func() any {
 			return lz4.NewWriter(nil)
 		},
 	}

--- a/encoding/binaryread.go
+++ b/encoding/binaryread.go
@@ -6,7 +6,7 @@ import (
 )
 
 // LittleEndian
-func BinaryReadINT32(r io.Reader, nums []interface{}) error {
+func BinaryReadINT32(r io.Reader, nums []any) error {
 	buf := make([]byte, len(nums)*4)
 	n, err := io.ReadFull(r, buf)
 	if err != nil {
@@ -25,7 +25,7 @@ func BinaryReadINT32(r io.Reader, nums []interface{}) error {
 	return nil
 }
 
-func BinaryReadINT64(r io.Reader, nums []interface{}) error {
+func BinaryReadINT64(r io.Reader, nums []any) error {
 	buf := make([]byte, len(nums)*8)
 	n, err := io.ReadFull(r, buf)
 	if err != nil {
@@ -48,7 +48,7 @@ func BinaryReadINT64(r io.Reader, nums []interface{}) error {
 	return nil
 }
 
-func BinaryReadFLOAT32(r io.Reader, nums []interface{}) error {
+func BinaryReadFLOAT32(r io.Reader, nums []any) error {
 	buf := make([]byte, len(nums)*4)
 	n, err := io.ReadFull(r, buf)
 	if err != nil {
@@ -67,7 +67,7 @@ func BinaryReadFLOAT32(r io.Reader, nums []interface{}) error {
 	return nil
 }
 
-func BinaryReadFLOAT64(r io.Reader, nums []interface{}) error {
+func BinaryReadFLOAT64(r io.Reader, nums []any) error {
 	buf := make([]byte, len(nums)*8)
 	n, err := io.ReadFull(r, buf)
 	if err != nil {

--- a/encoding/binarywrite.go
+++ b/encoding/binarywrite.go
@@ -7,7 +7,7 @@ import (
 )
 
 // LittleEndian
-func BinaryWriteINT32(w io.Writer, nums []interface{}) error {
+func BinaryWriteINT32(w io.Writer, nums []any) error {
 	buf := make([]byte, len(nums)*4)
 	for i, n := range nums {
 		tmp, ok := n.(int32)
@@ -25,7 +25,7 @@ func BinaryWriteINT32(w io.Writer, nums []interface{}) error {
 	return err
 }
 
-func BinaryWriteINT64(w io.Writer, nums []interface{}) error {
+func BinaryWriteINT64(w io.Writer, nums []any) error {
 	buf := make([]byte, len(nums)*8)
 	for i, n := range nums {
 		tmp, ok := n.(int64)
@@ -47,7 +47,7 @@ func BinaryWriteINT64(w io.Writer, nums []interface{}) error {
 	return err
 }
 
-func BinaryWriteFLOAT32(w io.Writer, nums []interface{}) error {
+func BinaryWriteFLOAT32(w io.Writer, nums []any) error {
 	buf := make([]byte, len(nums)*4)
 	for i, n := range nums {
 		tmp, ok := n.(float32)
@@ -65,7 +65,7 @@ func BinaryWriteFLOAT32(w io.Writer, nums []interface{}) error {
 	return err
 }
 
-func BinaryWriteFLOAT64(w io.Writer, nums []interface{}) error {
+func BinaryWriteFLOAT64(w io.Writer, nums []any) error {
 	buf := make([]byte, len(nums)*8)
 	for i, n := range nums {
 		tmp, ok := n.(float64)

--- a/encoding/encodingread.go
+++ b/encoding/encodingread.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hangxie/parquet-go/v2/parquet"
 )
 
-func ReadPlain(bytesReader *bytes.Reader, dataType parquet.Type, cnt, bitWidth uint64) ([]interface{}, error) {
+func ReadPlain(bytesReader *bytes.Reader, dataType parquet.Type, cnt, bitWidth uint64) ([]any, error) {
 	if dataType == parquet.Type_BOOLEAN {
 		return ReadPlainBOOLEAN(bytesReader, cnt)
 	} else if dataType == parquet.Type_INT32 {
@@ -32,13 +32,13 @@ func ReadPlain(bytesReader *bytes.Reader, dataType parquet.Type, cnt, bitWidth u
 	}
 }
 
-func ReadPlainBOOLEAN(bytesReader *bytes.Reader, cnt uint64) ([]interface{}, error) {
+func ReadPlainBOOLEAN(bytesReader *bytes.Reader, cnt uint64) ([]any, error) {
 	var (
-		res []interface{}
+		res []any
 		err error
 	)
 
-	res = make([]interface{}, cnt)
+	res = make([]any, cnt)
 	resInt, err := ReadBitPacked(bytesReader, uint64(cnt<<1), 1)
 	if err != nil {
 		return res, err
@@ -54,23 +54,23 @@ func ReadPlainBOOLEAN(bytesReader *bytes.Reader, cnt uint64) ([]interface{}, err
 	return res, err
 }
 
-func ReadPlainINT32(bytesReader *bytes.Reader, cnt uint64) ([]interface{}, error) {
+func ReadPlainINT32(bytesReader *bytes.Reader, cnt uint64) ([]any, error) {
 	var err error
-	res := make([]interface{}, cnt)
+	res := make([]any, cnt)
 	err = BinaryReadINT32(bytesReader, res)
 	return res, err
 }
 
-func ReadPlainINT64(bytesReader *bytes.Reader, cnt uint64) ([]interface{}, error) {
+func ReadPlainINT64(bytesReader *bytes.Reader, cnt uint64) ([]any, error) {
 	var err error
-	res := make([]interface{}, cnt)
+	res := make([]any, cnt)
 	err = BinaryReadINT64(bytesReader, res)
 	return res, err
 }
 
-func ReadPlainINT96(bytesReader *bytes.Reader, cnt uint64) ([]interface{}, error) {
+func ReadPlainINT96(bytesReader *bytes.Reader, cnt uint64) ([]any, error) {
 	var err error
-	res := make([]interface{}, cnt)
+	res := make([]any, cnt)
 	cur := make([]byte, 12)
 	for i := 0; i < int(cnt); i++ {
 		if _, err = bytesReader.Read(cur); err != nil {
@@ -81,23 +81,23 @@ func ReadPlainINT96(bytesReader *bytes.Reader, cnt uint64) ([]interface{}, error
 	return res, err
 }
 
-func ReadPlainFLOAT(bytesReader *bytes.Reader, cnt uint64) ([]interface{}, error) {
+func ReadPlainFLOAT(bytesReader *bytes.Reader, cnt uint64) ([]any, error) {
 	var err error
-	res := make([]interface{}, cnt)
+	res := make([]any, cnt)
 	err = BinaryReadFLOAT32(bytesReader, res)
 	return res, err
 }
 
-func ReadPlainDOUBLE(bytesReader *bytes.Reader, cnt uint64) ([]interface{}, error) {
+func ReadPlainDOUBLE(bytesReader *bytes.Reader, cnt uint64) ([]any, error) {
 	var err error
-	res := make([]interface{}, cnt)
+	res := make([]any, cnt)
 	err = BinaryReadFLOAT64(bytesReader, res)
 	return res, err
 }
 
-func ReadPlainBYTE_ARRAY(bytesReader *bytes.Reader, cnt uint64) ([]interface{}, error) {
+func ReadPlainBYTE_ARRAY(bytesReader *bytes.Reader, cnt uint64) ([]any, error) {
 	var err error
-	res := make([]interface{}, cnt)
+	res := make([]any, cnt)
 	for i := 0; i < int(cnt); i++ {
 		buf := make([]byte, 4)
 		if _, err = bytesReader.Read(buf); err != nil {
@@ -113,9 +113,9 @@ func ReadPlainBYTE_ARRAY(bytesReader *bytes.Reader, cnt uint64) ([]interface{}, 
 	return res, err
 }
 
-func ReadPlainFIXED_LEN_BYTE_ARRAY(bytesReader *bytes.Reader, cnt, fixedLength uint64) ([]interface{}, error) {
+func ReadPlainFIXED_LEN_BYTE_ARRAY(bytesReader *bytes.Reader, cnt, fixedLength uint64) ([]any, error) {
 	var err error
-	res := make([]interface{}, cnt)
+	res := make([]any, cnt)
 	for i := 0; i < int(cnt); i++ {
 		cur := make([]byte, fixedLength)
 		if _, err = bytesReader.Read(cur); err != nil {
@@ -145,9 +145,9 @@ func ReadUnsignedVarInt(bytesReader *bytes.Reader) (uint64, error) {
 }
 
 // RLE return res is []INT64
-func ReadRLE(bytesReader *bytes.Reader, header, bitWidth uint64) ([]interface{}, error) {
+func ReadRLE(bytesReader *bytes.Reader, header, bitWidth uint64) ([]any, error) {
 	var err error
-	var res []interface{}
+	var res []any
 	cnt := header >> 1
 	width := (bitWidth + 7) / 8
 	data := make([]byte, width)
@@ -160,7 +160,7 @@ func ReadRLE(bytesReader *bytes.Reader, header, bitWidth uint64) ([]interface{},
 		data = append(data, byte(0))
 	}
 	val := int64(binary.LittleEndian.Uint32(data))
-	res = make([]interface{}, cnt)
+	res = make([]any, cnt)
 
 	for i := 0; i < int(cnt); i++ {
 		res[i] = val
@@ -169,13 +169,13 @@ func ReadRLE(bytesReader *bytes.Reader, header, bitWidth uint64) ([]interface{},
 }
 
 // return res is []INT64
-func ReadBitPacked(bytesReader *bytes.Reader, header, bitWidth uint64) ([]interface{}, error) {
+func ReadBitPacked(bytesReader *bytes.Reader, header, bitWidth uint64) ([]any, error) {
 	var err error
 	numGroup := (header >> 1)
 	cnt := numGroup * 8
 	byteCnt := cnt * bitWidth / 8
 
-	res := make([]interface{}, 0, cnt)
+	res := make([]any, 0, cnt)
 
 	if cnt == 0 {
 		return res, nil
@@ -230,8 +230,8 @@ func ReadBitPacked(bytesReader *bytes.Reader, header, bitWidth uint64) ([]interf
 }
 
 // res is INT64
-func ReadRLEBitPackedHybrid(bytesReader *bytes.Reader, bitWidth, length uint64) ([]interface{}, error) {
-	res := make([]interface{}, 0)
+func ReadRLEBitPackedHybrid(bytesReader *bytes.Reader, bitWidth, length uint64) ([]any, error) {
+	res := make([]any, 0)
 	if length <= 0 {
 		lb, err := ReadPlainINT32(bytesReader, 1)
 		if err != nil {
@@ -269,10 +269,10 @@ func ReadRLEBitPackedHybrid(bytesReader *bytes.Reader, bitWidth, length uint64) 
 	return res, nil
 }
 
-func ReadDeltaBinaryPackedINT32(bytesReader *bytes.Reader) ([]interface{}, error) {
+func ReadDeltaBinaryPackedINT32(bytesReader *bytes.Reader) ([]any, error) {
 	var (
 		err error
-		res []interface{}
+		res []any
 	)
 
 	blockSize, err := ReadUnsignedVarInt(bytesReader)
@@ -296,7 +296,7 @@ func ReadDeltaBinaryPackedINT32(bytesReader *bytes.Reader) ([]interface{}, error
 	var firstValue int32 = int32(uint32(fv32)>>1) ^ -(fv32 & 1)
 	numValuesInMiniBlock := blockSize / numMiniblocksInBlock
 
-	res = make([]interface{}, 0)
+	res = make([]any, 0)
 	res = append(res, firstValue)
 	for uint64(len(res)) < numValues {
 		minDeltaZigZag, err := ReadUnsignedVarInt(bytesReader)
@@ -328,10 +328,10 @@ func ReadDeltaBinaryPackedINT32(bytesReader *bytes.Reader) ([]interface{}, error
 }
 
 // res is INT64
-func ReadDeltaBinaryPackedINT64(bytesReader *bytes.Reader) ([]interface{}, error) {
+func ReadDeltaBinaryPackedINT64(bytesReader *bytes.Reader) ([]any, error) {
 	var (
 		err error
-		res []interface{}
+		res []any
 	)
 
 	blockSize, err := ReadUnsignedVarInt(bytesReader)
@@ -354,7 +354,7 @@ func ReadDeltaBinaryPackedINT64(bytesReader *bytes.Reader) ([]interface{}, error
 
 	numValuesInMiniBlock := blockSize / numMiniblocksInBlock
 
-	res = make([]interface{}, 0)
+	res = make([]any, 0)
 	res = append(res, int64(firstValue))
 	for uint64(len(res)) < numValues {
 		minDeltaZigZag, err := ReadUnsignedVarInt(bytesReader)
@@ -384,9 +384,9 @@ func ReadDeltaBinaryPackedINT64(bytesReader *bytes.Reader) ([]interface{}, error
 	return res[:numValues], err
 }
 
-func ReadDeltaLengthByteArray(bytesReader *bytes.Reader) ([]interface{}, error) {
+func ReadDeltaLengthByteArray(bytesReader *bytes.Reader) ([]any, error) {
 	var (
-		res []interface{}
+		res []any
 		err error
 	)
 
@@ -394,7 +394,7 @@ func ReadDeltaLengthByteArray(bytesReader *bytes.Reader) ([]interface{}, error) 
 	if err != nil {
 		return res, err
 	}
-	res = make([]interface{}, len(lengths))
+	res = make([]any, len(lengths))
 	for i := 0; i < len(lengths); i++ {
 		res[i] = ""
 		length := uint64(lengths[i].(int64))
@@ -410,9 +410,9 @@ func ReadDeltaLengthByteArray(bytesReader *bytes.Reader) ([]interface{}, error) 
 	return res, err
 }
 
-func ReadDeltaByteArray(bytesReader *bytes.Reader) ([]interface{}, error) {
+func ReadDeltaByteArray(bytesReader *bytes.Reader) ([]any, error) {
 	var (
-		res []interface{}
+		res []any
 		err error
 	)
 
@@ -424,7 +424,7 @@ func ReadDeltaByteArray(bytesReader *bytes.Reader) ([]interface{}, error) {
 	if err != nil {
 		return res, err
 	}
-	res = make([]interface{}, len(prefixLengths))
+	res = make([]any, len(prefixLengths))
 
 	res[0] = suffixes[0]
 	for i := 1; i < len(prefixLengths); i++ {
@@ -436,8 +436,8 @@ func ReadDeltaByteArray(bytesReader *bytes.Reader) ([]interface{}, error) {
 	return res, err
 }
 
-func ReadByteStreamSplitFloat32(bytesReader *bytes.Reader, cnt uint64) ([]interface{}, error) {
-	res := make([]interface{}, cnt)
+func ReadByteStreamSplitFloat32(bytesReader *bytes.Reader, cnt uint64) ([]any, error) {
+	res := make([]any, cnt)
 	buf := make([]byte, cnt*4)
 
 	n, err := io.ReadFull(bytesReader, buf)
@@ -458,8 +458,8 @@ func ReadByteStreamSplitFloat32(bytesReader *bytes.Reader, cnt uint64) ([]interf
 	return res, err
 }
 
-func ReadByteStreamSplitFloat64(bytesReader *bytes.Reader, cnt uint64) ([]interface{}, error) {
-	res := make([]interface{}, cnt)
+func ReadByteStreamSplitFloat64(bytesReader *bytes.Reader, cnt uint64) ([]any, error) {
+	res := make([]any, cnt)
 	buf := make([]byte, cnt*8)
 
 	n, err := io.ReadFull(bytesReader, buf)

--- a/encoding/encodingread_test.go
+++ b/encoding/encodingread_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestReadPlainBOOLEAN(t *testing.T) {
-	testData := [][]interface{}{
+	testData := [][]any{
 		{(true)},
 		{(false)},
 		{(false), (false)},
@@ -35,12 +35,12 @@ func TestReadPlainBOOLEAN(t *testing.T) {
 
 func TestReadPlainINT32(t *testing.T) {
 	testData := []struct {
-		expected   []interface{}
+		expected   []any
 		byteReader *bytes.Reader
 	}{
-		{[]interface{}{}, bytes.NewReader([]byte{})},
-		{[]interface{}{int32(0)}, bytes.NewReader([]byte{0, 0, 0, 0})},
-		{[]interface{}{int32(0), int32(1), int32(2)}, bytes.NewReader([]byte{0, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0})},
+		{[]any{}, bytes.NewReader([]byte{})},
+		{[]any{int32(0)}, bytes.NewReader([]byte{0, 0, 0, 0})},
+		{[]any{int32(0), int32(1), int32(2)}, bytes.NewReader([]byte{0, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0})},
 	}
 
 	for _, data := range testData {
@@ -53,12 +53,12 @@ func TestReadPlainINT32(t *testing.T) {
 
 func TestReadPlainINT64(t *testing.T) {
 	testData := []struct {
-		expected   []interface{}
+		expected   []any
 		byteReader *bytes.Reader
 	}{
-		{[]interface{}{}, bytes.NewReader([]byte{})},
-		{[]interface{}{int64(0)}, bytes.NewReader([]byte{0, 0, 0, 0, 0, 0, 0, 0})},
-		{[]interface{}{int64(0), int64(1), int64(2)}, bytes.NewReader([]byte{0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0})},
+		{[]any{}, bytes.NewReader([]byte{})},
+		{[]any{int64(0)}, bytes.NewReader([]byte{0, 0, 0, 0, 0, 0, 0, 0})},
+		{[]any{int64(0), int64(1), int64(2)}, bytes.NewReader([]byte{0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0})},
 	}
 
 	for _, data := range testData {
@@ -70,7 +70,7 @@ func TestReadPlainINT64(t *testing.T) {
 }
 
 func TestReadPlainBYTE_ARRAY(t *testing.T) {
-	testData := [][]interface{}{
+	testData := [][]any{
 		{("hello"), ("world")},
 		{("good"), (""), ("a"), ("b")},
 	}
@@ -89,7 +89,7 @@ func TestReadPlainBYTE_ARRAY(t *testing.T) {
 }
 
 func TestReadPlainFIXED_LEN_BYTE_ARRAY(t *testing.T) {
-	testData := [][]interface{}{
+	testData := [][]any{
 		{("hello"), ("world")},
 		{("a"), ("b"), ("c"), ("d")},
 	}
@@ -108,7 +108,7 @@ func TestReadPlainFIXED_LEN_BYTE_ARRAY(t *testing.T) {
 }
 
 func TestReadPlainFLOAT(t *testing.T) {
-	testData := [][]interface{}{
+	testData := [][]any{
 		{float32(0), float32(1), float32(2)},
 		{float32(0), float32(0.1), float32(0.2)},
 	}
@@ -127,7 +127,7 @@ func TestReadPlainFLOAT(t *testing.T) {
 }
 
 func TestReadPlainDOUBLE(t *testing.T) {
-	testData := [][]interface{}{
+	testData := [][]any{
 		{float64(0), float64(1), float64(2)},
 		{float64(0), float64(0), float64(0)},
 	}
@@ -158,7 +158,7 @@ func TestReadUnsignedVarInt(t *testing.T) {
 }
 
 func TestReadRLEBitPackedHybrid(t *testing.T) {
-	testData := [][]interface{}{
+	testData := [][]any{
 		{int64(1), int64(2), int64(3), int64(4)},
 		{int64(0), int64(0), int64(0), int64(0), int64(0)},
 	}
@@ -177,7 +177,7 @@ func TestReadRLEBitPackedHybrid(t *testing.T) {
 }
 
 func TestReadDeltaBinaryPackedINT(t *testing.T) {
-	testData := [][]interface{}{
+	testData := [][]any{
 		{int64(1), int64(2), int64(3), int64(4)},
 		{int64(math.MaxInt64), int64(math.MinInt64), int64(-15654523568543623), int64(4354365463543632), int64(0)},
 	}
@@ -217,7 +217,7 @@ func TestReadDeltaINT32(t *testing.T) {
 }
 
 func TestReadDeltaBinaryPackedINT32(t *testing.T) {
-	testData := [][]interface{}{
+	testData := [][]any{
 		{int32(1), int32(2), int32(3), int32(4)},
 		{int32(-1570499385), int32(-1570499385), int32(-1570499386), int32(-1570499388), int32(-1570499385)},
 	}
@@ -236,7 +236,7 @@ func TestReadDeltaBinaryPackedINT32(t *testing.T) {
 }
 
 func TestReadDeltaByteArray(t *testing.T) {
-	testData := [][]interface{}{
+	testData := [][]any{
 		{"Hello", "world"},
 	}
 	for _, data := range testData {
@@ -248,7 +248,7 @@ func TestReadDeltaByteArray(t *testing.T) {
 }
 
 func TestReadLengthDeltaByteArray(t *testing.T) {
-	testData := [][]interface{}{
+	testData := [][]any{
 		{"Hello", "world"},
 	}
 	for _, data := range testData {
@@ -260,7 +260,7 @@ func TestReadLengthDeltaByteArray(t *testing.T) {
 }
 
 func TestReadBitPacked(t *testing.T) {
-	testData := [][]interface{}{
+	testData := [][]any{
 		{1, 2, 3, 4, 5, 6, 7, 8},
 		{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 	}

--- a/encoding/encodingwrite.go
+++ b/encoding/encodingwrite.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hangxie/parquet-go/v2/parquet"
 )
 
-func ToInt64(nums []interface{}) []int64 { // convert bool/int values to int64 values
+func ToInt64(nums []any) []int64 { // convert bool/int values to int64 values
 	ln := len(nums)
 	res := make([]int64, ln)
 	if ln <= 0 {
@@ -32,7 +32,7 @@ func ToInt64(nums []interface{}) []int64 { // convert bool/int values to int64 v
 	return res
 }
 
-func WritePlain(src []interface{}, pt parquet.Type) ([]byte, error) {
+func WritePlain(src []any, pt parquet.Type) ([]byte, error) {
 	ln := len(src)
 	if ln <= 0 {
 		return []byte{}, nil
@@ -59,7 +59,7 @@ func WritePlain(src []interface{}, pt parquet.Type) ([]byte, error) {
 	}
 }
 
-func WritePlainBOOLEAN(nums []interface{}) ([]byte, error) {
+func WritePlainBOOLEAN(nums []any) ([]byte, error) {
 	ln := len(nums)
 	byteNum := (ln + 7) / 8
 	res := make([]byte, byteNum)
@@ -75,7 +75,7 @@ func WritePlainBOOLEAN(nums []interface{}) ([]byte, error) {
 	return res, nil
 }
 
-func WritePlainINT32(nums []interface{}) ([]byte, error) {
+func WritePlainINT32(nums []any) ([]byte, error) {
 	bufWriter := new(bytes.Buffer)
 	if err := BinaryWriteINT32(bufWriter, nums); err != nil {
 		return nil, err
@@ -83,7 +83,7 @@ func WritePlainINT32(nums []interface{}) ([]byte, error) {
 	return bufWriter.Bytes(), nil
 }
 
-func WritePlainINT64(nums []interface{}) ([]byte, error) {
+func WritePlainINT64(nums []any) ([]byte, error) {
 	bufWriter := new(bytes.Buffer)
 	if err := BinaryWriteINT64(bufWriter, nums); err != nil {
 		return nil, err
@@ -91,7 +91,7 @@ func WritePlainINT64(nums []interface{}) ([]byte, error) {
 	return bufWriter.Bytes(), nil
 }
 
-func WritePlainINT96(nums []interface{}) []byte {
+func WritePlainINT96(nums []any) []byte {
 	bufWriter := new(bytes.Buffer)
 	for i := 0; i < len(nums); i++ {
 		bufWriter.WriteString(nums[i].(string))
@@ -99,7 +99,7 @@ func WritePlainINT96(nums []interface{}) []byte {
 	return bufWriter.Bytes()
 }
 
-func WritePlainFLOAT(nums []interface{}) ([]byte, error) {
+func WritePlainFLOAT(nums []any) ([]byte, error) {
 	bufWriter := new(bytes.Buffer)
 	if err := BinaryWriteFLOAT32(bufWriter, nums); err != nil {
 		return nil, err
@@ -107,7 +107,7 @@ func WritePlainFLOAT(nums []interface{}) ([]byte, error) {
 	return bufWriter.Bytes(), nil
 }
 
-func WritePlainDOUBLE(nums []interface{}) ([]byte, error) {
+func WritePlainDOUBLE(nums []any) ([]byte, error) {
 	bufWriter := new(bytes.Buffer)
 	if err := BinaryWriteFLOAT64(bufWriter, nums); err != nil {
 		return nil, err
@@ -115,7 +115,7 @@ func WritePlainDOUBLE(nums []interface{}) ([]byte, error) {
 	return bufWriter.Bytes(), nil
 }
 
-func WritePlainBYTE_ARRAY(arrays []interface{}) ([]byte, error) {
+func WritePlainBYTE_ARRAY(arrays []any) ([]byte, error) {
 	bufLen := 0
 	for i := 0; i < len(arrays); i++ {
 		bufLen += 4 + len(arrays[i].(string))
@@ -136,7 +136,7 @@ func WritePlainBYTE_ARRAY(arrays []interface{}) ([]byte, error) {
 	return buf, nil
 }
 
-func WritePlainFIXED_LEN_BYTE_ARRAY(arrays []interface{}) ([]byte, error) {
+func WritePlainFIXED_LEN_BYTE_ARRAY(arrays []any) ([]byte, error) {
 	bufWriter := new(bytes.Buffer)
 	cnt := len(arrays)
 	for i := 0; i < int(cnt); i++ {
@@ -166,7 +166,7 @@ func WriteUnsignedVarInt(num uint64) []byte {
 	return res
 }
 
-func WriteRLE(vals []interface{}, bitWidth int32, pt parquet.Type) ([]byte, error) {
+func WriteRLE(vals []any, bitWidth int32, pt parquet.Type) ([]byte, error) {
 	ln := len(vals)
 	i := 0
 	res := make([]byte, 0)
@@ -180,7 +180,7 @@ func WriteRLE(vals []interface{}, bitWidth int32, pt parquet.Type) ([]byte, erro
 		byteNum := (bitWidth + 7) / 8
 		headerBuf := WriteUnsignedVarInt(uint64(header))
 
-		valBuf, err := WritePlain([]interface{}{vals[i]}, pt)
+		valBuf, err := WritePlain([]any{vals[i]}, pt)
 		if err != nil {
 			return nil, err
 		}
@@ -194,13 +194,13 @@ func WriteRLE(vals []interface{}, bitWidth int32, pt parquet.Type) ([]byte, erro
 	return res, nil
 }
 
-func WriteRLEBitPackedHybrid(vals []interface{}, bitWidths int32, pt parquet.Type) ([]byte, error) {
+func WriteRLEBitPackedHybrid(vals []any, bitWidths int32, pt parquet.Type) ([]byte, error) {
 	rleBuf, err := WriteRLE(vals, bitWidths, pt)
 	if err != nil {
 		return nil, err
 	}
 	res := make([]byte, 0)
-	lenBuf, err := WritePlain([]interface{}{int32(len(rleBuf))}, parquet.Type_INT32)
+	lenBuf, err := WritePlain([]any{int32(len(rleBuf))}, parquet.Type_INT32)
 	if err != nil {
 		return nil, err
 	}
@@ -236,7 +236,7 @@ func WriteRLEInt32(vals []int32, bitWidth int32) []byte {
 func WriteRLEBitPackedHybridInt32(vals []int32, bitWidths int32) ([]byte, error) {
 	rleBuf := WriteRLEInt32(vals, bitWidths)
 	res := make([]byte, 0)
-	lenBuf, err := WritePlain([]interface{}{int32(len(rleBuf))}, parquet.Type_INT32)
+	lenBuf, err := WritePlain([]any{int32(len(rleBuf))}, parquet.Type_INT32)
 	if err != nil {
 		return nil, err
 	}
@@ -245,7 +245,7 @@ func WriteRLEBitPackedHybridInt32(vals []int32, bitWidths int32) ([]byte, error)
 	return res, nil
 }
 
-func WriteBitPacked(vals []interface{}, bitWidth int64, ifHeader bool) []byte {
+func WriteBitPacked(vals []any, bitWidth int64, ifHeader bool) []byte {
 	ln := len(vals)
 	if ln <= 0 {
 		return nil
@@ -301,7 +301,7 @@ func WriteBitPacked(vals []interface{}, bitWidth int64, ifHeader bool) []byte {
 	return res
 }
 
-func WriteDelta(nums []interface{}) []byte {
+func WriteDelta(nums []any) []byte {
 	ln := len(nums)
 	if ln <= 0 {
 		return []byte{}
@@ -316,7 +316,7 @@ func WriteDelta(nums []interface{}) []byte {
 	}
 }
 
-func WriteDeltaINT32(nums []interface{}) []byte {
+func WriteDeltaINT32(nums []any) []byte {
 	res := make([]byte, 0)
 	var blockSize uint64 = 128
 	var numMiniBlocksInBlock uint64 = 4
@@ -333,7 +333,7 @@ func WriteDeltaINT32(nums []interface{}) []byte {
 
 	i := 1
 	for i < len(nums) {
-		blockBuf := make([]interface{}, 0)
+		blockBuf := make([]any, 0)
 		var minDelta int32 = 0x7FFFFFFF
 
 		for i < len(nums) && uint64(len(blockBuf)) < blockSize {
@@ -374,7 +374,7 @@ func WriteDeltaINT32(nums []interface{}) []byte {
 	return res
 }
 
-func WriteDeltaINT64(nums []interface{}) []byte {
+func WriteDeltaINT64(nums []any) []byte {
 	res := make([]byte, 0)
 	var blockSize uint64 = 128
 	var numMiniBlocksInBlock uint64 = 4
@@ -391,7 +391,7 @@ func WriteDeltaINT64(nums []interface{}) []byte {
 
 	i := 1
 	for i < len(nums) {
-		blockBuf := make([]interface{}, 0)
+		blockBuf := make([]any, 0)
 		var minDelta int64 = 0x7FFFFFFFFFFFFFFF
 
 		for i < len(nums) && uint64(len(blockBuf)) < blockSize {
@@ -432,9 +432,9 @@ func WriteDeltaINT64(nums []interface{}) []byte {
 	return res
 }
 
-func WriteDeltaLengthByteArray(arrays []interface{}) []byte {
+func WriteDeltaLengthByteArray(arrays []any) []byte {
 	ln := len(arrays)
-	lengthArray := make([]interface{}, ln)
+	lengthArray := make([]any, ln)
 	for i := 0; i < ln; i++ {
 		array := reflect.ValueOf(arrays[i]).String()
 		lengthArray[i] = int32(len(array))
@@ -449,7 +449,7 @@ func WriteDeltaLengthByteArray(arrays []interface{}) []byte {
 	return res
 }
 
-func WriteBitPackedDeprecated(vals []interface{}, bitWidth int64) []byte {
+func WriteBitPackedDeprecated(vals []any, bitWidth int64) []byte {
 	ln := len(vals)
 	if ln <= 0 {
 		return []byte{}
@@ -496,14 +496,14 @@ func WriteBitPackedDeprecated(vals []interface{}, bitWidth int64) []byte {
 	return res
 }
 
-func WriteDeltaByteArray(arrays []interface{}) []byte {
+func WriteDeltaByteArray(arrays []any) []byte {
 	ln := len(arrays)
 	if ln <= 0 {
 		return []byte{}
 	}
 
-	prefixLengths := make([]interface{}, ln)
-	suffixes := make([]interface{}, ln)
+	prefixLengths := make([]any, ln)
+	suffixes := make([]any, ln)
 	prefixLengths[0] = int32(0)
 	suffixes[0] = arrays[0]
 
@@ -532,7 +532,7 @@ func WriteDeltaByteArray(arrays []interface{}) []byte {
 	return res
 }
 
-func WriteByteStreamSplit(nums []interface{}) []byte {
+func WriteByteStreamSplit(nums []any) []byte {
 	ln := len(nums)
 	if ln <= 0 {
 		return []byte{}
@@ -547,7 +547,7 @@ func WriteByteStreamSplit(nums []interface{}) []byte {
 	}
 }
 
-func WriteByteStreamSplitFloat32(vals []interface{}) []byte {
+func WriteByteStreamSplitFloat32(vals []any) []byte {
 	ln := len(vals)
 	if ln <= 0 {
 		return []byte{}
@@ -563,7 +563,7 @@ func WriteByteStreamSplitFloat32(vals []interface{}) []byte {
 	return buf
 }
 
-func WriteByteStreamSplitFloat64(vals []interface{}) []byte {
+func WriteByteStreamSplitFloat64(vals []any) []byte {
 	ln := len(vals)
 	if ln <= 0 {
 		return []byte{}

--- a/encoding/encodingwrite_test.go
+++ b/encoding/encodingwrite_test.go
@@ -10,12 +10,12 @@ import (
 
 func TestToInt64(t *testing.T) {
 	testData := []struct {
-		nums     []interface{}
+		nums     []any
 		expected []int64
 	}{
-		{nums: []interface{}{int(1), int(2), int(3)}, expected: []int64{int64(1), int64(2), int64(3)}},
-		{nums: []interface{}{true, false, true}, expected: []int64{int64(1), int64(0), int64(1)}},
-		{nums: []interface{}{}, expected: []int64{}},
+		{nums: []any{int(1), int(2), int(3)}, expected: []int64{int64(1), int64(2), int64(3)}},
+		{nums: []any{true, false, true}, expected: []int64{int64(1), int64(0), int64(1)}},
+		{nums: []any{}, expected: []int64{}},
 	}
 
 	for _, data := range testData {
@@ -68,12 +68,12 @@ func TestWriteUnsignedVarInt(t *testing.T) {
 
 func TestWriteRLE(t *testing.T) {
 	testData := []struct {
-		nums     []interface{}
+		nums     []any
 		expected []byte
 	}{
-		{[]interface{}{int64(0), int64(0), int64(0)}, []byte{byte(3 << 1)}},
-		{[]interface{}{int64(3)}, []byte{byte(1 << 1), byte(3)}},
-		{[]interface{}{int64(1), int64(2), int64(3), int64(3)}, []byte{byte(1 << 1), byte(1), byte(1 << 1), byte(2), byte(2 << 1), byte(3)}},
+		{[]any{int64(0), int64(0), int64(0)}, []byte{byte(3 << 1)}},
+		{[]any{int64(3)}, []byte{byte(1 << 1), byte(3)}},
+		{[]any{int64(1), int64(2), int64(3), int64(3)}, []byte{byte(1 << 1), byte(1), byte(1 << 1), byte(2), byte(2 << 1), byte(3)}},
 	}
 
 	for _, data := range testData {
@@ -88,11 +88,11 @@ func TestWriteRLE(t *testing.T) {
 
 func TestWriteBitPacked(t *testing.T) {
 	testData := []struct {
-		nums     []interface{}
+		nums     []any
 		expected []byte
 	}{
-		{[]interface{}{0, 0, 0, 0, 0, 0, 0, 0}, []byte{3}},
-		{[]interface{}{0, 1, 2, 3, 4, 5, 6, 7}, []byte{3, 0x88, 0xC6, 0xFA}},
+		{[]any{0, 0, 0, 0, 0, 0, 0, 0}, []byte{3}},
+		{[]any{0, 1, 2, 3, 4, 5, 6, 7}, []byte{3, 0x88, 0xC6, 0xFA}},
 	}
 
 	for _, data := range testData {
@@ -105,13 +105,13 @@ func TestWriteBitPacked(t *testing.T) {
 
 func TestWritePlainBOOLEAN(t *testing.T) {
 	testData := []struct {
-		nums     []interface{}
+		nums     []any
 		expected []byte
 	}{
-		{[]interface{}{}, []byte{}},
-		{[]interface{}{(true)}, []byte{1}},
-		{[]interface{}{(true), (false)}, []byte{1}},
-		{[]interface{}{(true), (false), (false), (true), (false)}, []byte{9}},
+		{[]any{}, []byte{}},
+		{[]any{(true)}, []byte{1}},
+		{[]any{(true), (false)}, []byte{1}},
+		{[]any{(true), (false), (false), (true), (false)}, []byte{9}},
 	}
 
 	for _, data := range testData {
@@ -126,12 +126,12 @@ func TestWritePlainBOOLEAN(t *testing.T) {
 
 func TestWritePlainINT32(t *testing.T) {
 	testData := []struct {
-		nums     []interface{}
+		nums     []any
 		expected []byte
 	}{
-		{[]interface{}{}, []byte{}},
-		{[]interface{}{int32(0)}, []byte{0, 0, 0, 0}},
-		{[]interface{}{int32(0), int32(1), int32(2)}, []byte{0, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0}},
+		{[]any{}, []byte{}},
+		{[]any{int32(0)}, []byte{0, 0, 0, 0}},
+		{[]any{int32(0), int32(1), int32(2)}, []byte{0, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0}},
 	}
 
 	for _, data := range testData {
@@ -146,12 +146,12 @@ func TestWritePlainINT32(t *testing.T) {
 
 func TestWritePlainINT64(t *testing.T) {
 	testData := []struct {
-		nums     []interface{}
+		nums     []any
 		expected []byte
 	}{
-		{[]interface{}{}, []byte{}},
-		{[]interface{}{int64(0)}, []byte{0, 0, 0, 0, 0, 0, 0, 0}},
-		{[]interface{}{int64(0), int64(1), int64(2)}, []byte{0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0}},
+		{[]any{}, []byte{}},
+		{[]any{int64(0)}, []byte{0, 0, 0, 0, 0, 0, 0, 0}},
+		{[]any{int64(0), int64(1), int64(2)}, []byte{0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0}},
 	}
 
 	for _, data := range testData {
@@ -166,13 +166,13 @@ func TestWritePlainINT64(t *testing.T) {
 
 func TestWritePlainINT96(t *testing.T) {
 	testData := []struct {
-		nums     []interface{}
+		nums     []any
 		expected []byte
 	}{
-		{[]interface{}{}, []byte{}},
-		{[]interface{}{string([]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0})}, []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}},
+		{[]any{}, []byte{}},
+		{[]any{string([]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0})}, []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}},
 		{
-			[]interface{}{
+			[]any{
 				string([]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}),
 				string([]byte{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}),
 				string([]byte{2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}),
@@ -192,11 +192,11 @@ func TestWritePlainINT96(t *testing.T) {
 
 func TestWritePlainBYTE_ARRAY(t *testing.T) {
 	testData := []struct {
-		nums     []interface{}
+		nums     []any
 		expected []byte
 	}{
-		{[]interface{}{}, []byte{}},
-		{[]interface{}{("a"), ("abc")}, []byte{1, 0, 0, 0, 97, 3, 0, 0, 0, 97, 98, 99}},
+		{[]any{}, []byte{}},
+		{[]any{("a"), ("abc")}, []byte{1, 0, 0, 0, 97, 3, 0, 0, 0, 97, 98, 99}},
 	}
 
 	for _, data := range testData {
@@ -211,11 +211,11 @@ func TestWritePlainBYTE_ARRAY(t *testing.T) {
 
 func TestWritePlainFIXED_LEN_BYTE_ARRAY(t *testing.T) {
 	testData := []struct {
-		nums     []interface{}
+		nums     []any
 		expected []byte
 	}{
-		{[]interface{}{}, []byte{}},
-		{[]interface{}{("bca"), ("abc")}, []byte{98, 99, 97, 97, 98, 99}},
+		{[]any{}, []byte{}},
+		{[]any{("bca"), ("abc")}, []byte{98, 99, 97, 97, 98, 99}},
 	}
 
 	for _, data := range testData {
@@ -230,12 +230,12 @@ func TestWritePlainFIXED_LEN_BYTE_ARRAY(t *testing.T) {
 
 func TestWriteDeltaINT32(t *testing.T) {
 	testData := []struct {
-		nums     []interface{}
+		nums     []any
 		expected []byte
 	}{
-		{[]interface{}{int32(1), int32(2), int32(3), int32(4), int32(5)}, []byte{128, 1, 4, 5, 2, 2, 0, 0, 0, 0}},
+		{[]any{int32(1), int32(2), int32(3), int32(4), int32(5)}, []byte{128, 1, 4, 5, 2, 2, 0, 0, 0, 0}},
 		{
-			[]interface{}{int32(7), int32(5), int32(3), int32(1), int32(2), int32(3), int32(4), int32(5)},
+			[]any{int32(7), int32(5), int32(3), int32(1), int32(2), int32(3), int32(4), int32(5)},
 			[]byte{128, 1, 4, 8, 14, 3, 2, 0, 0, 0, 192, 63, 0, 0, 0, 0, 0, 0},
 		},
 	}
@@ -250,12 +250,12 @@ func TestWriteDeltaINT32(t *testing.T) {
 
 func TestWriteDeltaint64(t *testing.T) {
 	testData := []struct {
-		nums     []interface{}
+		nums     []any
 		expected []byte
 	}{
-		{[]interface{}{int64(1), int64(2), int64(3), int64(4), int64(5)}, []byte{128, 1, 4, 5, 2, 2, 0, 0, 0, 0}},
+		{[]any{int64(1), int64(2), int64(3), int64(4), int64(5)}, []byte{128, 1, 4, 5, 2, 2, 0, 0, 0, 0}},
 		{
-			[]interface{}{int64(7), int64(5), int64(3), int64(1), int64(2), int64(3), int64(4), int64(5)},
+			[]any{int64(7), int64(5), int64(3), int64(1), int64(2), int64(3), int64(4), int64(5)},
 			[]byte{128, 1, 4, 8, 14, 3, 2, 0, 0, 0, 192, 63, 0, 0, 0, 0, 0, 0},
 		},
 	}
@@ -270,10 +270,10 @@ func TestWriteDeltaint64(t *testing.T) {
 
 func TestWriteDeltaLengthByteArray(t *testing.T) {
 	testData := []struct {
-		nums     []interface{}
+		nums     []any
 		expected []byte
 	}{
-		{[]interface{}{"Hello", "World", "Foobar", "ABCDEF"}, []byte{128, 1, 4, 4, 10, 0, 1, 0, 0, 0, 2, 0, 0, 0, 72, 101, 108, 108, 111, 87, 111, 114, 108, 100, 70, 111, 111, 98, 97, 114, 65, 66, 67, 68, 69, 70}},
+		{[]any{"Hello", "World", "Foobar", "ABCDEF"}, []byte{128, 1, 4, 4, 10, 0, 1, 0, 0, 0, 2, 0, 0, 0, 72, 101, 108, 108, 111, 87, 111, 114, 108, 100, 70, 111, 111, 98, 97, 114, 65, 66, 67, 68, 69, 70}},
 	}
 
 	for _, data := range testData {
@@ -286,10 +286,10 @@ func TestWriteDeltaLengthByteArray(t *testing.T) {
 
 func TestWriteDeltaByteArray(t *testing.T) {
 	testData := []struct {
-		nums     []interface{}
+		nums     []any
 		expected []byte
 	}{
-		{[]interface{}{"Hello", "World", "Foobar", "ABCDEF"}, []byte{128, 1, 4, 4, 0, 0, 0, 0, 0, 0, 128, 1, 4, 4, 10, 0, 1, 0, 0, 0, 2, 0, 0, 0, 72, 101, 108, 108, 111, 87, 111, 114, 108, 100, 70, 111, 111, 98, 97, 114, 65, 66, 67, 68, 69, 70}},
+		{[]any{"Hello", "World", "Foobar", "ABCDEF"}, []byte{128, 1, 4, 4, 0, 0, 0, 0, 0, 0, 128, 1, 4, 4, 10, 0, 1, 0, 0, 0, 2, 0, 0, 0, 72, 101, 108, 108, 111, 87, 111, 114, 108, 100, 70, 111, 111, 98, 97, 114, 65, 66, 67, 68, 69, 70}},
 	}
 
 	for _, data := range testData {
@@ -302,10 +302,10 @@ func TestWriteDeltaByteArray(t *testing.T) {
 
 func TestWriteBitPackedDeprecated(t *testing.T) {
 	testData := []struct {
-		nums     []interface{}
+		nums     []any
 		expected []byte
 	}{
-		{[]interface{}{1, 2, 3, 4}, []byte{41}},
+		{[]any{1, 2, 3, 4}, []byte{41}},
 	}
 
 	for _, data := range testData {

--- a/example/column_read/column_read.go
+++ b/example/column_read/column_read.go
@@ -56,7 +56,7 @@ func main() {
 	log.Println("Write Finished")
 	_ = fw.Close()
 
-	var names, classes, scores_key, scores_value, ids []interface{}
+	var names, classes, scores_key, scores_value, ids []any
 	var rls, dls []int32
 
 	// read

--- a/example/csv_write/csv_write.go
+++ b/example/csv_write/csv_write.go
@@ -47,7 +47,7 @@ func main() {
 			log.Println("WriteString error", err)
 		}
 
-		data2 := []interface{}{
+		data2 := []any{
 			"Student Name",
 			int32(20 + i%5),
 			int64(i),

--- a/example/gcs/gcs_write.go
+++ b/example/gcs/gcs_write.go
@@ -53,7 +53,7 @@ func main() {
 			log.Println("WriteString error", err)
 		}
 
-		data2 := []interface{}{
+		data2 := []any{
 			"Student Name",
 			int32(20 + i%5),
 			int64(i),

--- a/layout/chunk.go
+++ b/layout/chunk.go
@@ -24,8 +24,8 @@ func PagesToChunk(pages []*Page) (*Chunk, error) {
 	var totalUncompressedSize int64 = 0
 	var totalCompressedSize int64 = 0
 
-	var maxVal interface{} = pages[0].MaxVal
-	var minVal interface{} = pages[0].MinVal
+	var maxVal any = pages[0].MaxVal
+	var minVal any = pages[0].MinVal
 	var nullCount int64 = 0
 	pT, cT, logT, omitStats := pages[0].Schema.Type, pages[0].Schema.ConvertedType, pages[0].Schema.LogicalType, pages[0].Info.OmitStats
 	funcTable, err := common.FindFuncTable(pT, cT, logT)
@@ -65,11 +65,11 @@ func PagesToChunk(pages []*Page) (*Chunk, error) {
 	metaData.Statistics = parquet.NewStatistics()
 
 	if !omitStats && maxVal != nil && minVal != nil {
-		tmpBufMax, err := encoding.WritePlain([]interface{}{maxVal}, *pT)
+		tmpBufMax, err := encoding.WritePlain([]any{maxVal}, *pT)
 		if err != nil {
 			return nil, err
 		}
-		tmpBufMin, err := encoding.WritePlain([]interface{}{minVal}, *pT)
+		tmpBufMin, err := encoding.WritePlain([]any{minVal}, *pT)
 		if err != nil {
 			return nil, err
 		}
@@ -100,8 +100,8 @@ func PagesToDictChunk(pages []*Page) (*Chunk, error) {
 	var totalUncompressedSize int64 = 0
 	var totalCompressedSize int64 = 0
 
-	var maxVal interface{} = pages[1].MaxVal
-	var minVal interface{} = pages[1].MinVal
+	var maxVal any = pages[1].MaxVal
+	var minVal any = pages[1].MinVal
 	var nullCount int64 = 0
 	pT, cT, logT, omitStats := pages[1].Schema.Type, pages[1].Schema.ConvertedType, pages[1].Schema.LogicalType, pages[1].Info.OmitStats
 	funcTable, err := common.FindFuncTable(pT, cT, logT)
@@ -143,11 +143,11 @@ func PagesToDictChunk(pages []*Page) (*Chunk, error) {
 	metaData.Statistics = parquet.NewStatistics()
 
 	if !omitStats && maxVal != nil && minVal != nil {
-		tmpBufMax, err := encoding.WritePlain([]interface{}{maxVal}, *pT)
+		tmpBufMax, err := encoding.WritePlain([]any{maxVal}, *pT)
 		if err != nil {
 			return nil, err
 		}
-		tmpBufMin, err := encoding.WritePlain([]interface{}{minVal}, *pT)
+		tmpBufMin, err := encoding.WritePlain([]any{minVal}, *pT)
 		if err != nil {
 			return nil, err
 		}

--- a/layout/dictpage.go
+++ b/layout/dictpage.go
@@ -14,14 +14,14 @@ import (
 )
 
 type DictRecType struct {
-	DictMap   map[interface{}]int32
-	DictSlice []interface{}
+	DictMap   map[any]int32
+	DictSlice []any
 	Type      parquet.Type
 }
 
 func NewDictRec(pT parquet.Type) *DictRecType {
 	res := new(DictRecType)
-	res.DictMap = make(map[interface{}]int32)
+	res.DictMap = make(map[any]int32)
 	res.Type = pT
 	return res
 }
@@ -91,8 +91,8 @@ func TableToDictDataPages(dictRec *DictRecType, table *Table, pageSize, bitWidth
 		var size int32 = 0
 		var numValues int32 = 0
 
-		var maxVal interface{} = table.Values[i]
-		var minVal interface{} = table.Values[i]
+		var maxVal any = table.Values[i]
+		var minVal any = table.Values[i]
 		var nullCount int64 = 0
 		values := make([]int32, 0)
 
@@ -214,7 +214,7 @@ func (page *Page) DictDataPageCompress(compressType parquet.CompressionCodec, bi
 
 	page.Header.DataPageHeader.Statistics = parquet.NewStatistics()
 	if page.MaxVal != nil {
-		tmpBuf, err := encoding.WritePlain([]interface{}{page.MaxVal}, *page.Schema.Type)
+		tmpBuf, err := encoding.WritePlain([]any{page.MaxVal}, *page.Schema.Type)
 		if err != nil {
 			return nil, err
 		}
@@ -225,7 +225,7 @@ func (page *Page) DictDataPageCompress(compressType parquet.CompressionCodec, bi
 		page.Header.DataPageHeader.Statistics.MaxValue = tmpBuf
 	}
 	if page.MinVal != nil {
-		tmpBuf, err := encoding.WritePlain([]interface{}{page.MinVal}, *page.Schema.Type)
+		tmpBuf, err := encoding.WritePlain([]any{page.MinVal}, *page.Schema.Type)
 		if err != nil {
 			return nil, err
 		}

--- a/layout/table.go
+++ b/layout/table.go
@@ -38,7 +38,7 @@ type Table struct {
 	MaxRepetitionLevel int32
 
 	// Parquet values
-	Values []interface{}
+	Values []any
 	// Definition Levels slice
 	DefinitionLevels []int32
 	// Repetition Levels slice
@@ -50,11 +50,7 @@ type Table struct {
 
 // Merge several tables to one table(the first table)
 func (t *Table) Merge(tables ...*Table) {
-	ln := len(tables)
-	if ln <= 0 {
-		return
-	}
-	for i := 0; i < ln; i++ {
+	for i := range len(tables) {
 		if tables[i] == nil {
 			continue
 		}

--- a/layout/table_test.go
+++ b/layout/table_test.go
@@ -8,15 +8,15 @@ import (
 func TestMergeTable(t *testing.T) {
 	tables := make([]*Table, 2)
 	tables[0], tables[1] = new(Table), new(Table)
-	tables[0].Values = []interface{}{int32(1), int32(2)}
-	tables[1].Values = []interface{}{int32(3), int32(4)}
+	tables[0].Values = []any{int32(1), int32(2)}
+	tables[1].Values = []any{int32(3), int32(4)}
 	tables[0].DefinitionLevels = []int32{0, 0}
 	tables[1].DefinitionLevels = []int32{0, 0}
 	tables[0].RepetitionLevels = []int32{0, 0}
 	tables[1].RepetitionLevels = []int32{0, 0}
 
 	tables[0].Merge(tables[1])
-	if fmt.Sprintf("%v", tables[0].Values) != fmt.Sprintf("%v", []interface{}{int32(1), int32(2), int32(3), int32(4)}) ||
+	if fmt.Sprintf("%v", tables[0].Values) != fmt.Sprintf("%v", []any{int32(1), int32(2), int32(3), int32(4)}) ||
 		fmt.Sprintf("%v", tables[0].DefinitionLevels) != fmt.Sprintf("%v", []int32{0, 0, 0, 0}) ||
 		fmt.Sprintf("%v", tables[0].RepetitionLevels) != fmt.Sprintf("%v", []int32{0, 0, 0, 0}) {
 		t.Errorf("MergeTable err")

--- a/marshal/arrow.go
+++ b/marshal/arrow.go
@@ -12,12 +12,12 @@ import (
 // column by column since the wrapper ParquetWriter uses the number of rows
 // to execute intermediate flush depending on the size of the objects,
 // determined by row, which are currently written.
-func MarshalArrow(records []interface{}, schemaHandler *schema.SchemaHandler) (*map[string]*layout.Table, error) {
+func MarshalArrow(records []any, schemaHandler *schema.SchemaHandler) (*map[string]*layout.Table, error) {
 	res := make(map[string]*layout.Table)
 	if ln := len(records); ln <= 0 {
 		return &res, nil
 	}
-	for i := 0; i < len(records[0].([]interface{})); i++ {
+	for i := 0; i < len(records[0].([]any)); i++ {
 		pathStr := schemaHandler.GetRootInName() + common.PAR_GO_PATH_DELIMITER + schemaHandler.Infos[i+1].InName
 		table := layout.NewEmptyTable()
 		res[pathStr] = table
@@ -39,12 +39,12 @@ func MarshalArrow(records []interface{}, schemaHandler *schema.SchemaHandler) (*
 		table.RepetitionType = *table.Schema.RepetitionType
 		table.Info = schemaHandler.Infos[i+1]
 		// Pre-allocate these arrays for efficiency.
-		table.Values = make([]interface{}, 0, len(records))
+		table.Values = make([]any, 0, len(records))
 		table.RepetitionLevels = make([]int32, 0, len(records))
 		table.DefinitionLevels = make([]int32, 0, len(records))
 
 		for j := 0; j < len(records); j++ {
-			rec := records[j].([]interface{})[i]
+			rec := records[j].([]any)[i]
 			table.Values = append(table.Values, rec)
 
 			table.RepetitionLevels = append(table.RepetitionLevels, 0)

--- a/marshal/csv.go
+++ b/marshal/csv.go
@@ -8,13 +8,13 @@ import (
 )
 
 // Marshal function for CSV like data
-func MarshalCSV(records []interface{}, schemaHandler *schema.SchemaHandler) (*map[string]*layout.Table, error) {
+func MarshalCSV(records []any, schemaHandler *schema.SchemaHandler) (*map[string]*layout.Table, error) {
 	res := make(map[string]*layout.Table)
 	if ln := len(records); ln <= 0 {
 		return &res, nil
 	}
 
-	for i := 0; i < len(records[0].([]interface{})); i++ {
+	for i := 0; i < len(records[0].([]any)); i++ {
 		pathStr := schemaHandler.GetRootInName() + common.PAR_GO_PATH_DELIMITER + schemaHandler.Infos[i+1].InName
 		table := layout.NewEmptyTable()
 		res[pathStr] = table
@@ -37,12 +37,12 @@ func MarshalCSV(records []interface{}, schemaHandler *schema.SchemaHandler) (*ma
 		table.Schema = schemaHandler.SchemaElements[schemaHandler.MapIndex[pathStr]]
 		table.Info = schemaHandler.Infos[i+1]
 		// Pre-allocate these arrays for efficiency
-		table.Values = make([]interface{}, 0, len(records))
+		table.Values = make([]any, 0, len(records))
 		table.RepetitionLevels = make([]int32, 0, len(records))
 		table.DefinitionLevels = make([]int32, 0, len(records))
 
 		for j := 0; j < len(records); j++ {
-			rec := records[j].([]interface{})[i]
+			rec := records[j].([]any)[i]
 			table.Values = append(table.Values, rec)
 
 			table.RepetitionLevels = append(table.RepetitionLevels, 0)

--- a/marshal/json.go
+++ b/marshal/json.go
@@ -14,7 +14,7 @@ import (
 )
 
 // ss is []string
-func MarshalJSON(ss []interface{}, schemaHandler *schema.SchemaHandler) (tb *map[string]*layout.Table, err error) {
+func MarshalJSON(ss []any, schemaHandler *schema.SchemaHandler) (tb *map[string]*layout.Table, err error) {
 	res := setupTableMap(schemaHandler, len(ss))
 	pathMap := schemaHandler.PathMap
 	nodeBuf := NewNodeBuf(1)
@@ -25,7 +25,7 @@ func MarshalJSON(ss []interface{}, schemaHandler *schema.SchemaHandler) (tb *map
 		nodeBuf.Reset()
 
 		node := nodeBuf.GetNode()
-		var ui interface{}
+		var ui any
 
 		var d *json.Decoder
 
@@ -35,7 +35,7 @@ func MarshalJSON(ss []interface{}, schemaHandler *schema.SchemaHandler) (tb *map
 		case []byte:
 			d = json.NewDecoder(bytes.NewReader(t))
 		}
-		// `useNumber`causes the Decoder to unmarshal a number into an interface{} as a Number instead of as a float64.
+		// `useNumber`causes the Decoder to unmarshal a number into an any as a Number instead of as a float64.
 		d.UseNumber()
 		if err := d.Decode(&ui); err != nil {
 			return nil, err

--- a/marshal/marshal_test.go
+++ b/marshal/marshal_test.go
@@ -84,12 +84,12 @@ func TestMarshalFast(t *testing.T) {
 	}
 
 	type testIfaceElem struct {
-		Bool      interface{} `parquet:"name=bool, type=BOOLEAN"`
-		Int32     interface{} `parquet:"name=int32, type=INT32"`
-		Int64     interface{} `parquet:"name=int64, type=INT64"`
-		Float     interface{} `parquet:"name=float, type=FLOAT"`
-		Double    interface{} `parquet:"name=double, type=DOUBLE"`
-		ByteArray interface{} `parquet:"name=bytearray, type=BYTE_ARRAY"`
+		Bool      any `parquet:"name=bool, type=BOOLEAN"`
+		Int32     any `parquet:"name=int32, type=INT32"`
+		Int64     any `parquet:"name=int64, type=INT64"`
+		Float     any `parquet:"name=float, type=FLOAT"`
+		Double    any `parquet:"name=double, type=DOUBLE"`
+		ByteArray any `parquet:"name=bytearray, type=BYTE_ARRAY"`
 	}
 
 	i64 := int64(31)
@@ -99,7 +99,7 @@ func TestMarshalFast(t *testing.T) {
 	str := "hi"
 
 	testCases := []struct {
-		value interface{}
+		value any
 	}{
 		{testElem{Bool: true}},
 		{testElem{Ptr: &i64, PtrPtr: &refRef}},
@@ -151,7 +151,7 @@ func TestMarshalFast(t *testing.T) {
 		{testNestedElem{EmptyRepeated: []*struct{}{{}}}},
 		{testNestedElem{EmptyRepeated: []*struct{}{{}, nil, {}}}},
 
-		// interface{}
+		// any
 		{testIfaceElem{}},
 		{testIfaceElem{
 			Bool:      false,
@@ -173,7 +173,7 @@ func TestMarshalFast(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run("", func(t *testing.T) {
-			input := []interface{}{tt.value}
+			input := []any{tt.value}
 			schemaType := reflect.Zero(reflect.PointerTo(reflect.TypeOf(tt.value))).Interface()
 			sch, err := schema.NewSchemaHandlerFromStruct(schemaType)
 			if err != nil {

--- a/marshal/unmarshal.go
+++ b/marshal/unmarshal.go
@@ -27,7 +27,7 @@ type SliceRecord struct {
 }
 
 // Convert the table map to objects slice. dstInterface is a slice of pointers of objects
-func Unmarshal(tableMap *map[string]*layout.Table, bgn, end int, dstInterface interface{}, schemaHandler *schema.SchemaHandler, prefixPath string) (err error) {
+func Unmarshal(tableMap *map[string]*layout.Table, bgn, end int, dstInterface any, schemaHandler *schema.SchemaHandler, prefixPath string) (err error) {
 	tableNeeds := make(map[string]*layout.Table)
 	tableBgn, tableEnd := make(map[string]int), make(map[string]int)
 	for name, table := range *tableMap {

--- a/marshal/unmarshal_test.go
+++ b/marshal/unmarshal_test.go
@@ -96,7 +96,7 @@ func TestMarshalUnmarshal(t *testing.T) {
 		Classes: &stu02Class,
 	}
 
-	stus := make([]interface{}, 0)
+	stus := make([]any, 0)
 	stus = append(stus, stu01, stu02)
 
 	src, err := Marshal(stus, schemaHandler)

--- a/reader/columnreader.go
+++ b/reader/columnreader.go
@@ -60,22 +60,22 @@ func (pr *ParquetReader) SkipRowsByIndex(index, num int64) {
 }
 
 // ReadColumnByPath reads column by path in schema.
-func (pr *ParquetReader) ReadColumnByPath(pathStr string, num int64) (values []interface{}, rls, dls []int32, err error) {
+func (pr *ParquetReader) ReadColumnByPath(pathStr string, num int64) (values []any, rls, dls []int32, err error) {
 	errPathNotFound := fmt.Errorf("path %v not found", pathStr)
 
 	pathStr, err = pr.SchemaHandler.ConvertToInPathStr(pathStr)
 	if num <= 0 || len(pathStr) <= 0 || err != nil {
-		return []interface{}{}, []int32{}, []int32{}, err
+		return []any{}, []int32{}, []int32{}, err
 	}
 
 	if _, ok := pr.SchemaHandler.MapIndex[pathStr]; !ok {
-		return []interface{}{}, []int32{}, []int32{}, errPathNotFound
+		return []any{}, []int32{}, []int32{}, errPathNotFound
 	}
 
 	if _, ok := pr.ColumnBuffers[pathStr]; !ok {
 		var err error
 		if pr.ColumnBuffers[pathStr], err = NewColumnBuffer(pr.PFile, pr.Footer, pr.SchemaHandler, pathStr); err != nil {
-			return []interface{}{}, []int32{}, []int32{}, err
+			return []any{}, []int32{}, []int32{}, err
 		}
 	}
 
@@ -83,11 +83,11 @@ func (pr *ParquetReader) ReadColumnByPath(pathStr string, num int64) (values []i
 		table, _ := cb.ReadRows(int64(num))
 		return table.Values, table.RepetitionLevels, table.DefinitionLevels, nil
 	}
-	return []interface{}{}, []int32{}, []int32{}, errPathNotFound
+	return []any{}, []int32{}, []int32{}, errPathNotFound
 }
 
 // ReadColumnByIndex reads column by index. The index of first column is 0.
-func (pr *ParquetReader) ReadColumnByIndex(index, num int64) (values []interface{}, rls, dls []int32, err error) {
+func (pr *ParquetReader) ReadColumnByIndex(index, num int64) (values []any, rls, dls []int32, err error) {
 	if index >= int64(len(pr.SchemaHandler.ValueColumns)) {
 		err = fmt.Errorf("index %v out of range %v", index, len(pr.SchemaHandler.ValueColumns))
 		return

--- a/reader/reader.go
+++ b/reader/reader.go
@@ -39,7 +39,7 @@ type ParquetReader struct {
 }
 
 // Create a parquet reader: obj is a object with schema tags or a JSON schema string
-func NewParquetReader(pFile source.ParquetFileReader, obj interface{}, np int64, opts ...ParquetReaderOptions) (*ParquetReader, error) {
+func NewParquetReader(pFile source.ParquetFileReader, obj any, np int64, opts ...ParquetReaderOptions) (*ParquetReader, error) {
 	var caseInsensitive bool
 	if len(opts) > 0 {
 		caseInsensitive = opts[0].CaseInsensitive
@@ -221,12 +221,12 @@ func (pr *ParquetReader) SkipRows(num int64) error {
 }
 
 // Read rows of parquet file and unmarshal all to dst
-func (pr *ParquetReader) Read(dstInterface interface{}) error {
+func (pr *ParquetReader) Read(dstInterface any) error {
 	return pr.read(dstInterface, "")
 }
 
 // Read maxReadNumber objects
-func (pr *ParquetReader) ReadByNumber(maxReadNumber int) ([]interface{}, error) {
+func (pr *ParquetReader) ReadByNumber(maxReadNumber int) ([]any, error) {
 	var err error
 	if pr.ObjType == nil {
 		if pr.ObjType, err = pr.SchemaHandler.GetType(pr.SchemaHandler.GetRootInName()); err != nil {
@@ -243,7 +243,7 @@ func (pr *ParquetReader) ReadByNumber(maxReadNumber int) ([]interface{}, error) 
 	}
 
 	ln := res.Elem().Len()
-	ret := make([]interface{}, ln)
+	ret := make([]any, ln)
 	for i := 0; i < ln; i++ {
 		ret[i] = res.Elem().Index(i).Interface()
 	}
@@ -252,7 +252,7 @@ func (pr *ParquetReader) ReadByNumber(maxReadNumber int) ([]interface{}, error) 
 }
 
 // Read rows of parquet file and unmarshal all to dst
-func (pr *ParquetReader) ReadPartial(dstInterface interface{}, prefixPath string) error {
+func (pr *ParquetReader) ReadPartial(dstInterface any, prefixPath string) error {
 	prefixPath, err := pr.SchemaHandler.ConvertToInPathStr(prefixPath)
 	if err != nil {
 		return err
@@ -262,7 +262,7 @@ func (pr *ParquetReader) ReadPartial(dstInterface interface{}, prefixPath string
 }
 
 // Read maxReadNumber partial objects
-func (pr *ParquetReader) ReadPartialByNumber(maxReadNumber int, prefixPath string) ([]interface{}, error) {
+func (pr *ParquetReader) ReadPartialByNumber(maxReadNumber int, prefixPath string) ([]any, error) {
 	var err error
 	if pr.ObjPartialType == nil {
 		if pr.ObjPartialType, err = pr.SchemaHandler.GetType(prefixPath); err != nil {
@@ -279,7 +279,7 @@ func (pr *ParquetReader) ReadPartialByNumber(maxReadNumber int, prefixPath strin
 	}
 
 	ln := res.Elem().Len()
-	ret := make([]interface{}, ln)
+	ret := make([]any, ln)
 	for i := 0; i < ln; i++ {
 		ret[i] = res.Elem().Index(i).Interface()
 	}
@@ -288,7 +288,7 @@ func (pr *ParquetReader) ReadPartialByNumber(maxReadNumber int, prefixPath strin
 }
 
 // Read rows of parquet file with a prefixPath
-func (pr *ParquetReader) read(dstInterface interface{}, prefixPath string) error {
+func (pr *ParquetReader) read(dstInterface any, prefixPath string) error {
 	var err error
 	tmap := make(map[string]*layout.Table)
 	locker := new(sync.Mutex)
@@ -340,7 +340,7 @@ func (pr *ParquetReader) read(dstInterface interface{}, prefixPath string) error
 		stopChan <- 0
 	}
 
-	dstList := make([]interface{}, pr.NP)
+	dstList := make([]any, pr.NP)
 	delta := (int64(num) + pr.NP - 1) / pr.NP
 
 	var wg sync.WaitGroup

--- a/schema/json.go
+++ b/schema/json.go
@@ -37,7 +37,8 @@ func NewSchemaHandlerFromJSON(str string) (sh *SchemaHandler, err error) {
 			return nil, fmt.Errorf("failed parse tag: %s", err.Error())
 		}
 		var newInfo *common.Tag
-		if info.Type == "" { // struct
+		switch info.Type {
+		case "": // struct
 			schema := parquet.NewSchemaElement()
 			schema.Name = info.InName
 			rt := info.RepetitionType
@@ -54,8 +55,7 @@ func NewSchemaHandlerFromJSON(str string) (sh *SchemaHandler, err error) {
 				newItem := item.Fields[i]
 				stack = append(stack, newItem)
 			}
-
-		} else if info.Type == "LIST" { // list
+		case "LIST": // list
 			schema := parquet.NewSchemaElement()
 			schema.Name = info.InName
 			rt1 := info.RepetitionType
@@ -87,8 +87,7 @@ func NewSchemaHandlerFromJSON(str string) (sh *SchemaHandler, err error) {
 				return nil, fmt.Errorf("LIST needs exact 1 field to define element type")
 			}
 			stack = append(stack, item.Fields[0])
-
-		} else if info.Type == "MAP" { // map
+		case "MAP": // map
 			schema := parquet.NewSchemaElement()
 			schema.Name = info.InName
 			rt1 := info.RepetitionType
@@ -123,8 +122,7 @@ func NewSchemaHandlerFromJSON(str string) (sh *SchemaHandler, err error) {
 			}
 			stack = append(stack, item.Fields[1]) // put value
 			stack = append(stack, item.Fields[0]) // put key
-
-		} else { // normal variable
+		default: // normal variable
 			schema, err := common.NewSchemaElementFromTagMap(info)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create schema from tag map: %s", err.Error())

--- a/schema/schemahandler.go
+++ b/schema/schemahandler.go
@@ -227,7 +227,7 @@ func NewItem() *Item {
 }
 
 // Create schema handler from a object
-func NewSchemaHandlerFromStruct(obj interface{}) (sh *SchemaHandler, err error) {
+func NewSchemaHandlerFromStruct(obj any) (sh *SchemaHandler, err error) {
 	ot := reflect.TypeOf(obj).Elem()
 	item := NewItem()
 	item.GoType = ot

--- a/types/types.go
+++ b/types/types.go
@@ -5,162 +5,138 @@ import (
 	"math/big"
 	"reflect"
 
+	"github.com/hangxie/parquet-go/v2/common"
 	"github.com/hangxie/parquet-go/v2/parquet"
 )
 
 func ParquetTypeToGoReflectType(pT *parquet.Type, rT *parquet.FieldRepetitionType) reflect.Type {
 	if rT == nil || *rT != parquet.FieldRepetitionType_OPTIONAL {
-		if *pT == parquet.Type_BOOLEAN {
+		switch *pT {
+		case parquet.Type_BOOLEAN:
 			return reflect.TypeOf(true)
-		} else if *pT == parquet.Type_INT32 {
+		case parquet.Type_INT32:
 			return reflect.TypeOf(int32(0))
-		} else if *pT == parquet.Type_INT64 {
+		case parquet.Type_INT64:
 			return reflect.TypeOf(int64(0))
-		} else if *pT == parquet.Type_INT96 {
+		case parquet.Type_INT96:
 			return reflect.TypeOf("")
-		} else if *pT == parquet.Type_FLOAT {
+		case parquet.Type_FLOAT:
 			return reflect.TypeOf(float32(0))
-		} else if *pT == parquet.Type_DOUBLE {
+		case parquet.Type_DOUBLE:
 			return reflect.TypeOf(float64(0))
-		} else if *pT == parquet.Type_BYTE_ARRAY {
+		case parquet.Type_BYTE_ARRAY:
 			return reflect.TypeOf("")
-		} else if *pT == parquet.Type_FIXED_LEN_BYTE_ARRAY {
+		case parquet.Type_FIXED_LEN_BYTE_ARRAY:
 			return reflect.TypeOf("")
-		} else {
+		default:
 			return nil
 		}
-	} else {
-		if *pT == parquet.Type_BOOLEAN {
-			v := true
-			return reflect.TypeOf(&v)
+	}
 
-		} else if *pT == parquet.Type_INT32 {
-			v := int32(0)
-			return reflect.TypeOf(&v)
-
-		} else if *pT == parquet.Type_INT64 {
-			v := int64(0)
-			return reflect.TypeOf(&v)
-
-		} else if *pT == parquet.Type_INT96 {
-			v := ""
-			return reflect.TypeOf(&v)
-
-		} else if *pT == parquet.Type_FLOAT {
-			v := float32(0)
-			return reflect.TypeOf(&v)
-
-		} else if *pT == parquet.Type_DOUBLE {
-			v := float64(0)
-			return reflect.TypeOf(&v)
-
-		} else if *pT == parquet.Type_BYTE_ARRAY {
-			v := ""
-			return reflect.TypeOf(&v)
-
-		} else if *pT == parquet.Type_FIXED_LEN_BYTE_ARRAY {
-			v := ""
-			return reflect.TypeOf(&v)
-
-		} else {
-			return nil
-		}
+	switch *pT {
+	case parquet.Type_BOOLEAN:
+		return reflect.TypeOf(common.ToPtr(true))
+	case parquet.Type_INT32:
+		return reflect.TypeOf(common.ToPtr(int32(0)))
+	case parquet.Type_INT64:
+		return reflect.TypeOf(common.ToPtr(int64(0)))
+	case parquet.Type_INT96:
+		return reflect.TypeOf(common.ToPtr(""))
+	case parquet.Type_FLOAT:
+		return reflect.TypeOf(common.ToPtr(float32(0)))
+	case parquet.Type_DOUBLE:
+		return reflect.TypeOf(common.ToPtr(float64(0)))
+	case parquet.Type_BYTE_ARRAY:
+		return reflect.TypeOf(common.ToPtr(""))
+	case parquet.Type_FIXED_LEN_BYTE_ARRAY:
+		return reflect.TypeOf(common.ToPtr(""))
+	default:
+		return nil
 	}
 }
 
 // Scan a string to parquet value; length and scale just for decimal
-func StrToParquetType(s string, pT *parquet.Type, cT *parquet.ConvertedType, length, scale int) (interface{}, error) {
+func StrToParquetType(s string, pT *parquet.Type, cT *parquet.ConvertedType, length, scale int) (any, error) {
 	if cT == nil {
-		if *pT == parquet.Type_BOOLEAN {
+		switch *pT {
+		case parquet.Type_BOOLEAN:
 			var v bool
 			_, err := fmt.Sscanf(s, "%t", &v)
 			return v, err
-
-		} else if *pT == parquet.Type_INT32 {
+		case parquet.Type_INT32:
 			var v int32
 			_, err := fmt.Sscanf(s, "%d", &v)
 			return v, err
-
-		} else if *pT == parquet.Type_INT64 {
+		case parquet.Type_INT64:
 			var v int64
 			_, err := fmt.Sscanf(s, "%d", &v)
 			return v, err
-
-		} else if *pT == parquet.Type_INT96 {
+		case parquet.Type_INT96:
 			res := StrIntToBinary(s, "LittleEndian", 12, true)
 			return res, nil
-
-		} else if *pT == parquet.Type_FLOAT {
+		case parquet.Type_FLOAT:
 			var v float32
 			_, err := fmt.Sscanf(s, "%f", &v)
 			return v, err
-
-		} else if *pT == parquet.Type_DOUBLE {
+		case parquet.Type_DOUBLE:
 			var v float64
 			_, err := fmt.Sscanf(s, "%f", &v)
 			return v, err
-
-		} else if *pT == parquet.Type_BYTE_ARRAY {
+		case parquet.Type_BYTE_ARRAY:
 			return s, nil
-		} else if *pT == parquet.Type_FIXED_LEN_BYTE_ARRAY {
+		case parquet.Type_FIXED_LEN_BYTE_ARRAY:
 			return s, nil
+		default:
+			return nil, nil
 		}
-		return nil, nil
 	}
 
-	if *cT == parquet.ConvertedType_UTF8 {
+	switch *cT {
+	case parquet.ConvertedType_UTF8:
 		return s, nil
-	} else if *cT == parquet.ConvertedType_INT_8 {
+	case parquet.ConvertedType_INT_8:
 		var v int8
 		_, err := fmt.Sscanf(s, "%d", &v)
 		return int32(v), err
-
-	} else if *cT == parquet.ConvertedType_INT_16 {
+	case parquet.ConvertedType_INT_16:
 		var v int16
 		_, err := fmt.Sscanf(s, "%d", &v)
 		return int32(v), err
-
-	} else if *cT == parquet.ConvertedType_INT_32 {
+	case parquet.ConvertedType_INT_32:
 		var v int32
 		_, err := fmt.Sscanf(s, "%d", &v)
 		return int32(v), err
-
-	} else if *cT == parquet.ConvertedType_UINT_8 {
+	case parquet.ConvertedType_UINT_8:
 		var v uint8
 		_, err := fmt.Sscanf(s, "%d", &v)
 		return int32(v), err
-
-	} else if *cT == parquet.ConvertedType_UINT_16 {
+	case parquet.ConvertedType_UINT_16:
 		var v uint16
 		_, err := fmt.Sscanf(s, "%d", &v)
 		return int32(v), err
-
-	} else if *cT == parquet.ConvertedType_UINT_32 {
+	case parquet.ConvertedType_UINT_32:
 		var v uint32
 		_, err := fmt.Sscanf(s, "%d", &v)
 		return int32(v), err
-
-	} else if *cT == parquet.ConvertedType_DATE || *cT == parquet.ConvertedType_TIME_MILLIS {
+	case parquet.ConvertedType_DATE, parquet.ConvertedType_TIME_MILLIS:
 		var v int32
 		_, err := fmt.Sscanf(s, "%d", &v)
 		return int32(v), err
-
-	} else if *cT == parquet.ConvertedType_UINT_64 {
+	case parquet.ConvertedType_UINT_64:
 		var vt uint64
 		_, err := fmt.Sscanf(s, "%d", &vt)
 		return int64(vt), err
-
-	} else if *cT == parquet.ConvertedType_INT_64 ||
-		*cT == parquet.ConvertedType_TIME_MICROS || *cT == parquet.ConvertedType_TIMESTAMP_MICROS || *cT == parquet.ConvertedType_TIMESTAMP_MILLIS {
+	case parquet.ConvertedType_INT_64,
+		parquet.ConvertedType_TIME_MICROS,
+		parquet.ConvertedType_TIMESTAMP_MICROS,
+		parquet.ConvertedType_TIMESTAMP_MILLIS:
 		var v int64
 		_, err := fmt.Sscanf(s, "%d", &v)
 		return v, err
-
-	} else if *cT == parquet.ConvertedType_INTERVAL {
+	case parquet.ConvertedType_INTERVAL:
 		res := StrIntToBinary(s, "LittleEndian", 12, false)
 		return res, nil
-
-	} else if *cT == parquet.ConvertedType_DECIMAL {
+	case parquet.ConvertedType_DECIMAL:
 		numSca := big.NewFloat(1.0)
 		for i := 0; i < scale; i++ {
 			numSca.Mul(numSca, big.NewFloat(10))
@@ -169,30 +145,28 @@ func StrToParquetType(s string, pT *parquet.Type, cT *parquet.ConvertedType, len
 		num.SetString(s)
 		num.Mul(num, numSca)
 
-		if *pT == parquet.Type_INT32 {
+		switch *pT {
+		case parquet.Type_INT32:
 			tmp, _ := num.Float64()
 			return int32(tmp), nil
-
-		} else if *pT == parquet.Type_INT64 {
+		case parquet.Type_INT64:
 			tmp, _ := num.Float64()
 			return int64(tmp), nil
-
-		} else if *pT == parquet.Type_FIXED_LEN_BYTE_ARRAY {
+		case parquet.Type_FIXED_LEN_BYTE_ARRAY:
 			s = num.Text('f', 0)
 			res := StrIntToBinary(s, "BigEndian", length, true)
 			return res, nil
-
-		} else {
+		default:
 			s = num.Text('f', 0)
 			res := StrIntToBinary(s, "BigEndian", 0, true)
 			return res, nil
 		}
-	} else {
+	default:
 		return nil, nil
 	}
 }
 
-func InterfaceToParquetType(src interface{}, pT *parquet.Type) interface{} {
+func InterfaceToParquetType(src any, pT *parquet.Type) any {
 	if src == nil {
 		return src
 	}
@@ -318,7 +292,7 @@ func StrIntToBinary(num, order string, length int, signed bool) string {
 	return string(bs)
 }
 
-func JSONTypeToParquetType(val reflect.Value, pT *parquet.Type, cT *parquet.ConvertedType, length, scale int) (interface{}, error) {
+func JSONTypeToParquetType(val reflect.Value, pT *parquet.Type, cT *parquet.ConvertedType, length, scale int) (any, error) {
 	if val.Type().Kind() == reflect.Interface && val.IsNil() {
 		return nil, nil
 	}

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -12,7 +12,7 @@ import (
 func TestStrToParquetType(t *testing.T) {
 	testData := []struct {
 		StrData string
-		GoData  interface{}
+		GoData  any
 		PT      *parquet.Type
 		CT      *parquet.ConvertedType
 		Length  int

--- a/writer/arrow.go
+++ b/writer/arrow.go
@@ -63,7 +63,7 @@ func NewArrowWriter(arrowSchema *arrow.Schema, pfile source.ParquetFileWriter,
 // gives as array of columns, to array of rows which the parquet-go library
 // can understand as it does not accepts data by columns, but rather by rows.
 func (w *ArrowWriter) WriteArrow(record arrow.Record) error {
-	table := make([][]interface{}, 0)
+	table := make([][]any, 0)
 	for i, column := range record.Columns() {
 		columnFromRecord, err := common.ArrowColToParquetCol(
 			record.Schema().Field(i), column)

--- a/writer/arrow_test.go
+++ b/writer/arrow_test.go
@@ -616,11 +616,11 @@ func TestE2ENullabilityValid(t *testing.T) {
 	res, err := pr.ReadByNumber(num)
 	assert.Nil(t, err)
 
-	actualTable := [][]interface{}{}
+	actualTable := [][]any{}
 	for _, row := range res {
 		actualTable = append(actualTable, rowToSliceOfValues(row))
 	}
-	expectedTable := [][]interface{}{
+	expectedTable := [][]any{
 		{
 			-1, nil, -21, nil, 1, nil, 21, nil, float32(1.1), nil, 1, nil, "A", nil, true,
 			nil, 1, nil, 1,
@@ -657,9 +657,9 @@ func TestE2ENullabilityValid(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func rowToSliceOfValues(s interface{}) []interface{} {
+func rowToSliceOfValues(s any) []any {
 	v := reflect.ValueOf(s)
-	res := []interface{}{}
+	res := []any{}
 	for i := 0; i < v.NumField(); i++ {
 		field := v.Field(i)
 		if field.IsNil() {

--- a/writer/csv.go
+++ b/writer/csv.go
@@ -48,12 +48,12 @@ func NewCSVWriter(md []string, pfile source.ParquetFileWriter, np int64) (*CSVWr
 }
 
 // Write string values to parquet file
-func (w *CSVWriter) WriteString(recsi interface{}) error {
+func (w *CSVWriter) WriteString(recsi any) error {
 	var err error
 	recs := recsi.([]*string)
 	lr := len(recs)
-	rec := make([]interface{}, lr)
-	for i := 0; i < lr; i++ {
+	rec := make([]any, lr)
+	for i := range lr {
 		rec[i] = nil
 		if recs[i] != nil {
 			rec[i], err = types.StrToParquetType(*recs[i],

--- a/writer/csv_test.go
+++ b/writer/csv_test.go
@@ -130,7 +130,7 @@ func Benchmark_WriteCSVPlainDictionary(b *testing.B) {
 			b.Fatal(err)
 		}
 		for j := 0; j < 10000; j++ {
-			err = pw.Write([]interface{}{"Harry", "S", "Truman", "Lamar"})
+			err = pw.Write([]any{"Harry", "S", "Truman", "Lamar"})
 			if err != nil {
 				b.Fatal(err)
 			}

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -31,7 +31,7 @@ type ParquetWriter struct {
 	CompressionType parquet.CompressionCodec
 	Offset          int64
 
-	Objs              []interface{}
+	Objs              []any
 	ObjsSize          int64
 	ObjSize           int64
 	CheckSizeCritical int64
@@ -45,18 +45,18 @@ type ParquetWriter struct {
 	ColumnIndexes []*parquet.ColumnIndex
 	OffsetIndexes []*parquet.OffsetIndex
 
-	MarshalFunc func(src []interface{}, sh *schema.SchemaHandler) (*map[string]*layout.Table, error)
+	MarshalFunc func(src []any, sh *schema.SchemaHandler) (*map[string]*layout.Table, error)
 
 	stopped bool
 }
 
-func NewParquetWriterFromWriter(w io.Writer, obj interface{}, np int64) (*ParquetWriter, error) {
+func NewParquetWriterFromWriter(w io.Writer, obj any, np int64) (*ParquetWriter, error) {
 	wf := writerfile.NewWriterFile(w)
 	return NewParquetWriter(wf, obj, np)
 }
 
 // Create a parquet handler. Obj is a object with tags or JSON schema string.
-func NewParquetWriter(pFile source.ParquetFileWriter, obj interface{}, np int64) (*ParquetWriter, error) {
+func NewParquetWriter(pFile source.ParquetFileWriter, obj any, np int64) (*ParquetWriter, error) {
 	var err error
 
 	res := new(ParquetWriter)
@@ -224,7 +224,7 @@ func (pw *ParquetWriter) WriteStop() error {
 }
 
 // Write one object to parquet file
-func (pw *ParquetWriter) Write(src interface{}) error {
+func (pw *ParquetWriter) Write(src any) error {
 	if pw.stopped {
 		return errors.New("writer is stopped")
 	}
@@ -428,7 +428,7 @@ func (pw *ParquetWriter) Flush(flag bool) error {
 
 			firstRowIndex := int64(0)
 
-			for l := 0; l < pageCount; l++ {
+			for l := range pageCount {
 				page := rowGroup.Chunks[k].Pages[l]
 				if page.Header.Type == parquet.PageType_DICTIONARY_PAGE {
 					tmp := pw.Offset


### PR DESCRIPTION
Use generic to reduce redundant code, replace `interface{}` with `any`, replace `if`/`else if` with `switch`/`case`, etc.