### PR TITLE
fix: add nil guard in SetSchemaHandlerFromJSON

### DIFF
--- a/reader/reader.go
+++ b/reader/reader.go
@@ -142,10 +142,14 @@ func (pr *ParquetReader) SetSchemaHandlerFromJSON(jsonSchema string) error {
 	pr.RenameSchema()
 	for i := range len(pr.SchemaHandler.SchemaElements) {
 		schemaElement := pr.SchemaHandler.SchemaElements[i]
+		if schemaElement == nil {
+			continue
+		}
 		if schemaElement.GetNumChildren() == 0 {
-			pathStr := pr.SchemaHandler.IndexMap[int32(i)]
-			if pr.ColumnBuffers[pathStr], err = NewColumnBuffer(pr.PFile, pr.Footer, pr.SchemaHandler, pathStr, layout.PageReadOptions{CRCMode: pr.crcMode, MaxPageSize: layout.DefaultMaxPageSize}); err != nil {
-				return fmt.Errorf("init column buffer for %s: %w", pathStr, err)
+			if pathStr, exists := pr.SchemaHandler.IndexMap[int32(i)]; exists {
+				if pr.ColumnBuffers[pathStr], err = NewColumnBuffer(pr.PFile, pr.Footer, pr.SchemaHandler, pathStr, layout.PageReadOptions{CRCMode: pr.crcMode, MaxPageSize: layout.DefaultMaxPageSize}); err != nil {
+					return fmt.Errorf("init column buffer for %s: %w", pathStr, err)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- Added nil check for schema elements and map key existence check in `SetSchemaHandlerFromJSON`
- Matches the defensive checks already present in `NewParquetReader`
- Prevents panic on nil SchemaElements and silent zero-value on missing IndexMap keys

## Test plan
- [x] `make all` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)