### PR TITLE
fix: return error for unsupported Arrow types in ArrowColToParquetCol

### DIFF
--- a/common/arrow.go
+++ b/common/arrow.go
@@ -51,7 +51,7 @@ func arrowArrayToParquetList[arrowValueT any](field arrow.Field, col arrow.Array
 // If `col` contains Null value but `field` is not marked as Nullable this
 // results in an error.
 func ArrowColToParquetCol(field arrow.Field, col arrow.Array) ([]any, error) {
-	recs := make([]any, col.Len())
+	var recs []any
 	var err error
 	switch field.Type.(type) {
 	case *arrow.Int8Type:
@@ -88,6 +88,8 @@ func ArrowColToParquetCol(field arrow.Field, col arrow.Array) ([]any, error) {
 		recs, err = arrowArrayToParquetList(field, col, func(v arrow.Time32) any { return int32(v) })
 	case *arrow.TimestampType:
 		recs, err = arrowArrayToParquetList(field, col, func(v arrow.Timestamp) any { return int64(v) })
+	default:
+		return nil, fmt.Errorf("unsupported Arrow type: %v", field.Type)
 	}
 	return recs, err
 }

--- a/common/arrow_test.go
+++ b/common/arrow_test.go
@@ -174,6 +174,16 @@ func TestArrowColToParquetCol(t *testing.T) {
 			col:    buildArray(mem, []int32{1, 2, 3}, []bool{true, false, true}, array.NewInt32Builder),
 			errMsg: "field with name 'test' is marked non-nullable but its column array contains Null value at index 1",
 		},
+		"unsupported_type_null": {
+			field:  arrow.Field{Name: "test", Type: arrow.Null, Nullable: true},
+			col:    array.NewNull(3),
+			errMsg: "unsupported Arrow type: null",
+		},
+		"unsupported_type_float16": {
+			field:  arrow.Field{Name: "test", Type: &arrow.Float16Type{}, Nullable: true},
+			col:    array.NewNull(1),
+			errMsg: "unsupported Arrow type: float16",
+		},
 	}
 
 	for name, tc := range testCases {


### PR DESCRIPTION
## Summary
- Added `default` case to switch in `ArrowColToParquetCol` that returns a descriptive error
- Removed wasteful pre-allocation of `recs` slice (fixed linter `ineffassign` warning)
- Prevents silent nil-value return for unsupported Arrow types (Float16, LargeString, Duration, etc.)

## Test plan
- [x] `make all` passes (including linter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)