### PR TITLE
fix: handle error and close CSV file in example

### DIFF
--- a/example/csv_to_parquet/csv_to_parquet.go
+++ b/example/csv_to_parquet/csv_to_parquet.go
@@ -39,7 +39,12 @@ func main() {
 		return
 	}
 
-	csvFile, _ := os.Open("shoes.csv")
+	csvFile, err := os.Open("shoes.csv")
+	if err != nil {
+		log.Println("Can't open CSV file", err)
+		return
+	}
+	defer csvFile.Close()
 	reader := csv.NewReader(bufio.NewReader(csvFile))
 
 	for {


### PR DESCRIPTION
## Summary
- Added error handling for `os.Open("shoes.csv")` 
- Added `defer csvFile.Close()` to ensure the file is properly closed
- Fixes bad pattern for users to follow in example code

## Test plan
- [x] `make all` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)