### PR TITLE
change INTERVAL type output format

### DIFF
--- a/types/converter.go
+++ b/types/converter.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"encoding/binary"
+	"fmt"
 	"math/big"
 	"strconv"
 	"strings"
@@ -153,20 +154,31 @@ func DECIMAL_BYTE_ARRAY_ToString(dec []byte, precision, scale int) string {
 	return sign + sa
 }
 
-func IntervalToDuration(interval []byte) time.Duration {
+func IntervalToString(interval []byte) string {
 	if len(interval) != 12 {
-		return 0
+		return ""
 	}
 
 	months := binary.LittleEndian.Uint32(interval[0:4])
 	days := binary.LittleEndian.Uint32(interval[4:8])
 	milliseconds := binary.LittleEndian.Uint32(interval[8:12])
 
-	duration := time.Duration(months)*30*24*time.Hour +
-		time.Duration(days)*24*time.Hour +
-		time.Duration(milliseconds)*time.Millisecond
+	// Convert milliseconds to seconds with decimals
+	seconds := float64(milliseconds) / 1000.0
 
-	return duration
+	// Format as "XX mon XX day XX.xx sec"
+	var parts []string
+	if months > 0 {
+		parts = append(parts, fmt.Sprintf("%d mon", months))
+	}
+	if days > 0 {
+		parts = append(parts, fmt.Sprintf("%d day", days))
+	}
+	if seconds > 0 || len(parts) == 0 {
+		parts = append(parts, fmt.Sprintf("%.2f sec", seconds))
+	}
+
+	return strings.Join(parts, " ")
 }
 
 func TIMESTAMP_MILLISToISO8601(millis int64, adjustedToUTC bool) string {

--- a/types/types.go
+++ b/types/types.go
@@ -548,7 +548,7 @@ func convertINT96Value(val any) any {
 	return val
 }
 
-// convertIntervalValue handles INTERVAL to Go duration string conversion
+// convertIntervalValue handles INTERVAL to formatted string conversion
 func convertIntervalValue(val any) any {
 	if val == nil {
 		return nil
@@ -557,13 +557,11 @@ func convertIntervalValue(val any) any {
 	switch v := val.(type) {
 	case []byte:
 		if len(v) == 12 {
-			duration := IntervalToDuration(v)
-			return duration.String()
+			return IntervalToString(v)
 		}
 	case string:
 		if len(v) == 12 {
-			duration := IntervalToDuration([]byte(v))
-			return duration.String()
+			return IntervalToString([]byte(v))
 		}
 	}
 

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -1043,7 +1043,7 @@ func Test_ParquetTypeToJSONType(t *testing.T) {
 			cT:        parquet.ConvertedTypePtr(parquet.ConvertedType_INTERVAL),
 			precision: 0,
 			scale:     0,
-			expected:  (26 * time.Hour).String(), // 1 day + 2 hours = 26 hours
+			expected:  "1 day 7200.00 sec", // 1 day + 2 hours = 1 day + 7200 seconds
 		},
 		{
 			name:      "timestamp_millis_converted_type",
@@ -1358,7 +1358,7 @@ func Test_convertIntervalValue(t *testing.T) {
 				binary.LittleEndian.PutUint32(b[8:12], 3600000) // 1 hour in milliseconds
 				return b
 			}(),
-			expected: (25 * time.Hour).String(), // 1 day + 1 hour = 25 hours
+			expected: "1 day 3600.00 sec",
 		},
 		{
 			name: "valid_interval_string",
@@ -1369,7 +1369,18 @@ func Test_convertIntervalValue(t *testing.T) {
 				binary.LittleEndian.PutUint32(b[8:12], 1000) // 1 second in milliseconds
 				return string(b)
 			}(),
-			expected: time.Second.String(),
+			expected: "1.00 sec",
+		},
+		{
+			name: "interval_with_months_days_seconds",
+			val: func() []byte {
+				b := make([]byte, 12)
+				binary.LittleEndian.PutUint32(b[0:4], 2)     // 2 months
+				binary.LittleEndian.PutUint32(b[4:8], 15)    // 15 days
+				binary.LittleEndian.PutUint32(b[8:12], 1500) // 1.5 seconds
+				return b
+			}(),
+			expected: "2 mon 15 day 1.50 sec",
 		},
 		{
 			name:     "invalid_length_string",


### PR DESCRIPTION
Change INTERVAL output format to "2 mon 15 day 7200.00 sec", which aligns with parquet spec, and easier to read.