### PR TITLE
fix: ensure bloom filters are initialized for all writer types

### DIFF
--- a/writer/csv.go
+++ b/writer/csv.go
@@ -46,6 +46,7 @@ func NewCSVWriter(md []string, pfile source.ParquetFileWriter, np int64) (*CSVWr
 		return nil, fmt.Errorf("write magic header: %w", err)
 	}
 	res.MarshalFunc = marshal.MarshalCSV
+	res.initBloomFilters()
 	return res, nil
 }
 

--- a/writer/json.go
+++ b/writer/json.go
@@ -44,6 +44,7 @@ func NewJSONWriter(jsonSchema string, pfile source.ParquetFileWriter, np int64) 
 	res.Offset = 4
 	_, err = res.PFile.Write([]byte("PAR1"))
 	res.MarshalFunc = marshal.MarshalJSON
+	res.initBloomFilters()
 	return res, err
 }
 


### PR DESCRIPTION
NewParquetWriter had an early return for JSON string schemas before calling initBloomFilters(). Also NewJSONWriter and NewCSVWriter never called initBloomFilters(). Fix by restructuring NewParquetWriter to always reach initBloomFilters() and adding the call to JSON/CSV writers.

Also fix Footer.Schema duplication when using JSON string schema path.