### PR TITLE
fix: validate length prefix in ReadPlainBYTE_ARRAY

### DIFF
--- a/encoding/encodingread.go
+++ b/encoding/encodingread.go
@@ -138,12 +138,11 @@ func ReadPlainBYTE_ARRAY(bytesReader *bytes.Reader, cnt uint64) ([]any, error) {
 	if err := validateCount(cnt); err != nil {
 		return nil, fmt.Errorf("ReadPlainBYTE_ARRAY: %w", err)
 	}
-	var err error
 	res := make([]any, cnt)
+	buf := make([]byte, 4)
 	for i := range int(cnt) {
-		buf := make([]byte, 4)
-		if _, err = bytesReader.Read(buf); err != nil {
-			break
+		if _, err := io.ReadFull(bytesReader, buf); err != nil {
+			return nil, fmt.Errorf("ReadPlainBYTE_ARRAY: read length prefix at index %d: %w", i, err)
 		}
 		ln := binary.LittleEndian.Uint32(buf)
 		if uint64(ln) > uint64(bytesReader.Len()) {
@@ -151,29 +150,31 @@ func ReadPlainBYTE_ARRAY(bytesReader *bytes.Reader, cnt uint64) ([]any, error) {
 		}
 		cur := make([]byte, ln)
 		if ln > 0 {
-			if _, err := bytesReader.Read(cur); err != nil {
-				return nil, err
+			if _, err := io.ReadFull(bytesReader, cur); err != nil {
+				return nil, fmt.Errorf("ReadPlainBYTE_ARRAY: read value at index %d: %w", i, err)
 			}
 		}
 		res[i] = string(cur)
 	}
-	return res, err
+	return res, nil
 }
 
 func ReadPlainFIXED_LEN_BYTE_ARRAY(bytesReader *bytes.Reader, cnt, fixedLength uint64) ([]any, error) {
 	if err := validateCount(cnt); err != nil {
 		return nil, fmt.Errorf("ReadPlainFIXED_LEN_BYTE_ARRAY: %w", err)
 	}
-	var err error
+	if fixedLength > uint64(bytesReader.Len()) {
+		return nil, fmt.Errorf("ReadPlainFIXED_LEN_BYTE_ARRAY: fixed length %d exceeds remaining data size %d", fixedLength, bytesReader.Len())
+	}
 	res := make([]any, cnt)
 	for i := range int(cnt) {
 		cur := make([]byte, fixedLength)
-		if _, err = bytesReader.Read(cur); err != nil {
-			break
+		if _, err := io.ReadFull(bytesReader, cur); err != nil {
+			return nil, fmt.Errorf("ReadPlainFIXED_LEN_BYTE_ARRAY: read value at index %d: %w", i, err)
 		}
 		res[i] = string(cur)
 	}
-	return res, err
+	return res, nil
 }
 
 func ReadUnsignedVarInt(bytesReader *bytes.Reader) (uint64, error) {

--- a/encoding/encodingread.go
+++ b/encoding/encodingread.go
@@ -146,6 +146,9 @@ func ReadPlainBYTE_ARRAY(bytesReader *bytes.Reader, cnt uint64) ([]any, error) {
 			break
 		}
 		ln := binary.LittleEndian.Uint32(buf)
+		if uint64(ln) > uint64(bytesReader.Len()) {
+			return nil, fmt.Errorf("ReadPlainBYTE_ARRAY: length prefix %d exceeds remaining data size %d", ln, bytesReader.Len())
+		}
 		cur := make([]byte, ln)
 		if ln > 0 {
 			if _, err := bytesReader.Read(cur); err != nil {

--- a/encoding/encodingread_test.go
+++ b/encoding/encodingread_test.go
@@ -663,6 +663,76 @@ func TestReadPlain(t *testing.T) {
 		require.Contains(t, err.Error(), "exceeds remaining data size")
 	})
 
+	t.Run("byte_array_boundary_cases", func(t *testing.T) {
+		tests := []struct {
+			name      string
+			buf       []byte
+			cnt       uint64
+			expectErr bool
+		}{
+			{
+				name: "length_equals_remaining_succeeds",
+				// length prefix = 3, remaining = 3 bytes
+				buf:       []byte{0x03, 0x00, 0x00, 0x00, 0x41, 0x42, 0x43},
+				cnt:       1,
+				expectErr: false,
+			},
+			{
+				name: "length_exceeds_remaining_by_one",
+				// length prefix = 4, remaining = 3 bytes
+				buf:       []byte{0x04, 0x00, 0x00, 0x00, 0x41, 0x42, 0x43},
+				cnt:       1,
+				expectErr: true,
+			},
+			{
+				name: "zero_length_value",
+				// length prefix = 0
+				buf:       []byte{0x00, 0x00, 0x00, 0x00},
+				cnt:       1,
+				expectErr: false,
+			},
+			{
+				name: "multiple_values_second_oversized",
+				// first value: length=1, data="A"; second value: length=0xFF, only 1 byte left
+				buf:       []byte{0x01, 0x00, 0x00, 0x00, 0x41, 0xFF, 0x00, 0x00, 0x00, 0x42},
+				cnt:       2,
+				expectErr: true,
+			},
+			{
+				name: "truncated_length_prefix",
+				// only 2 bytes instead of 4 for length prefix
+				buf:       []byte{0x01, 0x00},
+				cnt:       1,
+				expectErr: true,
+			},
+			{
+				name:      "cnt_zero",
+				buf:       []byte{},
+				cnt:       0,
+				expectErr: false,
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				_, err := ReadPlainBYTE_ARRAY(bytes.NewReader(tt.buf), tt.cnt)
+				if tt.expectErr {
+					require.Error(t, err)
+				} else {
+					require.NoError(t, err)
+				}
+			})
+		}
+	})
+
+	t.Run("fixed_len_byte_array_exceeds_buffer", func(t *testing.T) {
+		// 3 bytes of data but fixedLength=100
+		buf := []byte{0x01, 0x02, 0x03}
+		_, err := ReadPlainFIXED_LEN_BYTE_ARRAY(bytes.NewReader(buf), 1, 100)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "fixed length")
+		require.Contains(t, err.Error(), "exceeds remaining data size")
+	})
+
 	t.Run("double", func(t *testing.T) {
 		testData := [][]any{
 			{float64(0), float64(1), float64(2)},

--- a/encoding/encodingread_test.go
+++ b/encoding/encodingread_test.go
@@ -651,6 +651,18 @@ func TestReadPlain(t *testing.T) {
 		}
 	})
 
+	t.Run("byte_array_length_prefix_exceeds_buffer", func(t *testing.T) {
+		// Craft a buffer with a length prefix that far exceeds remaining data.
+		buf := []byte{
+			0xFF, 0xFF, 0xFF, 0xFF, // length prefix: ~4GB
+			0x01, 0x02, 0x03, // only 3 bytes of actual data
+		}
+		_, err := ReadPlainBYTE_ARRAY(bytes.NewReader(buf), 1)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "length prefix")
+		require.Contains(t, err.Error(), "exceeds remaining data size")
+	})
+
 	t.Run("double", func(t *testing.T) {
 		testData := [][]any{
 			{float64(0), float64(1), float64(2)},


### PR DESCRIPTION
## Summary
- Added bounds check to validate length prefix against remaining buffer size in `ReadPlainBYTE_ARRAY`
- Prevents potential ~4GB allocation from malicious Parquet files with crafted length prefixes

## Test plan
- [x] `make all` passes
- [x] Added test `byte_array_length_prefix_exceeds_buffer` verifying error on oversized length prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)