### PR TITLE
do not write min/max statistics for geospatial and interval data

### DIFF
--- a/layout/chunk_test.go
+++ b/layout/chunk_test.go
@@ -1223,7 +1223,7 @@ func Test_ChunkLevel_SkipMinMaxStatistics_ForGeospatialTypes(t *testing.T) {
 				}
 
 				// Add geospatial statistics if it's a geospatial type
-				if tt.logicalType != nil && (tt.logicalType.IsSetGEOMETRY() || tt.logicalType.IsSetGEOGRAPHY()) {
+				if isGeospatial {
 					page1.GeospatialBBox = &parquet.BoundingBox{Xmin: 10.5, Xmax: 10.5, Ymin: 20.3, Ymax: 20.3}
 					page1.GeospatialTypes = []int32{1}
 					page2.GeospatialBBox = &parquet.BoundingBox{Xmin: 10.5, Xmax: 10.5, Ymin: 20.3, Ymax: 20.3}
@@ -1255,8 +1255,8 @@ func Test_ChunkLevel_SkipMinMaxStatistics_ForGeospatialTypes(t *testing.T) {
 				// Null count should always be present
 				require.NotNil(t, chunk.ChunkHeader.MetaData.Statistics.NullCount)
 
-				// Verify geospatial statistics are present for geospatial types
-				if tt.logicalType != nil && (tt.logicalType.IsSetGEOMETRY() || tt.logicalType.IsSetGEOGRAPHY()) {
+				// Verify geospatial statistics are present for geospatial types only
+				if isGeospatial {
 					require.NotNil(t, chunk.ChunkHeader.MetaData.GeospatialStatistics)
 					require.NotNil(t, chunk.ChunkHeader.MetaData.GeospatialStatistics.Bbox)
 					require.NotNil(t, chunk.ChunkHeader.MetaData.GeospatialStatistics.GeospatialTypes)
@@ -1308,7 +1308,7 @@ func Test_ChunkLevel_SkipMinMaxStatistics_ForGeospatialTypes(t *testing.T) {
 				}
 
 				// Add geospatial statistics if it's a geospatial type
-				if tt.logicalType != nil && (tt.logicalType.IsSetGEOMETRY() || tt.logicalType.IsSetGEOGRAPHY()) {
+				if isGeospatial {
 					dataPage.GeospatialBBox = &parquet.BoundingBox{Xmin: 10.5, Xmax: 10.5, Ymin: 20.3, Ymax: 20.3}
 					dataPage.GeospatialTypes = []int32{1}
 				}
@@ -1338,8 +1338,8 @@ func Test_ChunkLevel_SkipMinMaxStatistics_ForGeospatialTypes(t *testing.T) {
 				// Null count should always be present
 				require.NotNil(t, chunk.ChunkHeader.MetaData.Statistics.NullCount)
 
-				// Verify geospatial statistics are present for geospatial types
-				if tt.logicalType != nil && (tt.logicalType.IsSetGEOMETRY() || tt.logicalType.IsSetGEOGRAPHY()) {
+				// Verify geospatial statistics are present for geospatial types only
+				if isGeospatial {
 					require.NotNil(t, chunk.ChunkHeader.MetaData.GeospatialStatistics)
 					require.NotNil(t, chunk.ChunkHeader.MetaData.GeospatialStatistics.Bbox)
 					require.NotNil(t, chunk.ChunkHeader.MetaData.GeospatialStatistics.GeospatialTypes)

--- a/layout/chunk_test.go
+++ b/layout/chunk_test.go
@@ -1241,27 +1241,27 @@ func Test_ChunkLevel_SkipMinMaxStatistics_ForGeospatialTypes(t *testing.T) {
 
 				// Check min/max statistics based on expectation
 				if tt.expectMinMaxStats {
-					require.NotNil(t, chunk.ChunkHeader.MetaData.Statistics.Max, "Expected min/max statistics for %s", tt.name)
-					require.NotNil(t, chunk.ChunkHeader.MetaData.Statistics.Min, "Expected min/max statistics for %s", tt.name)
-					require.NotNil(t, chunk.ChunkHeader.MetaData.Statistics.MaxValue, "Expected MaxValue for %s", tt.name)
-					require.NotNil(t, chunk.ChunkHeader.MetaData.Statistics.MinValue, "Expected MinValue for %s", tt.name)
+					require.NotNil(t, chunk.ChunkHeader.MetaData.Statistics.Max)
+					require.NotNil(t, chunk.ChunkHeader.MetaData.Statistics.Min)
+					require.NotNil(t, chunk.ChunkHeader.MetaData.Statistics.MaxValue)
+					require.NotNil(t, chunk.ChunkHeader.MetaData.Statistics.MinValue)
 				} else {
-					require.Nil(t, chunk.ChunkHeader.MetaData.Statistics.Max, "Expected no Max statistics for %s", tt.name)
-					require.Nil(t, chunk.ChunkHeader.MetaData.Statistics.Min, "Expected no Min statistics for %s", tt.name)
-					require.Nil(t, chunk.ChunkHeader.MetaData.Statistics.MaxValue, "Expected no MaxValue for %s", tt.name)
-					require.Nil(t, chunk.ChunkHeader.MetaData.Statistics.MinValue, "Expected no MinValue for %s", tt.name)
+					require.Nil(t, chunk.ChunkHeader.MetaData.Statistics.Max)
+					require.Nil(t, chunk.ChunkHeader.MetaData.Statistics.Min)
+					require.Nil(t, chunk.ChunkHeader.MetaData.Statistics.MaxValue)
+					require.Nil(t, chunk.ChunkHeader.MetaData.Statistics.MinValue)
 				}
 
 				// Null count should always be present
-				require.NotNil(t, chunk.ChunkHeader.MetaData.Statistics.NullCount, "Expected NullCount for %s", tt.name)
+				require.NotNil(t, chunk.ChunkHeader.MetaData.Statistics.NullCount)
 
 				// Verify geospatial statistics are present for geospatial types
 				if tt.logicalType != nil && (tt.logicalType.IsSetGEOMETRY() || tt.logicalType.IsSetGEOGRAPHY()) {
-					require.NotNil(t, chunk.ChunkHeader.MetaData.GeospatialStatistics, "Expected GeospatialStatistics for %s", tt.name)
-					require.NotNil(t, chunk.ChunkHeader.MetaData.GeospatialStatistics.Bbox, "Expected GeospatialStatistics.Bbox for %s", tt.name)
-					require.NotNil(t, chunk.ChunkHeader.MetaData.GeospatialStatistics.GeospatialTypes, "Expected GeospatialStatistics.GeospatialTypes for %s", tt.name)
+					require.NotNil(t, chunk.ChunkHeader.MetaData.GeospatialStatistics)
+					require.NotNil(t, chunk.ChunkHeader.MetaData.GeospatialStatistics.Bbox)
+					require.NotNil(t, chunk.ChunkHeader.MetaData.GeospatialStatistics.GeospatialTypes)
 				} else {
-					require.Nil(t, chunk.ChunkHeader.MetaData.GeospatialStatistics, "Expected no GeospatialStatistics for %s", tt.name)
+					require.Nil(t, chunk.ChunkHeader.MetaData.GeospatialStatistics)
 				}
 			})
 
@@ -1324,27 +1324,27 @@ func Test_ChunkLevel_SkipMinMaxStatistics_ForGeospatialTypes(t *testing.T) {
 
 				// Check min/max statistics based on expectation
 				if tt.expectMinMaxStats {
-					require.NotNil(t, chunk.ChunkHeader.MetaData.Statistics.Max, "Expected min/max statistics for %s", tt.name)
-					require.NotNil(t, chunk.ChunkHeader.MetaData.Statistics.Min, "Expected min/max statistics for %s", tt.name)
-					require.NotNil(t, chunk.ChunkHeader.MetaData.Statistics.MaxValue, "Expected MaxValue for %s", tt.name)
-					require.NotNil(t, chunk.ChunkHeader.MetaData.Statistics.MinValue, "Expected MinValue for %s", tt.name)
+					require.NotNil(t, chunk.ChunkHeader.MetaData.Statistics.Max)
+					require.NotNil(t, chunk.ChunkHeader.MetaData.Statistics.Min)
+					require.NotNil(t, chunk.ChunkHeader.MetaData.Statistics.MaxValue)
+					require.NotNil(t, chunk.ChunkHeader.MetaData.Statistics.MinValue)
 				} else {
-					require.Nil(t, chunk.ChunkHeader.MetaData.Statistics.Max, "Expected no Max statistics for %s", tt.name)
-					require.Nil(t, chunk.ChunkHeader.MetaData.Statistics.Min, "Expected no Min statistics for %s", tt.name)
-					require.Nil(t, chunk.ChunkHeader.MetaData.Statistics.MaxValue, "Expected no MaxValue for %s", tt.name)
-					require.Nil(t, chunk.ChunkHeader.MetaData.Statistics.MinValue, "Expected no MinValue for %s", tt.name)
+					require.Nil(t, chunk.ChunkHeader.MetaData.Statistics.Max)
+					require.Nil(t, chunk.ChunkHeader.MetaData.Statistics.Min)
+					require.Nil(t, chunk.ChunkHeader.MetaData.Statistics.MaxValue)
+					require.Nil(t, chunk.ChunkHeader.MetaData.Statistics.MinValue)
 				}
 
 				// Null count should always be present
-				require.NotNil(t, chunk.ChunkHeader.MetaData.Statistics.NullCount, "Expected NullCount for %s", tt.name)
+				require.NotNil(t, chunk.ChunkHeader.MetaData.Statistics.NullCount)
 
 				// Verify geospatial statistics are present for geospatial types
 				if tt.logicalType != nil && (tt.logicalType.IsSetGEOMETRY() || tt.logicalType.IsSetGEOGRAPHY()) {
-					require.NotNil(t, chunk.ChunkHeader.MetaData.GeospatialStatistics, "Expected GeospatialStatistics for %s", tt.name)
-					require.NotNil(t, chunk.ChunkHeader.MetaData.GeospatialStatistics.Bbox, "Expected GeospatialStatistics.Bbox for %s", tt.name)
-					require.NotNil(t, chunk.ChunkHeader.MetaData.GeospatialStatistics.GeospatialTypes, "Expected GeospatialStatistics.GeospatialTypes for %s", tt.name)
+					require.NotNil(t, chunk.ChunkHeader.MetaData.GeospatialStatistics)
+					require.NotNil(t, chunk.ChunkHeader.MetaData.GeospatialStatistics.Bbox)
+					require.NotNil(t, chunk.ChunkHeader.MetaData.GeospatialStatistics.GeospatialTypes)
 				} else {
-					require.Nil(t, chunk.ChunkHeader.MetaData.GeospatialStatistics, "Expected no GeospatialStatistics for %s", tt.name)
+					require.Nil(t, chunk.ChunkHeader.MetaData.GeospatialStatistics)
 				}
 			})
 		})

--- a/layout/page.go
+++ b/layout/page.go
@@ -126,8 +126,11 @@ func TableToDataPages(table *Table, pageSize int32, compressType parquet.Compres
 		page.DataTable.DefinitionLevels = table.DefinitionLevels[i:j]
 		page.DataTable.RepetitionLevels = table.RepetitionLevels[i:j]
 		if !omitStats {
-			// Skip min/max values for GEOMETRY and GEOGRAPHY types
-			if logT == nil || (!logT.IsSetGEOMETRY() && !logT.IsSetGEOGRAPHY()) {
+			// Skip min/max values for GEOMETRY, GEOGRAPHY, and INTERVAL types
+			isGeospatial := logT != nil && (logT.IsSetGEOMETRY() || logT.IsSetGEOGRAPHY())
+			isInterval := cT != nil && *cT == parquet.ConvertedType_INTERVAL
+
+			if !isGeospatial && !isInterval {
 				page.MaxVal = maxVal
 				page.MinVal = minVal
 			}

--- a/layout/page_test.go
+++ b/layout/page_test.go
@@ -146,26 +146,26 @@ func Test_GeospatialFields_SkipMinMaxStatistics(t *testing.T) {
 
 				// Check min/max statistics based on expectation
 				if tt.expectMinMaxStats {
-					require.NotNil(t, page.Header.DataPageHeader.Statistics.Max, "Expected min/max statistics for %s", tt.name)
-					require.NotNil(t, page.Header.DataPageHeader.Statistics.Min, "Expected min/max statistics for %s", tt.name)
-					require.NotNil(t, page.Header.DataPageHeader.Statistics.MaxValue, "Expected MaxValue for %s", tt.name)
-					require.NotNil(t, page.Header.DataPageHeader.Statistics.MinValue, "Expected MinValue for %s", tt.name)
+					require.NotNil(t, page.Header.DataPageHeader.Statistics.Max)
+					require.NotNil(t, page.Header.DataPageHeader.Statistics.Min)
+					require.NotNil(t, page.Header.DataPageHeader.Statistics.MaxValue)
+					require.NotNil(t, page.Header.DataPageHeader.Statistics.MinValue)
 				} else {
-					require.Nil(t, page.Header.DataPageHeader.Statistics.Max, "Expected no Max statistics for %s", tt.name)
-					require.Nil(t, page.Header.DataPageHeader.Statistics.Min, "Expected no Min statistics for %s", tt.name)
-					require.Nil(t, page.Header.DataPageHeader.Statistics.MaxValue, "Expected no MaxValue for %s", tt.name)
-					require.Nil(t, page.Header.DataPageHeader.Statistics.MinValue, "Expected no MinValue for %s", tt.name)
+					require.Nil(t, page.Header.DataPageHeader.Statistics.Max)
+					require.Nil(t, page.Header.DataPageHeader.Statistics.Min)
+					require.Nil(t, page.Header.DataPageHeader.Statistics.MaxValue)
+					require.Nil(t, page.Header.DataPageHeader.Statistics.MinValue)
 				}
 
 				// Null count should always be present (not skipped)
 				if tt.expectNullCountStat {
-					require.NotNil(t, page.Header.DataPageHeader.Statistics.NullCount, "Expected NullCount for %s", tt.name)
+					require.NotNil(t, page.Header.DataPageHeader.Statistics.NullCount)
 				}
 
 				// Verify geospatial statistics are preserved for geospatial types
 				if tt.logicalType != nil && (tt.logicalType.IsSetGEOMETRY() || tt.logicalType.IsSetGEOGRAPHY()) {
-					require.NotNil(t, page.GeospatialBBox, "Expected GeospatialBBox to be preserved for %s", tt.name)
-					require.NotNil(t, page.GeospatialTypes, "Expected GeospatialTypes to be preserved for %s", tt.name)
+					require.NotNil(t, page.GeospatialBBox)
+					require.NotNil(t, page.GeospatialTypes)
 				}
 			})
 
@@ -219,26 +219,26 @@ func Test_GeospatialFields_SkipMinMaxStatistics(t *testing.T) {
 
 				// Check min/max statistics based on expectation
 				if tt.expectMinMaxStats {
-					require.NotNil(t, page.Header.DataPageHeaderV2.Statistics.Max, "Expected min/max statistics for %s", tt.name)
-					require.NotNil(t, page.Header.DataPageHeaderV2.Statistics.Min, "Expected min/max statistics for %s", tt.name)
-					require.NotNil(t, page.Header.DataPageHeaderV2.Statistics.MaxValue, "Expected MaxValue for %s", tt.name)
-					require.NotNil(t, page.Header.DataPageHeaderV2.Statistics.MinValue, "Expected MinValue for %s", tt.name)
+					require.NotNil(t, page.Header.DataPageHeaderV2.Statistics.Max)
+					require.NotNil(t, page.Header.DataPageHeaderV2.Statistics.Min)
+					require.NotNil(t, page.Header.DataPageHeaderV2.Statistics.MaxValue)
+					require.NotNil(t, page.Header.DataPageHeaderV2.Statistics.MinValue)
 				} else {
-					require.Nil(t, page.Header.DataPageHeaderV2.Statistics.Max, "Expected no Max statistics for %s", tt.name)
-					require.Nil(t, page.Header.DataPageHeaderV2.Statistics.Min, "Expected no Min statistics for %s", tt.name)
-					require.Nil(t, page.Header.DataPageHeaderV2.Statistics.MaxValue, "Expected no MaxValue for %s", tt.name)
-					require.Nil(t, page.Header.DataPageHeaderV2.Statistics.MinValue, "Expected no MinValue for %s", tt.name)
+					require.Nil(t, page.Header.DataPageHeaderV2.Statistics.Max)
+					require.Nil(t, page.Header.DataPageHeaderV2.Statistics.Min)
+					require.Nil(t, page.Header.DataPageHeaderV2.Statistics.MaxValue)
+					require.Nil(t, page.Header.DataPageHeaderV2.Statistics.MinValue)
 				}
 
 				// Null count should always be present (not skipped)
 				if tt.expectNullCountStat {
-					require.NotNil(t, page.Header.DataPageHeaderV2.Statistics.NullCount, "Expected NullCount for %s", tt.name)
+					require.NotNil(t, page.Header.DataPageHeaderV2.Statistics.NullCount)
 				}
 
 				// Verify geospatial statistics are preserved for geospatial types
 				if tt.logicalType != nil && (tt.logicalType.IsSetGEOMETRY() || tt.logicalType.IsSetGEOGRAPHY()) {
-					require.NotNil(t, page.GeospatialBBox, "Expected GeospatialBBox to be preserved for %s", tt.name)
-					require.NotNil(t, page.GeospatialTypes, "Expected GeospatialTypes to be preserved for %s", tt.name)
+					require.NotNil(t, page.GeospatialBBox)
+					require.NotNil(t, page.GeospatialTypes)
 				}
 			})
 		})

--- a/reader/reader.go
+++ b/reader/reader.go
@@ -134,24 +134,28 @@ func (pr *ParquetReader) RenameSchema() {
 		exPathToInPath = pr.SchemaHandler.ExPathToInPath
 	}
 
-	if pr.Footer.RowGroups != nil {
-		for _, rowGroup := range pr.Footer.RowGroups {
-			if rowGroup != nil && rowGroup.Columns != nil {
-				for _, chunk := range rowGroup.Columns {
-					if chunk != nil && chunk.MetaData != nil {
-						exPath := append([]string{pr.SchemaHandler.GetRootExName()}, chunk.MetaData.GetPathInSchema()...)
-						exPathStr := common.PathToStr(exPath)
+	if pr.Footer.RowGroups == nil {
+		return
+	}
 
-						if pr.CaseInsensitive {
-							exPathStr = strings.ToLower(exPathStr)
-						}
+	for _, rowGroup := range pr.Footer.RowGroups {
+		if rowGroup == nil || rowGroup.Columns == nil {
+			continue
+		}
+		for _, chunk := range rowGroup.Columns {
+			if chunk == nil || chunk.MetaData == nil {
+				continue
+			}
+			exPath := append([]string{pr.SchemaHandler.GetRootExName()}, chunk.MetaData.GetPathInSchema()...)
+			exPathStr := common.PathToStr(exPath)
 
-						if inPathStr, exists := exPathToInPath[exPathStr]; exists {
-							inPath := common.StrToPath(inPathStr)[1:]
-							chunk.MetaData.PathInSchema = inPath
-						}
-					}
-				}
+			if pr.CaseInsensitive {
+				exPathStr = strings.ToLower(exPathStr)
+			}
+
+			if inPathStr, exists := exPathToInPath[exPathStr]; exists {
+				inPath := common.StrToPath(inPathStr)[1:]
+				chunk.MetaData.PathInSchema = inPath
 			}
 		}
 	}


### PR DESCRIPTION
Check 2 sections at https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#geometry, min/max needs to be null on the writer side, and reader side should ignore them.

EDIT do the same thing for INTERVAL https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#interval