### PR TITLE
fix: reject negative lengths in ReadDeltaLengthByteArray

### DIFF
--- a/encoding/encodingread.go
+++ b/encoding/encodingread.go
@@ -467,7 +467,11 @@ func ReadDeltaLengthByteArray(bytesReader *bytes.Reader) ([]any, error) {
 	res = make([]any, len(lengths))
 	for i := range lengths {
 		res[i] = ""
-		length := uint64(lengths[i].(int64))
+		l := lengths[i].(int64)
+		if l < 0 {
+			return res, fmt.Errorf("ReadDeltaLengthByteArray: invalid negative length %d at index %d", l, i)
+		}
+		length := uint64(l)
 		if length > 0 {
 			cur, err := ReadPlainFIXED_LEN_BYTE_ARRAY(bytesReader, 1, length)
 			if err != nil {

--- a/encoding/encodingread_test.go
+++ b/encoding/encodingread_test.go
@@ -1245,6 +1245,15 @@ func TestReadDeltaEmpty(t *testing.T) {
 	})
 }
 
+func TestReadDeltaLengthByteArray_NegativeLength(t *testing.T) {
+	// WriteDeltaINT32 with a negative value produces a valid delta-encoded stream
+	// that ReadDeltaBinaryPackedINT64 decodes to a negative int64 length.
+	lengths := WriteDeltaINT32([]any{int32(-5)})
+	_, err := ReadDeltaLengthByteArray(bytes.NewReader(lengths))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid negative length")
+}
+
 func TestReadDeltaByteArrayWithEmptyPrefixLengths(t *testing.T) {
 	var buf []byte
 	buf = append(buf, WriteUnsignedVarInt(128)...)


### PR DESCRIPTION
## Summary
- Added check for negative int64 values before uint64 conversion in `ReadDeltaLengthByteArray`
- Prevents wrapping negative values to enormous uint64, which would cause huge allocations

## Test plan
- [x] `make all` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)