### PR TITLE
fix: use checked type assertion in CSVWriter.WriteString

### DIFF
--- a/writer/csv.go
+++ b/writer/csv.go
@@ -45,7 +45,10 @@ func NewCSVWriter(md []string, pfile source.ParquetFileWriter, opts ...WriterOpt
 // WriteString writes string values to parquet file.
 func (w *CSVWriter) WriteString(recsi any) error {
 	var err error
-	recs := recsi.([]*string)
+	recs, ok := recsi.([]*string)
+	if !ok {
+		return fmt.Errorf("WriteString: expected []*string, got %T", recsi)
+	}
 	lr := len(recs)
 	rec := make([]any, lr)
 	for i := range lr {

--- a/writer/csv_test.go
+++ b/writer/csv_test.go
@@ -103,4 +103,35 @@ func TestCSVWriter(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("write_string_wrong_type", func(t *testing.T) {
+		testCases := map[string]struct {
+			data   any
+			errMsg string
+		}{
+			"string_slice":  {[]string{"name", "123"}, "WriteString: expected []*string, got []string"},
+			"int_slice":     {[]int{1, 2}, "WriteString: expected []*string, got []int"},
+			"nil":           {nil, "WriteString: expected []*string, got <nil>"},
+			"single_string": {"name", "WriteString: expected []*string, got string"},
+			"any_slice":     {[]any{"name", "123"}, "WriteString: expected []*string, got []interface {}"},
+		}
+		schema := []string{
+			"Name=Name, Type=BYTE_ARRAY, ConvertedType=UTF8, Encoding=PLAIN",
+			"Name=id, Type=INT32",
+		}
+		var buf bytes.Buffer
+		bw := bufio.NewWriter(&buf)
+		cw, err := NewCSVWriterFromWriter(schema, bw)
+		require.NoError(t, err)
+
+		for name, tc := range testCases {
+			t.Run(name, func(t *testing.T) {
+				require.NotPanics(t, func() {
+					err := cw.WriteString(tc.data)
+					require.Error(t, err)
+					require.Equal(t, tc.errMsg, err.Error())
+				})
+			})
+		}
+	})
 }


### PR DESCRIPTION
## Summary
- Changed unchecked type assertion `recsi.([]*string)` to comma-ok pattern with descriptive error
- Prevents runtime panic when caller passes wrong type to `WriteString`

## Test plan
- [x] `make all` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)