### PR TITLE
feat: add GeospatialConfig injection point to ConvertToJSONFriendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ v3 removes all global mutable state in favor of per-instance functional options.
 | `layout.SetMaxPageSize()` | `writer.WithPageSize()` per writer instance |
 | `source/http.SetDefaultClient()` | `http.NewHttpReaderWithClient()` per reader instance |
 | `source/mem.SetInMemFileFs()` | `mem.NewMemFileWriterWithFs()` per writer instance |
-| `types.SetGeo*()` global setters | `types.NewGeospatialConfig()` with functional options |
+| `types.SetGeo*()` global setters | `types.NewGeospatialConfig()` with functional options; pass to `marshal.ConvertToJSONFriendly` via `marshal.WithGeospatialConfig(cfg)` |
 
 #### Constructor Signature Changes
 

--- a/example/geospatial/main.go
+++ b/example/geospatial/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hangxie/parquet-go/v3/parquet"
 	"github.com/hangxie/parquet-go/v3/reader"
 	"github.com/hangxie/parquet-go/v3/source/local"
+	"github.com/hangxie/parquet-go/v3/types"
 	"github.com/hangxie/parquet-go/v3/writer"
 )
 
@@ -27,7 +28,7 @@ type Row struct {
 func main() {
 	// Geospatial JSON rendering is configured per-instance via GeospatialConfig.
 	// The default config uses Hex mode for GEOMETRY and GeoJSON for GEOGRAPHY.
-	// Custom configs can be created with NewGeospatialConfig(opts...).
+	// Custom configs can be passed to ConvertToJSONFriendly via marshal.WithGeospatialConfig(...).
 
 	// Write a few rows
 	fw, err := local.NewLocalFileWriter("/tmp/geospatial.parquet")
@@ -74,11 +75,25 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	// Default config: Hex for GEOMETRY, GeoJSON for GEOGRAPHY
 	out, err := marshal.ConvertToJSONFriendly(data, pr.SchemaHandler)
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Printf("%v\n", out)
+	fmt.Printf("Default config:\n%v\n", out)
+
+	// Custom config: GeoJSON for both GEOMETRY and GEOGRAPHY
+	geoCfg := types.NewGeospatialConfig(
+		types.WithGeometryJSONMode(types.GeospatialModeGeoJSON),
+		types.WithGeographyJSONMode(types.GeospatialModeGeoJSON),
+	)
+	out2, err := marshal.ConvertToJSONFriendly(data, pr.SchemaHandler,
+		marshal.WithGeospatialConfig(geoCfg),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("\nGeoJSON config:\n%v\n", out2)
 
 	// Display geospatial statistics for both geometry columns
 	fmt.Println("\nGeospatial Statistics:")

--- a/geoparquet.md
+++ b/geoparquet.md
@@ -70,8 +70,13 @@ cfg := types.NewGeospatialConfig(
     }),
 )
 
-// Then pass cfg to ConvertGeometryLogicalValue / ConvertGeographyLogicalValue
-result := types.ConvertGeographyLogicalValue(wkbBytes, geogType, cfg)
+// Pass cfg to ConvertToJSONFriendly to control geospatial rendering
+out, err := marshal.ConvertToJSONFriendly(data, schemaHandler,
+    marshal.WithGeospatialConfig(cfg),
+)
+
+// Or convert a single value using its schema element directly
+result := types.ConvertToJSONType(wkbBytes, schemaElement, cfg)
 ```
 
 The default config (`types.DefaultGeospatialConfig()`) uses Hex mode for GEOMETRY, GeoJSON mode for GEOGRAPHY, Feature wrapping enabled, and 6-decimal coordinate precision.

--- a/marshal/unmarshal.go
+++ b/marshal/unmarshal.go
@@ -556,10 +556,20 @@ type SliceRecord struct {
 	Index  int
 }
 
-// conversionContext holds cached data for performance optimization
-type conversionContext struct {
-	schemaCache sync.Map // map[string]*parquet.SchemaElement
-	fieldCache  sync.Map // map[reflect.Type]map[string]fieldInfo
+// jsonConverter holds configuration and caches for JSON conversion operations
+type jsonConverter struct {
+	schemaCache      sync.Map                // map[string]*parquet.SchemaElement
+	fieldCache       sync.Map                // map[reflect.Type]map[string]fieldInfo
+	geospatialConfig *types.GeospatialConfig // nil means use default
+}
+
+// JSONConvertOption configures ConvertToJSONFriendly behavior.
+type JSONConvertOption func(*jsonConverter)
+
+// WithGeospatialConfig sets a custom GeospatialConfig for geospatial type rendering.
+// If not provided or nil, the default config (Hex for GEOMETRY, GeoJSON for GEOGRAPHY) is used.
+func WithGeospatialConfig(cfg *types.GeospatialConfig) JSONConvertOption {
+	return func(converter *jsonConverter) { converter.geospatialConfig = cfg }
 }
 
 type fieldInfo struct {
@@ -1115,10 +1125,14 @@ func setVariantValue(root reflect.Value, variantPath, prefixPath string, _ *sche
 	return fmt.Errorf("could not set variant value at path end")
 }
 
-// ConvertToJSONFriendly converts parquet data to JSON-friendly format by applying logical type conversions
-func ConvertToJSONFriendly(data any, schemaHandler *schema.SchemaHandler) (any, error) {
-	ctx := &conversionContext{}
-	return convertValueToJSONFriendlyWithContext(reflect.ValueOf(data), schemaHandler, "", ctx)
+// ConvertToJSONFriendly converts parquet data to JSON-friendly format by applying logical type conversions.
+// Optional JSONConvertOption values can be passed to customize behavior (e.g., WithGeospatialConfig).
+func ConvertToJSONFriendly(data any, schemaHandler *schema.SchemaHandler, opts ...JSONConvertOption) (any, error) {
+	converter := &jsonConverter{}
+	for _, opt := range opts {
+		opt(converter)
+	}
+	return convertValueToJSONFriendlyWithContext(reflect.ValueOf(data), schemaHandler, "", converter)
 }
 
 // getFieldNameFromTag extracts the name from JSON tag since the struct from parquet reading uses JSON tags
@@ -1137,7 +1151,7 @@ func getFieldNameFromTag(field reflect.StructField) string {
 }
 
 // convertValueToJSONFriendlyWithContext recursively converts a value to JSON-friendly format with caching context
-func convertValueToJSONFriendlyWithContext(val reflect.Value, schemaHandler *schema.SchemaHandler, pathPrefix string, ctx *conversionContext) (any, error) {
+func convertValueToJSONFriendlyWithContext(val reflect.Value, schemaHandler *schema.SchemaHandler, pathPrefix string, converter *jsonConverter) (any, error) {
 	if !val.IsValid() {
 		return nil, nil
 	}
@@ -1147,30 +1161,30 @@ func convertValueToJSONFriendlyWithContext(val reflect.Value, schemaHandler *sch
 		if val.IsNil() {
 			return nil, nil
 		}
-		return convertValueToJSONFriendlyWithContext(val.Elem(), schemaHandler, pathPrefix, ctx)
+		return convertValueToJSONFriendlyWithContext(val.Elem(), schemaHandler, pathPrefix, converter)
 
 	case reflect.Pointer:
 		if val.IsNil() {
 			return nil, nil
 		}
-		return convertValueToJSONFriendlyWithContext(val.Elem(), schemaHandler, pathPrefix, ctx)
+		return convertValueToJSONFriendlyWithContext(val.Elem(), schemaHandler, pathPrefix, converter)
 
 	case reflect.Slice:
-		return convertSliceToJSONFriendly(val, schemaHandler, pathPrefix, ctx)
+		return convertSliceToJSONFriendly(val, schemaHandler, pathPrefix, converter)
 
 	case reflect.Map:
-		return convertMapToJSONFriendly(val, schemaHandler, pathPrefix, ctx)
+		return convertMapToJSONFriendly(val, schemaHandler, pathPrefix, converter)
 
 	case reflect.Struct:
-		return convertStructToJSONFriendly(val, schemaHandler, pathPrefix, ctx)
+		return convertStructToJSONFriendly(val, schemaHandler, pathPrefix, converter)
 
 	default:
-		return convertPrimitiveToJSONFriendly(val, schemaHandler, pathPrefix, ctx)
+		return convertPrimitiveToJSONFriendly(val, schemaHandler, pathPrefix, converter)
 	}
 }
 
 // convertSliceToJSONFriendly optimized slice conversion
-func convertSliceToJSONFriendly(val reflect.Value, schemaHandler *schema.SchemaHandler, pathPrefix string, ctx *conversionContext) (any, error) {
+func convertSliceToJSONFriendly(val reflect.Value, schemaHandler *schema.SchemaHandler, pathPrefix string, converter *jsonConverter) (any, error) {
 	result := make([]any, val.Len())
 	var elementPath string
 	if pathPrefix != "" {
@@ -1184,7 +1198,7 @@ func convertSliceToJSONFriendly(val reflect.Value, schemaHandler *schema.SchemaH
 	}
 
 	for i := range val.Len() {
-		converted, err := convertValueToJSONFriendlyWithContext(val.Index(i), schemaHandler, elementPath, ctx)
+		converted, err := convertValueToJSONFriendlyWithContext(val.Index(i), schemaHandler, elementPath, converter)
 		if err != nil {
 			return nil, err
 		}
@@ -1194,7 +1208,7 @@ func convertSliceToJSONFriendly(val reflect.Value, schemaHandler *schema.SchemaH
 }
 
 // convertMapToJSONFriendly optimized map conversion
-func convertMapToJSONFriendly(val reflect.Value, schemaHandler *schema.SchemaHandler, pathPrefix string, ctx *conversionContext) (any, error) {
+func convertMapToJSONFriendly(val reflect.Value, schemaHandler *schema.SchemaHandler, pathPrefix string, converter *jsonConverter) (any, error) {
 	result := make(map[string]any)
 	var keyPath, valuePath string
 
@@ -1217,13 +1231,13 @@ func convertMapToJSONFriendly(val reflect.Value, schemaHandler *schema.SchemaHan
 	}
 
 	for _, key := range val.MapKeys() {
-		converted, err := convertValueToJSONFriendlyWithContext(key, schemaHandler, keyPath, ctx)
+		converted, err := convertValueToJSONFriendlyWithContext(key, schemaHandler, keyPath, converter)
 		if err != nil {
 			return nil, err
 		}
 		keyStr := fmt.Sprint(converted)
 
-		converted, err = convertValueToJSONFriendlyWithContext(val.MapIndex(key), schemaHandler, valuePath, ctx)
+		converted, err = convertValueToJSONFriendlyWithContext(val.MapIndex(key), schemaHandler, valuePath, converter)
 		if err != nil {
 			return nil, err
 		}
@@ -1233,7 +1247,7 @@ func convertMapToJSONFriendly(val reflect.Value, schemaHandler *schema.SchemaHan
 }
 
 // convertStructToJSONFriendly optimized struct conversion with field caching
-func convertStructToJSONFriendly(val reflect.Value, schemaHandler *schema.SchemaHandler, pathPrefix string, ctx *conversionContext) (any, error) {
+func convertStructToJSONFriendly(val reflect.Value, schemaHandler *schema.SchemaHandler, pathPrefix string, converter *jsonConverter) (any, error) {
 	valType := val.Type()
 
 	// Special handling for types.Variant: decode the variant binary data
@@ -1256,13 +1270,13 @@ func convertStructToJSONFriendly(val reflect.Value, schemaHandler *schema.Schema
 		if pathPrefix != "" {
 			fieldPath = pathPrefix + common.ParGoPathDelimiter + fieldPath
 		}
-		return convertValueToJSONFriendlyWithContext(val.Field(0), schemaHandler, fieldPath, ctx)
+		return convertValueToJSONFriendlyWithContext(val.Field(0), schemaHandler, fieldPath, converter)
 	}
 
 	result := make(map[string]any)
 	var fieldMap map[string]fieldInfo
 
-	fieldMapInterface, exists := ctx.fieldCache.Load(valType)
+	fieldMapInterface, exists := converter.fieldCache.Load(valType)
 	if !exists {
 		fieldMap = make(map[string]fieldInfo)
 		for i := range val.NumField() {
@@ -1273,7 +1287,7 @@ func convertStructToJSONFriendly(val reflect.Value, schemaHandler *schema.Schema
 				}
 			}
 		}
-		ctx.fieldCache.Store(valType, fieldMap)
+		converter.fieldCache.Store(valType, fieldMap)
 	} else {
 		fieldMap = fieldMapInterface.(map[string]fieldInfo)
 	}
@@ -1296,7 +1310,7 @@ func convertStructToJSONFriendly(val reflect.Value, schemaHandler *schema.Schema
 			fieldPath = pathPrefix + common.ParGoPathDelimiter + fieldPath
 		}
 
-		converted, err := convertValueToJSONFriendlyWithContext(fieldVal, schemaHandler, fieldPath, ctx)
+		converted, err := convertValueToJSONFriendlyWithContext(fieldVal, schemaHandler, fieldPath, converter)
 		if err != nil {
 			return nil, err
 		}
@@ -1306,7 +1320,7 @@ func convertStructToJSONFriendly(val reflect.Value, schemaHandler *schema.Schema
 }
 
 // convertPrimitiveToJSONFriendly optimized primitive conversion with schema caching
-func convertPrimitiveToJSONFriendly(val reflect.Value, schemaHandler *schema.SchemaHandler, pathPrefix string, ctx *conversionContext) (any, error) {
+func convertPrimitiveToJSONFriendly(val reflect.Value, schemaHandler *schema.SchemaHandler, pathPrefix string, converter *jsonConverter) (any, error) {
 	if pathPrefix == "" {
 		return val.Interface(), nil
 	}
@@ -1319,14 +1333,14 @@ func convertPrimitiveToJSONFriendly(val reflect.Value, schemaHandler *schema.Sch
 
 	var schemaElement *parquet.SchemaElement
 
-	schemaElementInterface, cached := ctx.schemaCache.Load(expectedSchemaPath)
+	schemaElementInterface, cached := converter.schemaCache.Load(expectedSchemaPath)
 	if !cached {
 		schemaIndex, exists := schemaHandler.MapIndex[expectedSchemaPath]
 		if !exists || int(schemaIndex) >= len(schemaHandler.SchemaElements) {
 			return val.Interface(), nil
 		}
 		schemaElement = schemaHandler.SchemaElements[schemaIndex]
-		ctx.schemaCache.Store(expectedSchemaPath, schemaElement)
+		converter.schemaCache.Store(expectedSchemaPath, schemaElement)
 	} else {
 		schemaElement = schemaElementInterface.(*parquet.SchemaElement)
 	}
@@ -1335,10 +1349,11 @@ func convertPrimitiveToJSONFriendly(val reflect.Value, schemaHandler *schema.Sch
 		return val.Interface(), nil
 	}
 
-	pT, cT, lT := schemaElement.Type, schemaElement.ConvertedType, schemaElement.LogicalType
-	precision, scale := int(schemaElement.GetPrecision()), int(schemaElement.GetScale())
-	converted := types.ParquetTypeToJSONTypeWithLogical(val.Interface(), pT, cT, lT, precision, scale)
-
+	var typeOpts []types.JSONTypeOption
+	if converter.geospatialConfig != nil {
+		typeOpts = append(typeOpts, types.WithGeospatialConfig(converter.geospatialConfig))
+	}
+	converted := types.ConvertToJSONType(val.Interface(), schemaElement, typeOpts...)
 	if converted != val.Interface() {
 		return converted, nil
 	}

--- a/marshal/unmarshal_test.go
+++ b/marshal/unmarshal_test.go
@@ -495,7 +495,7 @@ func TestConvertValueToJSONFriendlyWithContext(t *testing.T) {
 	schemaHandler, err := schema.NewSchemaHandlerFromStruct(new(TestStruct))
 	require.NoError(t, err)
 
-	ctx := &conversionContext{}
+	ctx := &jsonConverter{}
 
 	tests := []struct {
 		name          string
@@ -664,7 +664,7 @@ func TestConvertValueToJSONFriendlyWithContext_NilCases(t *testing.T) {
 	schemaHandler, err := schema.NewSchemaHandlerFromStruct(new(struct{}))
 	require.NoError(t, err)
 
-	ctx := &conversionContext{}
+	ctx := &jsonConverter{}
 
 	tests := []struct {
 		name        string
@@ -982,8 +982,8 @@ func createOldListTable(path []string, values []any, repetitionLevels, definitio
 }
 
 // createConversionContext creates a standard conversion context for JSON conversion tests
-func createConversionContext() *conversionContext {
-	return &conversionContext{
+func createConversionContext() *jsonConverter {
+	return &jsonConverter{
 		fieldCache: sync.Map{},
 	}
 }
@@ -2474,4 +2474,62 @@ func TestShreddedVariantReconstructor_reconstructValue_Coverage(t *testing.T) {
 		val2, _ := types.ConvertVariantValue(v2)
 		require.Equal(t, int32(222), val2)
 	})
+}
+
+func TestConvertToJSONFriendly_WithGeospatialConfig(t *testing.T) {
+	type GeoRow struct {
+		Geom string `parquet:"name=geom, type=BYTE_ARRAY, logicaltype=GEOMETRY"`
+	}
+	sh, err := schema.NewSchemaHandlerFromStruct(new(GeoRow))
+	require.NoError(t, err)
+
+	// WKB Point(100, 50) little-endian
+	wkbPoint := string([]byte{0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x59, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x49, 0x40})
+
+	tests := []struct {
+		name     string
+		opts     []JSONConvertOption
+		expected map[string]any
+	}{
+		{
+			name: "default_uses_hex_mode",
+			opts: nil,
+			expected: map[string]any{
+				"wkb_hex": "010100000000000000000059400000000000004940",
+				"crs":     "OGC:CRS84",
+			},
+		},
+		{
+			name: "custom_geojson_mode",
+			opts: []JSONConvertOption{WithGeospatialConfig(types.NewGeospatialConfig(
+				types.WithGeometryJSONMode(types.GeospatialModeGeoJSON),
+			))},
+			expected: map[string]any{
+				"type":       "Feature",
+				"geometry":   map[string]any{"type": "Point", "coordinates": []float64{100, 50}},
+				"properties": map[string]any{"crs": "OGC:CRS84"},
+			},
+		},
+		{
+			name: "custom_base64_mode",
+			opts: []JSONConvertOption{WithGeospatialConfig(types.NewGeospatialConfig(
+				types.WithGeometryJSONMode(types.GeospatialModeBase64),
+			))},
+			expected: map[string]any{
+				"wkb_b64": "AQEAAAAAAAAAAABZQAAAAAAAAElA",
+				"crs":     "OGC:CRS84",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := GeoRow{Geom: wkbPoint}
+			result, err := ConvertToJSONFriendly(input, sh, tt.opts...)
+			require.NoError(t, err)
+			resultMap, ok := result.(map[string]any)
+			require.True(t, ok)
+			require.Equal(t, tt.expected, resultMap["Geom"])
+		})
+	}
 }

--- a/reader/reader_test.go
+++ b/reader/reader_test.go
@@ -14,12 +14,14 @@ import (
 
 	"github.com/hangxie/parquet-go/v3/bloomfilter"
 	"github.com/hangxie/parquet-go/v3/common"
+	"github.com/hangxie/parquet-go/v3/marshal"
 	"github.com/hangxie/parquet-go/v3/parquet"
 	"github.com/hangxie/parquet-go/v3/schema"
 	"github.com/hangxie/parquet-go/v3/source"
 	"github.com/hangxie/parquet-go/v3/source/buffer"
 	phttp "github.com/hangxie/parquet-go/v3/source/http"
 	"github.com/hangxie/parquet-go/v3/source/writerfile"
+	"github.com/hangxie/parquet-go/v3/types"
 	"github.com/hangxie/parquet-go/v3/writer"
 )
 
@@ -1847,4 +1849,83 @@ func TestBloomFilterInterop(t *testing.T) {
 		}
 		require.True(t, foundLength)
 	})
+}
+
+func TestGeospatialConfigRoundTrip(t *testing.T) {
+	type GeoRow struct {
+		Geom string `parquet:"name=geom, type=BYTE_ARRAY, logicaltype=GEOMETRY"`
+	}
+
+	// WKB Point(1, 2) little-endian
+	wkbPoint := string([]byte{
+		0x01, 0x01, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xf0, 0x3f, // 1.0
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40, // 2.0
+	})
+
+	// Write
+	var buf bytes.Buffer
+	fw := writerfile.NewWriterFile(&buf)
+	pw, err := writer.NewParquetWriter(fw, new(GeoRow), writer.WithNP(1))
+	require.NoError(t, err)
+	require.NoError(t, pw.Write(GeoRow{Geom: wkbPoint}))
+	require.NoError(t, pw.WriteStop())
+	require.NoError(t, fw.Close())
+
+	// Read
+	fr := buffer.NewBufferReaderFromBytesNoAlloc(buf.Bytes())
+	pr, err := NewParquetReader(fr, nil, WithNP(1))
+	require.NoError(t, err)
+	data, err := pr.ReadByNumber(1)
+	require.NoError(t, err)
+	require.NoError(t, pr.ReadStopWithError())
+
+	tests := []struct {
+		name     string
+		cfg      *types.GeospatialConfig
+		expected map[string]any
+	}{
+		{
+			name: "default_hex",
+			cfg:  nil,
+			expected: map[string]any{
+				"wkb_hex": "0101000000000000000000f03f0000000000000040",
+				"crs":     "OGC:CRS84",
+			},
+		},
+		{
+			name: "geojson",
+			cfg:  types.NewGeospatialConfig(types.WithGeometryJSONMode(types.GeospatialModeGeoJSON)),
+			expected: map[string]any{
+				"type":       "Feature",
+				"geometry":   map[string]any{"type": "Point", "coordinates": []float64{1, 2}},
+				"properties": map[string]any{"crs": "OGC:CRS84"},
+			},
+		},
+		{
+			name: "base64",
+			cfg:  types.NewGeospatialConfig(types.WithGeometryJSONMode(types.GeospatialModeBase64)),
+			expected: map[string]any{
+				"wkb_b64": "AQEAAAAAAAAAAADwPwAAAAAAAABA",
+				"crs":     "OGC:CRS84",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var opts []marshal.JSONConvertOption
+			if tt.cfg != nil {
+				opts = append(opts, marshal.WithGeospatialConfig(tt.cfg))
+			}
+			out, err := marshal.ConvertToJSONFriendly(data, pr.SchemaHandler, opts...)
+			require.NoError(t, err)
+			slice, ok := out.([]any)
+			require.True(t, ok)
+			require.Len(t, slice, 1)
+			row, ok := slice[0].(map[string]any)
+			require.True(t, ok)
+			require.Equal(t, tt.expected, row["geom"])
+		})
+	}
 }

--- a/types/types.go
+++ b/types/types.go
@@ -636,18 +636,96 @@ func getNumericValue[T numericType](val reflect.Value) (T, bool) {
 	return 0, false
 }
 
-// ParquetTypeToJSONType converts a parquet physical value back to its logical JSON representation
-func ParquetTypeToJSONType(val any, pT *parquet.Type, cT *parquet.ConvertedType, precision, scale int) any {
-	if val == nil {
-		return nil
+// JSONTypeConfig holds configuration for ConvertToJSONType.
+type JSONTypeConfig struct {
+	Geospatial *GeospatialConfig
+}
+
+// JSONTypeOption configures ConvertToJSONType behavior.
+type JSONTypeOption func(*JSONTypeConfig)
+
+// WithGeospatialConfig sets a custom GeospatialConfig for GEOMETRY/GEOGRAPHY rendering.
+func WithGeospatialConfig(cfg *GeospatialConfig) JSONTypeOption {
+	return func(c *JSONTypeConfig) { c.Geospatial = cfg }
+}
+
+// ConvertToJSONType converts a parquet value to its JSON-friendly representation using the
+// schema element's type information (physical, converted, logical).
+// Options (e.g., WithGeospatialConfig) control type-specific rendering; unset options use defaults.
+// This is the canonical conversion entry point; callers only need the SchemaElement.
+func ConvertToJSONType(val any, se *parquet.SchemaElement, opts ...JSONTypeOption) any {
+	if val == nil || se == nil {
+		return val
 	}
 
-	// Handle INT96 timestamp conversion (before checking ConvertedType)
+	var cfg JSONTypeConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	pT, cT, lT := se.Type, se.ConvertedType, se.LogicalType
+
+	// Handle INT96 timestamp conversion (before checking logical/converted types)
 	if pT != nil && *pT == parquet.Type_INT96 {
 		return convertINT96Value(val)
 	}
 
-	// If no converted type, check for binary types that need base64 encoding
+	// LogicalType takes precedence (newer standard)
+	if lT != nil {
+		return parquetTypeToJSONTypeWithLogical(val, pT, lT, cfg.Geospatial)
+	}
+
+	// Fall back to ConvertedType (legacy)
+	return parquetTypeToJSONTypeWithConverted(val, pT, cT, int(se.GetPrecision()), int(se.GetScale()))
+}
+
+// parquetTypeToJSONTypeWithLogical converts a value using its LogicalType.
+func parquetTypeToJSONTypeWithLogical(val any, pT *parquet.Type, lT *parquet.LogicalType, geoCfg *GeospatialConfig) any {
+	if lT.IsSetDECIMAL() {
+		decimal := lT.GetDECIMAL()
+		return ConvertDecimalValue(val, pT, int(decimal.GetPrecision()), int(decimal.GetScale()))
+	}
+	if lT.IsSetFLOAT16() {
+		return ConvertFloat16LogicalValue(val)
+	}
+	if lT.IsSetTIMESTAMP() {
+		return convertTimestampLogicalValue(val, lT.GetTIMESTAMP())
+	}
+	if lT.IsSetTIME() {
+		return ConvertTimeLogicalValue(val, lT.GetTIME())
+	}
+	if lT.IsSetDATE() {
+		return ConvertDateLogicalValue(val)
+	}
+	if lT.IsSetSTRING() {
+		return val
+	}
+	if lT.IsSetINTEGER() {
+		return ConvertIntegerLogicalValue(val, pT, lT.GetINTEGER())
+	}
+	if lT.IsSetUUID() {
+		return ConvertUUIDValue(val)
+	}
+	if lT.IsSetGEOMETRY() {
+		if geoCfg == nil {
+			geoCfg = defaultGeospatialConfig
+		}
+		return ConvertGeometryLogicalValue(val, lT.GetGEOMETRY(), geoCfg)
+	}
+	if lT.IsSetGEOGRAPHY() {
+		if geoCfg == nil {
+			geoCfg = defaultGeospatialConfig
+		}
+		return ConvertGeographyLogicalValue(val, lT.GetGEOGRAPHY(), geoCfg)
+	}
+	if lT.IsSetBSON() {
+		return ConvertBSONLogicalValue(val)
+	}
+	return val
+}
+
+// parquetTypeToJSONTypeWithConverted converts a value using its ConvertedType (legacy path).
+func parquetTypeToJSONTypeWithConverted(val any, pT *parquet.Type, cT *parquet.ConvertedType, precision, scale int) any {
 	if cT == nil {
 		if pT != nil && (*pT == parquet.Type_BYTE_ARRAY || *pT == parquet.Type_FIXED_LEN_BYTE_ARRAY) {
 			return convertBinaryValue(val)
@@ -657,190 +735,61 @@ func ParquetTypeToJSONType(val any, pT *parquet.Type, cT *parquet.ConvertedType,
 
 	switch *cT {
 	case parquet.ConvertedType_DECIMAL:
-		// Convert decimal to numeric value for JSON output
-		switch *pT {
-		case parquet.Type_INT32:
-			if v, ok := val.(int32); ok {
-				return decimalIntToFloat(int64(v), scale)
-			}
-		case parquet.Type_INT64:
-			if v, ok := val.(int64); ok {
-				return decimalIntToFloat(v, scale)
-			}
-		case parquet.Type_BYTE_ARRAY, parquet.Type_FIXED_LEN_BYTE_ARRAY:
-			if v, ok := val.(string); ok {
-				return decimalByteArrayToFloat([]byte(v), precision, scale)
-			}
-		}
+		return ConvertDecimalValue(val, pT, precision, scale)
+	case parquet.ConvertedType_UTF8, parquet.ConvertedType_DATE,
+		parquet.ConvertedType_INT_32, parquet.ConvertedType_INT_64:
 		return val
-
-	case parquet.ConvertedType_UTF8:
-		// UTF8 strings should remain as strings
-		return val
-
-	case parquet.ConvertedType_DATE:
-		// DATE is stored as int32 days since epoch, could convert to readable format
-		// For now, keeping as int32 for JSON compatibility
-		return val
-
 	case parquet.ConvertedType_TIME_MILLIS:
-		// TIME_MILLIS is stored as int32 milliseconds, convert to readable time format
 		if v, ok := val.(int32); ok {
 			return TIME_MILLISToTimeFormat(v)
 		}
 		return val
-
 	case parquet.ConvertedType_TIME_MICROS:
-		// TIME_MICROS is stored as int64 microseconds, convert to readable time format
 		if v, ok := val.(int64); ok {
 			return TIME_MICROSToTimeFormat(v)
 		}
 		return val
-
 	case parquet.ConvertedType_TIMESTAMP_MILLIS:
-		// TIMESTAMP_MILLIS is stored as int64 milliseconds since epoch
-		// Convert to ISO8601 format
 		return ConvertTimestampValue(val, parquet.ConvertedType_TIMESTAMP_MILLIS)
-
 	case parquet.ConvertedType_TIMESTAMP_MICROS:
-		// TIMESTAMP_MICROS is stored as int64 microseconds since epoch
-		// Convert to ISO8601 format
 		return ConvertTimestampValue(val, parquet.ConvertedType_TIMESTAMP_MICROS)
-
 	case parquet.ConvertedType_INT_8:
-		// Convert back to int8 representation for JSON
 		if v, ok := val.(int32); ok {
 			return int8(v)
 		}
 		return val
-
 	case parquet.ConvertedType_INT_16:
-		// Convert back to int16 representation for JSON
 		if v, ok := val.(int32); ok {
 			return int16(v)
 		}
 		return val
-
-	case parquet.ConvertedType_INT_32:
-		// Already int32
-		return val
-
-	case parquet.ConvertedType_INT_64:
-		// Already int64
-		return val
-
 	case parquet.ConvertedType_UINT_8:
-		// Convert back to uint8 representation for JSON
 		if v, ok := val.(int32); ok {
 			return uint8(v)
 		}
 		return val
-
 	case parquet.ConvertedType_UINT_16:
-		// Convert back to uint16 representation for JSON
 		if v, ok := val.(int32); ok {
 			return uint16(v)
 		}
 		return val
-
 	case parquet.ConvertedType_UINT_32:
-		// Convert back to uint32 representation for JSON
 		if v, ok := val.(int32); ok {
 			return uint32(v)
 		}
 		return val
-
 	case parquet.ConvertedType_UINT_64:
-		// Convert back to uint64 representation for JSON
 		if v, ok := val.(int64); ok {
 			return uint64(v)
 		}
 		return val
-
 	case parquet.ConvertedType_INTERVAL:
-		// Convert INTERVAL to Go duration string
 		return convertIntervalValue(val)
-
 	case parquet.ConvertedType_BSON:
-		// Convert BSON to base64 string for JSON compatibility
 		return ConvertBSONLogicalValue(val)
-
 	default:
-		// For other converted types, return as-is
 		return val
 	}
-}
-
-// ParquetTypeToJSONTypeWithLogical converts a parquet physical value back to its logical JSON representation
-// supporting both ConvertedType and LogicalType
-func ParquetTypeToJSONTypeWithLogical(val any, pT *parquet.Type, cT *parquet.ConvertedType, lT *parquet.LogicalType, precision, scale int) any {
-	if val == nil {
-		return nil
-	}
-
-	// Handle INT96 timestamp conversion (before checking logical types)
-	if pT != nil && *pT == parquet.Type_INT96 {
-		return convertINT96Value(val)
-	}
-
-	// Check for LogicalType first (newer standard)
-	if lT != nil {
-		if lT.IsSetDECIMAL() {
-			decimal := lT.GetDECIMAL()
-			actualPrecision := int(decimal.GetPrecision())
-			actualScale := int(decimal.GetScale())
-			return ConvertDecimalValue(val, pT, actualPrecision, actualScale)
-		}
-		// Newer logical types handling
-		if lT.IsSetFLOAT16() {
-			return ConvertFloat16LogicalValue(val)
-		}
-		if lT.IsSetTIMESTAMP() {
-			return convertTimestampLogicalValue(val, lT.GetTIMESTAMP())
-		}
-		if lT.IsSetTIME() {
-			return ConvertTimeLogicalValue(val, lT.GetTIME())
-		}
-		if lT.IsSetDATE() {
-			return ConvertDateLogicalValue(val)
-		}
-		if lT.IsSetSTRING() {
-			// STRING logical type should return the string value as-is
-			return val
-		}
-		if lT.IsSetINTEGER() {
-			return ConvertIntegerLogicalValue(val, pT, lT.GetINTEGER())
-		}
-		if lT.IsSetUUID() {
-			return ConvertUUIDValue(val)
-		}
-		if lT.IsSetGEOMETRY() {
-			return ConvertGeometryLogicalValue(val, lT.GetGEOMETRY(), defaultGeospatialConfig)
-		}
-		if lT.IsSetGEOGRAPHY() {
-			return ConvertGeographyLogicalValue(val, lT.GetGEOGRAPHY(), defaultGeospatialConfig)
-		}
-		if lT.IsSetBSON() {
-			return ConvertBSONLogicalValue(val)
-		}
-		// For other logical types, don't apply base64 encoding - return as-is
-		return val
-	}
-
-	// Fall back to ConvertedType (legacy)
-	if cT != nil && *cT == parquet.ConvertedType_DECIMAL {
-		return ConvertDecimalValue(val, pT, precision, scale)
-	}
-
-	// If no logical type and no converted type, check for binary types
-	if cT == nil {
-		if pT != nil && (*pT == parquet.Type_BYTE_ARRAY || *pT == parquet.Type_FIXED_LEN_BYTE_ARRAY) {
-			return convertBinaryValue(val)
-		}
-	}
-
-	// For other types, use the existing function
-	return ParquetTypeToJSONType(val, pT, cT, precision, scale)
 }
 
 // ConvertDecimalValue handles decimal conversion for both logical and converted types

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -1114,7 +1114,7 @@ func TestParquetTypeToGoReflectType_SafetyChecks(t *testing.T) {
 	}
 }
 
-func TestParquetTypeToJSONType(t *testing.T) {
+func TestConvertToJSONType_AllConvertedTypes(t *testing.T) {
 	tests := []struct {
 		name      string
 		value     any
@@ -1364,14 +1364,24 @@ func TestParquetTypeToJSONType(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := ParquetTypeToJSONType(tt.value, tt.pT, tt.cT, tt.precision, tt.scale)
-
+			se := parquet.NewSchemaElement()
+			se.Type = tt.pT
+			se.ConvertedType = tt.cT
+			if tt.precision != 0 {
+				p := int32(tt.precision)
+				se.Precision = &p
+			}
+			if tt.scale != 0 {
+				s := int32(tt.scale)
+				se.Scale = &s
+			}
+			result := ConvertToJSONType(tt.value, se)
 			require.Equal(t, tt.expected, result)
 		})
 	}
 }
 
-func TestParquetTypeToJSONTypeWithLogical(t *testing.T) {
+func TestConvertToJSONType_AllLogicalTypes(t *testing.T) {
 	tests := []struct {
 		name      string
 		value     any
@@ -1857,7 +1867,105 @@ func TestParquetTypeToJSONTypeWithLogical(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := ParquetTypeToJSONTypeWithLogical(tt.value, tt.pT, tt.cT, tt.lT, tt.precision, tt.scale)
+			se := parquet.NewSchemaElement()
+			se.Type = tt.pT
+			se.ConvertedType = tt.cT
+			se.LogicalType = tt.lT
+			if tt.precision != 0 {
+				p := int32(tt.precision)
+				se.Precision = &p
+			}
+			if tt.scale != 0 {
+				s := int32(tt.scale)
+				se.Scale = &s
+			}
+			result := ConvertToJSONType(tt.value, se)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestConvertToJSONType(t *testing.T) {
+	wkbPoint := []byte{0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x59, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x49, 0x40} // POINT(100 50)
+	geomLT := createGeometryLogicalType("OGC:CRS84")
+	geogLT := createGeographyLogicalType("OGC:CRS84", parquet.EdgeInterpolationAlgorithm_SPHERICAL)
+
+	makeSchemaElement := func(lT *parquet.LogicalType) *parquet.SchemaElement {
+		se := parquet.NewSchemaElement()
+		se.Type = parquet.TypePtr(parquet.Type_BYTE_ARRAY)
+		se.LogicalType = lT
+		return se
+	}
+
+	tests := []struct {
+		name     string
+		value    any
+		se       *parquet.SchemaElement
+		opts     []JSONTypeOption
+		expected any
+	}{
+		{
+			name:     "nil_schema_element_returns_val",
+			value:    wkbPoint,
+			se:       nil,
+			expected: wkbPoint,
+		},
+		{
+			name:  "geometry_default_uses_hex",
+			value: wkbPoint,
+			se:    makeSchemaElement(geomLT),
+			expected: map[string]any{
+				"wkb_hex": "010100000000000000000059400000000000004940",
+				"crs":     "OGC:CRS84",
+			},
+		},
+		{
+			name:  "geometry_geojson_mode",
+			value: wkbPoint,
+			se:    makeSchemaElement(geomLT),
+			opts:  []JSONTypeOption{WithGeospatialConfig(NewGeospatialConfig(WithGeometryJSONMode(GeospatialModeGeoJSON)))},
+			expected: map[string]any{
+				"type":       "Feature",
+				"geometry":   map[string]any{"type": "Point", "coordinates": []float64{100, 50}},
+				"properties": map[string]any{"crs": "OGC:CRS84"},
+			},
+		},
+		{
+			name:  "geometry_base64_mode",
+			value: wkbPoint,
+			se:    makeSchemaElement(geomLT),
+			opts:  []JSONTypeOption{WithGeospatialConfig(NewGeospatialConfig(WithGeometryJSONMode(GeospatialModeBase64)))},
+			expected: map[string]any{
+				"wkb_b64": "AQEAAAAAAAAAAABZQAAAAAAAAElA",
+				"crs":     "OGC:CRS84",
+			},
+		},
+		{
+			name:  "geography_default_uses_geojson",
+			value: wkbPoint,
+			se:    makeSchemaElement(geogLT),
+			expected: map[string]any{
+				"type":       "Feature",
+				"geometry":   map[string]any{"type": "Point", "coordinates": []float64{100, 50}},
+				"properties": map[string]any{"crs": "OGC:CRS84", "algorithm": "SPHERICAL"},
+			},
+		},
+		{
+			name:  "geography_hex_mode",
+			value: wkbPoint,
+			se:    makeSchemaElement(geogLT),
+			opts:  []JSONTypeOption{WithGeospatialConfig(NewGeospatialConfig(WithGeographyJSONMode(GeospatialModeHex)))},
+			expected: map[string]any{
+				"wkb_hex":   "010100000000000000000059400000000000004940",
+				"crs":       "OGC:CRS84",
+				"algorithm": "SPHERICAL",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ConvertToJSONType(tt.value, tt.se, tt.opts...)
 			require.Equal(t, tt.expected, result)
 		})
 	}
@@ -2601,8 +2709,8 @@ func TestConvertBSONLogicalValue(t *testing.T) {
 
 // Test JSONTypeToParquetType function comprehensively to improve its 30.8% coverage
 
-// Test ParquetTypeToJSONType comprehensively to improve its 52.0% coverage
-func TestParquetTypeToJSONType_Comprehensive(t *testing.T) {
+// Test parquetTypeToJSONTypeWithConverted comprehensively via ConvertToJSONType
+func TestConvertToJSONType_ConvertedTypes_Comprehensive(t *testing.T) {
 	tests := []struct {
 		name      string
 		value     any
@@ -2872,7 +2980,18 @@ func TestParquetTypeToJSONType_Comprehensive(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := ParquetTypeToJSONType(tt.value, tt.pT, tt.cT, tt.precision, tt.scale)
+			se := parquet.NewSchemaElement()
+			se.Type = tt.pT
+			se.ConvertedType = tt.cT
+			if tt.precision != 0 {
+				p := int32(tt.precision)
+				se.Precision = &p
+			}
+			if tt.scale != 0 {
+				s := int32(tt.scale)
+				se.Scale = &s
+			}
+			result := ConvertToJSONType(tt.value, se)
 			require.Equal(t, tt.expected, result)
 		})
 	}


### PR DESCRIPTION
Add marshal.WithGeospatialConfig option so downstream consumers can customize GEOMETRY/GEOGRAPHY JSON rendering without global state.

- Add *GeospatialConfig parameter to ParquetTypeToJSONTypeWithLogical (nil uses default config)
- Add ConvertOption type and WithGeospatialConfig to marshal package
- Thread config through conversionContext to primitive conversion
- Update documentation and example