### PR TITLE
fix: return error for unsupported types in WritePlain

### DIFF
--- a/encoding/encodingwrite.go
+++ b/encoding/encodingwrite.go
@@ -33,11 +33,6 @@ func ToInt64(nums []any) []int64 { // convert bool/int values to int64 values
 }
 
 func WritePlain(src []any, pt parquet.Type) ([]byte, error) {
-	ln := len(src)
-	if ln <= 0 {
-		return []byte{}, nil
-	}
-
 	switch pt {
 	case parquet.Type_BOOLEAN:
 		return WritePlainBOOLEAN(src)
@@ -56,7 +51,7 @@ func WritePlain(src []any, pt parquet.Type) ([]byte, error) {
 	case parquet.Type_FIXED_LEN_BYTE_ARRAY:
 		return WritePlainFIXED_LEN_BYTE_ARRAY(src)
 	default:
-		return []byte{}, nil
+		return nil, fmt.Errorf("unsupported parquet type: %v", pt)
 	}
 }
 

--- a/encoding/encodingwrite_test.go
+++ b/encoding/encodingwrite_test.go
@@ -330,25 +330,35 @@ func TestWritePlain(t *testing.T) {
 				dataType: parquet.Type_FIXED_LEN_BYTE_ARRAY,
 			},
 			{
-				name:     "unknown_type",
-				src:      []any{1, 2, 3},
-				dataType: parquet.Type(-1),
+				name:      "unknown_type",
+				src:       []any{1, 2, 3},
+				dataType:  parquet.Type(-1),
+				expectErr: true,
+			},
+			{
+				name:      "unknown_type_empty_src",
+				src:       []any{},
+				dataType:  parquet.Type(-1),
+				expectErr: true,
+			},
+			{
+				name:      "unknown_type_nil_src",
+				src:       nil,
+				dataType:  parquet.Type(-1),
+				expectErr: true,
 			},
 		}
 
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
 				result, err := WritePlain(tc.src, tc.dataType)
-				if !tc.expectErr {
-					require.NoError(t, err)
-				}
-
-				if tc.name == "empty_data" {
-					require.Equal(t, 0, len(result))
+				if tc.expectErr {
+					require.Error(t, err)
 					return
 				}
+				require.NoError(t, err)
 
-				if tc.name == "unknown_type" {
+				if tc.name == "empty_data" {
 					require.Equal(t, 0, len(result))
 					return
 				}


### PR DESCRIPTION
## Summary
- Changed `WritePlain` to return an error for unrecognized parquet types instead of silently returning empty bytes
- Updated existing test to expect the error
- Prevents silent data loss when writing unknown types

## Test plan
- [x] `make all` passes
- [x] Existing `unknown_type` test updated to verify error is returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)