### PR TITLE
fix: detect bloom filter bitset size from file header instead of meta…

### DIFF
--- a/example/bloom_filter/bloom_filter.go
+++ b/example/bloom_filter/bloom_filter.go
@@ -75,8 +75,7 @@ func main() {
 		}
 		bfStatus := "Disabled"
 		if info.BloomFilter {
-			// Note: BloomFilterSize detected from file includes Thrift header overhead
-			bfStatus = fmt.Sprintf("Enabled (Size estimate: %d bytes)", info.BloomFilterSize)
+			bfStatus = fmt.Sprintf("Enabled (Size: %d bytes)", info.BloomFilterSize)
 		}
 		fmt.Printf("Column: %-10s | BloomFilter: %s\n", info.InName, bfStatus)
 	}


### PR DESCRIPTION
…data length

BloomFilterLength in column metadata includes the Thrift header overhead (~16 bytes), so a 4096-byte bloom filter was reported as 4112 bytes. Now reads the actual bloom filter header from file to get the correct NumBytes (bitset-only size).