### PR TITLE
perf: preserve MaxDefinitionLevel/MaxRepetitionLevel in NewTableFromTable

### DIFF
--- a/layout/table.go
+++ b/layout/table.go
@@ -12,8 +12,8 @@ func NewTableFromTable(src *Table) *Table {
 	table := new(Table)
 	table.Schema = src.Schema
 	table.Path = append(table.Path, src.Path...)
-	table.MaxDefinitionLevel = 0
-	table.MaxRepetitionLevel = 0
+	table.MaxDefinitionLevel = src.MaxDefinitionLevel
+	table.MaxRepetitionLevel = src.MaxRepetitionLevel
 	table.Info = src.Info
 	return table
 }

--- a/layout/table_test.go
+++ b/layout/table_test.go
@@ -57,8 +57,8 @@ func TestNewTableFromTable(t *testing.T) {
 	require.NotNil(t, result)
 	require.Equal(t, src.Schema, result.Schema)
 	require.Len(t, result.Path, len(src.Path))
-	require.Equal(t, int32(0), result.MaxDefinitionLevel)
-	require.Equal(t, int32(0), result.MaxRepetitionLevel)
+	require.Equal(t, src.MaxDefinitionLevel, result.MaxDefinitionLevel)
+	require.Equal(t, src.MaxRepetitionLevel, result.MaxRepetitionLevel)
 }
 
 func TestTable_Merge(t *testing.T) {


### PR DESCRIPTION
## Summary
- NewTableFromTable previously reset MaxDefinitionLevel and MaxRepetitionLevel to 0
- Now copies the values from the source table, avoiding unnecessary recomputation in Merge
- Called frequently in the hot path of ReadRowsWithError

## Test plan
- [x] make all passes
- [x] All existing round-trip reader/writer tests pass

Generated with [Claude Code](https://claude.com/claude-code)