### PR TITLE
docs: disallow agent co-author trailers in commit messages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,7 @@ to the parquet-go library project.
 
 - **Always commit after completing a task.** Once `make all` passes, create a commit immediately — do not wait to be asked.
 - Commit messages should follow **Conventional Commits**.
+- **Do not** add the agent's name as a commit co-author (e.g., no `Co-Authored-By` trailers).
 - Avoid breaking backward compatibility without clear migration notes.
 - Maintain high-quality, reviewable commits after completing each logical phase (plan, test, implement, document).
 


### PR DESCRIPTION
This is the reason https://groups.google.com/g/golang-dev/c/4Li4Ovd_ehE/m/8L9s_jq4BAAJ.

I think it's valid to concern about copyright issue, so agent should not be as co-author.