### PR TITLE
fix: return error for unsupported types in WriteDelta

### DIFF
--- a/encoding/encodingwrite.go
+++ b/encoding/encodingwrite.go
@@ -297,20 +297,20 @@ func WriteBitPacked(vals []any, bitWidth int64, ifHeader bool) []byte {
 	return res
 }
 
-func WriteDelta(nums []any) []byte {
+func WriteDelta(nums []any) ([]byte, error) {
 	ln := len(nums)
 	if ln <= 0 {
 		// If empty, we default to treating it as INT32 for the sake of writing an empty header.
 		// The type doesn't matter much for an empty block as long as the header is valid.
-		return WriteDeltaINT32(nums)
+		return WriteDeltaINT32(nums), nil
 	}
 
 	if _, ok := nums[0].(int32); ok {
-		return WriteDeltaINT32(nums)
+		return WriteDeltaINT32(nums), nil
 	} else if _, ok := nums[0].(int64); ok {
-		return WriteDeltaINT64(nums)
+		return WriteDeltaINT64(nums), nil
 	} else {
-		return []byte{}
+		return nil, fmt.Errorf("WriteDelta: unsupported type %T, expected int32 or int64", nums[0])
 	}
 }
 

--- a/encoding/encodingwrite_test.go
+++ b/encoding/encodingwrite_test.go
@@ -197,11 +197,12 @@ func TestWriteDelta(t *testing.T) {
 
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
-				result := WriteDelta(tc.src)
+				result, err := WriteDelta(tc.src)
 				if tc.name == "unsupported_type" {
-					require.Len(t, result, 0)
+					require.Error(t, err)
 					return
 				}
+				require.NoError(t, err)
 				if tc.name == "empty_input" {
 					require.Equal(t, []byte{128, 1, 4, 0, 0}, result)
 					return

--- a/layout/page.go
+++ b/layout/page.go
@@ -338,7 +338,7 @@ func (page *Page) EncodingValues(valuesBuf []any) ([]byte, error) {
 		if *page.Schema.Type != parquet.Type_INT32 && *page.Schema.Type != parquet.Type_INT64 {
 			return nil, fmt.Errorf("DELTA_BINARY_PACKED encoding is only supported for INT32 and INT64, not %v", *page.Schema.Type)
 		}
-		return encoding.WriteDelta(valuesBuf), nil
+		return encoding.WriteDelta(valuesBuf)
 	case parquet.Encoding_DELTA_BYTE_ARRAY:
 		// DELTA_BYTE_ARRAY: BYTE_ARRAY only
 		if *page.Schema.Type != parquet.Type_BYTE_ARRAY {


### PR DESCRIPTION
## Summary
- Changed `WriteDelta` signature from `[]byte` to `([]byte, error)` to report unsupported types
- Returns descriptive error for non-int32/int64 types instead of silently returning empty bytes
- Updated caller in `layout/page.go` and tests

## Test plan
- [x] `make all` passes
- [x] Existing `unsupported_type` test updated to verify error is returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)