### PR TITLE
fix: correct typo in ConvertToThriftReader comment

### DIFF
--- a/source/source.go
+++ b/source/source.go
@@ -22,7 +22,7 @@ type ParquetFileWriter interface {
 
 const bufferSize = 4096
 
-// Convert a file reater to Thrift reader
+// ConvertToThriftReader converts a file reader to a Thrift buffered transport.
 func ConvertToThriftReader(file ParquetFileReader, offset int64) *thrift.TBufferedTransport {
 	if _, err := file.Seek(offset, 0); err != nil {
 		return nil


### PR DESCRIPTION
## Summary
- Fixed typo: "reater" → "reader" in `source.go` comment
- Improved comment to proper GoDoc format

## Test plan
- [x] `make all` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)