### PR TITLE
bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ import (
 )
 
 type Student struct {
-    Name   string  `parquet:"name=name, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+    Name   string  `parquet:"name=name, type=BYTE_ARRAY, logicaltype=STRING, encoding=PLAIN_DICTIONARY"`
     Age    int32   `parquet:"name=age, type=INT32"`
     ID     int64   `parquet:"name=id, type=INT64"`
     Weight float32 `parquet:"name=weight, type=FLOAT"`
@@ -98,7 +98,7 @@ import (
 )
 
 type Student struct {
-    Name   string  `parquet:"name=name, type=BYTE_ARRAY, convertedtype=UTF8"`
+    Name   string  `parquet:"name=name, type=BYTE_ARRAY, logicaltype=STRING"`
     Age    int32   `parquet:"name=age, type=INT32"`
     ID     int64   `parquet:"name=id, type=INT64"`
     Weight float32 `parquet:"name=weight, type=FLOAT"`
@@ -272,7 +272,7 @@ Four methods to define schema:
 
 ```go
 type Student struct {
-    Name   string  `parquet:"name=name, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+    Name   string  `parquet:"name=name, type=BYTE_ARRAY, logicaltype=STRING, encoding=PLAIN_DICTIONARY"`
     Age    int32   `parquet:"name=age, type=INT32, encoding=PLAIN"`
     ID     int64   `parquet:"name=id, type=INT64"`
     Weight float32 `parquet:"name=weight, type=FLOAT"`
@@ -286,7 +286,7 @@ type Student struct {
 jsonSchema := `{
   "Tag": "name=parquet_go_root, repetitiontype=REQUIRED",
   "Fields": [
-    {"Tag": "name=name, type=BYTE_ARRAY, convertedtype=UTF8, repetitiontype=REQUIRED"},
+    {"Tag": "name=name, type=BYTE_ARRAY, logicaltype=STRING, repetitiontype=REQUIRED"},
     {"Tag": "name=age, type=INT32, repetitiontype=REQUIRED"}
   ]
 }`
@@ -296,7 +296,7 @@ jsonSchema := `{
 
 ```go
 md := []string{
-    "name=Name, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY",
+    "name=Name, type=BYTE_ARRAY, logicaltype=STRING, encoding=PLAIN_DICTIONARY",
     "name=Age, type=INT32",
 }
 ```

--- a/layout/page.go
+++ b/layout/page.go
@@ -697,8 +697,12 @@ func (p *Page) GetRLDLFromRawData(schemaHandler *schema.SchemaHandler) (int64, i
 		buf = append(buf, dataBuf...)
 
 	} else {
-		if buf, err = resolveCompressor(p.compressor).Uncompress(p.RawData, p.CompressType); err != nil {
-			return 0, 0, fmt.Errorf("uncompress data page: %w", err)
+		if p.CompressType != parquet.CompressionCodec_UNCOMPRESSED {
+			if buf, err = resolveCompressor(p.compressor).UncompressWithExpectedSize(p.RawData, p.CompressType, int64(p.Header.GetUncompressedPageSize())); err != nil {
+				return 0, 0, fmt.Errorf("uncompress data page: %w", err)
+			}
+		} else {
+			buf = p.RawData
 		}
 	}
 
@@ -843,7 +847,12 @@ func (p *Page) processDictionaryPage() error {
 func (p *Page) processDataPageV2(schemaHandler *schema.SchemaHandler) error {
 	if p.Header.DataPageHeaderV2.GetIsCompressed() {
 		var err error
-		if p.RawData, err = resolveCompressor(p.compressor).Uncompress(p.RawData, p.CompressType); err != nil {
+		// In V2, rep/def levels are always uncompressed and already stripped from RawData.
+		// The expected uncompressed data size is the total minus the level byte lengths.
+		dll := int64(p.Header.DataPageHeaderV2.GetDefinitionLevelsByteLength())
+		rll := int64(p.Header.DataPageHeaderV2.GetRepetitionLevelsByteLength())
+		expectedDataSize := int64(p.Header.GetUncompressedPageSize()) - dll - rll
+		if p.RawData, err = resolveCompressor(p.compressor).UncompressWithExpectedSize(p.RawData, p.CompressType, expectedDataSize); err != nil {
 			return fmt.Errorf("uncompress data page v2: %w", err)
 		}
 	}
@@ -1081,7 +1090,8 @@ func ReadPage(thriftReader *thrift.TBufferedTransport, schemaHandler *schema.Sch
 		if pageHeader.DataPageHeaderV2.GetIsCompressed() {
 			codec := colMetaData.GetCodec()
 			if len(dataBuf) > 0 {
-				if dataBuf, err = c.Uncompress(dataBuf, codec); err != nil {
+				expectedDataSize := int64(pageHeader.GetUncompressedPageSize()) - int64(rll) - int64(dll)
+				if dataBuf, err = c.UncompressWithExpectedSize(dataBuf, codec, expectedDataSize); err != nil {
 					return nil, 0, 0, err
 				}
 			}
@@ -1117,7 +1127,7 @@ func ReadPage(thriftReader *thrift.TBufferedTransport, schemaHandler *schema.Sch
 			return nil, 0, 0, fmt.Errorf("CRC validation failed: %w", err)
 		}
 		codec := colMetaData.GetCodec()
-		if buf, err = c.Uncompress(buf, codec); err != nil {
+		if buf, err = c.UncompressWithExpectedSize(buf, codec, int64(pageHeader.GetUncompressedPageSize())); err != nil {
 			return nil, 0, 0, err
 		}
 	}

--- a/layout/page_test.go
+++ b/layout/page_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/hangxie/parquet-go/v3/common"
+	"github.com/hangxie/parquet-go/v3/compress"
 	"github.com/hangxie/parquet-go/v3/encoding"
 	"github.com/hangxie/parquet-go/v3/parquet"
 	"github.com/hangxie/parquet-go/v3/schema"
@@ -435,6 +436,61 @@ func TestGetRLDLFromRawData(t *testing.T) {
 			},
 			expectError:  true,
 			errorMessage: "unsupported page type",
+		},
+		{
+			name: "data_page_compressed_valid_expected_size",
+			setupPage: func() *Page {
+				// Compress known data and set matching UncompressedPageSize
+				rawData := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+				compressedData, err := compress.CompressWithError(rawData, parquet.CompressionCodec_SNAPPY)
+				if err != nil {
+					t.Fatalf("compress test data: %v", err)
+				}
+
+				page := NewDataPage()
+				page.Header.Type = parquet.PageType_DATA_PAGE
+				page.Header.UncompressedPageSize = int32(len(rawData))
+				page.Header.DataPageHeader = &parquet.DataPageHeader{
+					NumValues:               2,
+					Encoding:                parquet.Encoding_PLAIN,
+					DefinitionLevelEncoding: parquet.Encoding_RLE,
+					RepetitionLevelEncoding: parquet.Encoding_RLE,
+				}
+				page.Path = []string{"parquet_go_root", "required_field"}
+				page.CompressType = parquet.CompressionCodec_SNAPPY
+				page.RawData = compressedData
+				return page
+			},
+			expectError:    false,
+			expectedValues: 2,
+			expectedRows:   2,
+		},
+		{
+			name: "data_page_compressed_size_mismatch",
+			setupPage: func() *Page {
+				// Compress data but set wrong UncompressedPageSize
+				rawData := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+				compressedData, err := compress.CompressWithError(rawData, parquet.CompressionCodec_SNAPPY)
+				if err != nil {
+					t.Fatalf("compress test data: %v", err)
+				}
+
+				page := NewDataPage()
+				page.Header.Type = parquet.PageType_DATA_PAGE
+				page.Header.UncompressedPageSize = int32(len(rawData)) + 10 // wrong size
+				page.Header.DataPageHeader = &parquet.DataPageHeader{
+					NumValues:               2,
+					Encoding:                parquet.Encoding_PLAIN,
+					DefinitionLevelEncoding: parquet.Encoding_RLE,
+					RepetitionLevelEncoding: parquet.Encoding_RLE,
+				}
+				page.Path = []string{"parquet_go_root", "required_field"}
+				page.CompressType = parquet.CompressionCodec_SNAPPY
+				page.RawData = compressedData
+				return page
+			},
+			expectError:  true,
+			errorMessage: "uncompress data page",
 		},
 		{
 			name: "data_page_compressed_invalid",

--- a/layout/rowgroup.go
+++ b/layout/rowgroup.go
@@ -1,6 +1,8 @@
 package layout
 
 import (
+	"fmt"
+
 	"github.com/hangxie/parquet-go/v3/common"
 	"github.com/hangxie/parquet-go/v3/parquet"
 )
@@ -18,12 +20,16 @@ func NewRowGroup() *RowGroup {
 	return rowGroup
 }
 
-// Convert a RowGroup to table map
-func (rowGroup *RowGroup) RowGroupToTableMap() *map[string]*Table {
+// RowGroupToTableMap converts a RowGroup to a map of path to Table.
+// Returns an error if any page has a nil DataTable.
+func (rowGroup *RowGroup) RowGroupToTableMap() (*map[string]*Table, error) {
 	tableMap := make(map[string]*Table, 0)
 	for _, chunk := range rowGroup.Chunks {
 		pathStr := ""
 		for _, page := range chunk.Pages {
+			if page.DataTable == nil {
+				return nil, fmt.Errorf("page DataTable is nil, data may not have been decoded")
+			}
 			if pathStr == "" {
 				pathStr = common.PathToStr(page.DataTable.Path)
 			}
@@ -33,5 +39,5 @@ func (rowGroup *RowGroup) RowGroupToTableMap() *map[string]*Table {
 			tableMap[pathStr].Merge(page.DataTable)
 		}
 	}
-	return &tableMap
+	return &tableMap, nil
 }

--- a/layout/rowgroup_test.go
+++ b/layout/rowgroup_test.go
@@ -18,6 +18,7 @@ func TestRowGroupToTableMap(t *testing.T) {
 		name          string
 		setupRowGroup func() *RowGroup
 		expectedKeys  []string
+		expectError   bool
 		checkResult   func(t *testing.T, tableMap *map[string]*Table)
 	}{
 		{
@@ -127,6 +128,23 @@ func TestRowGroupToTableMap(t *testing.T) {
 			},
 		},
 		{
+			name: "nil_data_table",
+			setupRowGroup: func() *RowGroup {
+				return &RowGroup{
+					Chunks: []*Chunk{
+						{
+							Pages: []*Page{
+								{
+									DataTable: nil,
+								},
+							},
+						},
+					},
+				}
+			},
+			expectError: true,
+		},
+		{
 			name: "empty_path",
 			setupRowGroup: func() *RowGroup {
 				return &RowGroup{
@@ -157,8 +175,13 @@ func TestRowGroupToTableMap(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			rowGroup := tt.setupRowGroup()
-			tableMap := rowGroup.RowGroupToTableMap()
+			tableMap, err := rowGroup.RowGroupToTableMap()
 
+			if tt.expectError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
 			require.NotNil(t, tableMap)
 
 			if tt.checkResult != nil {

--- a/reader/page.go
+++ b/reader/page.go
@@ -279,7 +279,35 @@ func ReadPageData(pFile io.ReadSeeker, offset int64, pageHeader *parquet.PageHea
 		return nil, fmt.Errorf("CRC validation failed: %w", err)
 	}
 
-	// Decompress the data with expected size validation
+	// Handle DATA_PAGE_V2: rep/def levels are stored uncompressed at the
+	// start of the page, only the values portion is compressed.
+	if v2Header := pageHeader.DataPageHeaderV2; v2Header != nil {
+		dll := v2Header.GetDefinitionLevelsByteLength()
+		rll := v2Header.GetRepetitionLevelsByteLength()
+		levelBytes := int(dll + rll)
+
+		if levelBytes > len(compressedData) {
+			return nil, fmt.Errorf("level byte lengths exceed page data (dll=%d + rll=%d > %d)", dll, rll, len(compressedData))
+		}
+
+		levelData := compressedData[:levelBytes]
+		valuesData := compressedData[levelBytes:]
+
+		if v2Header.GetIsCompressed() && len(valuesData) > 0 {
+			expectedDataSize := int64(pageHeader.UncompressedPageSize) - int64(levelBytes)
+			valuesData, err = compress.UncompressWithExpectedSize(valuesData, codec, expectedDataSize)
+			if err != nil {
+				return nil, fmt.Errorf("decompress page data: %w", err)
+			}
+		}
+
+		result := make([]byte, 0, len(levelData)+len(valuesData))
+		result = append(result, levelData...)
+		result = append(result, valuesData...)
+		return result, nil
+	}
+
+	// Non-V2 pages: decompress the entire buffer
 	uncompressedData, err := compress.UncompressWithExpectedSize(compressedData, codec, int64(pageHeader.UncompressedPageSize))
 	if err != nil {
 		return nil, fmt.Errorf("decompress page data: %w", err)

--- a/reader/page.go
+++ b/reader/page.go
@@ -279,8 +279,8 @@ func ReadPageData(pFile io.ReadSeeker, offset int64, pageHeader *parquet.PageHea
 		return nil, fmt.Errorf("CRC validation failed: %w", err)
 	}
 
-	// Decompress the data
-	uncompressedData, err := compress.Uncompress(compressedData, codec)
+	// Decompress the data with expected size validation
+	uncompressedData, err := compress.UncompressWithExpectedSize(compressedData, codec, int64(pageHeader.UncompressedPageSize))
 	if err != nil {
 		return nil, fmt.Errorf("decompress page data: %w", err)
 	}

--- a/reader/page_test.go
+++ b/reader/page_test.go
@@ -805,6 +805,34 @@ func TestReadPageData_NegativeCases(t *testing.T) {
 		require.Contains(t, err.Error(), "decompress page data")
 	})
 
+	t.Run("decompressed size mismatch", func(t *testing.T) {
+		testFile := getTestParquetFile(t)
+		buf, err := local.NewLocalFileReader(testFile)
+		require.NoError(t, err)
+		pr, err := reader.NewParquetReader(buf, new(TestPageRecord), reader.WithNP(4))
+		require.NoError(t, err)
+		defer func() {
+			_ = pr.ReadStopWithError()
+		}()
+
+		col := pr.Footer.RowGroups[0].Columns[0]
+		headers, err := pr.GetAllPageHeaders(0, 0)
+		require.NoError(t, err)
+		require.NotEmpty(t, headers)
+
+		firstPage := headers[0]
+
+		// Set a wrong uncompressed page size to trigger size validation
+		pageHeader := parquet.NewPageHeader()
+		pageHeader.Type = firstPage.PageType
+		pageHeader.CompressedPageSize = firstPage.CompressedSize
+		pageHeader.UncompressedPageSize = firstPage.UncompressedSize + 10
+
+		_, err = reader.ReadPageData(pr.PFile, firstPage.Offset, pageHeader, col.MetaData.Codec, nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "decompress page data")
+	})
+
 	t.Run("decompression failure - invalid compressed data", func(t *testing.T) {
 		// Create minimal mock data that looks like a page but isn't valid GZIP
 		mockData := []byte{

--- a/reader/page_test.go
+++ b/reader/page_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hangxie/parquet-go/v3/reader"
 	"github.com/hangxie/parquet-go/v3/source/buffer"
 	"github.com/hangxie/parquet-go/v3/source/local"
+	"github.com/hangxie/parquet-go/v3/writer"
 )
 
 const (
@@ -268,6 +269,73 @@ func TestReadPageData(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, pageData)
 	require.Equal(t, firstPage.UncompressedSize, int32(len(pageData)))
+}
+
+func TestReadPageData_V2(t *testing.T) {
+	// Use an optional field so V2 pages have non-zero definition level bytes
+	type Record struct {
+		Name *string `parquet:"name=name, type=BYTE_ARRAY, convertedtype=UTF8, repetitiontype=OPTIONAL"`
+	}
+
+	var buf bytes.Buffer
+	pw, err := writer.NewParquetWriterFromWriter(&buf, new(Record),
+		writer.WithNP(1),
+		writer.WithDataPageVersion(2),
+		writer.WithCompressionType(parquet.CompressionCodec_SNAPPY),
+	)
+	require.NoError(t, err)
+
+	for i := range 100 {
+		s := fmt.Sprintf("name_%d", i)
+		require.NoError(t, pw.Write(Record{Name: &s}))
+	}
+	require.NoError(t, pw.WriteStop())
+
+	// Read back and verify ReadPageData handles V2 pages with level data
+	data := buf.Bytes()
+	pf := buffer.NewBufferReaderFromBytesNoAlloc(data)
+	pr, err := reader.NewParquetReader(pf, new(Record), reader.WithNP(1))
+	require.NoError(t, err)
+	defer func() { _ = pr.ReadStopWithError() }()
+
+	headers, err := pr.GetAllPageHeaders(0, 0)
+	require.NoError(t, err)
+	require.NotEmpty(t, headers)
+
+	col := pr.Footer.RowGroups[0].Columns[0]
+
+	// Verify we actually have V2 pages with non-zero level bytes
+	hasV2WithLevels := false
+	for _, h := range headers {
+		if h.PageType == parquet.PageType_DATA_PAGE_V2 && h.DefLevelBytes > 0 {
+			hasV2WithLevels = true
+		}
+	}
+	require.True(t, hasV2WithLevels, "test must produce V2 pages with non-zero definition level bytes")
+
+	for _, h := range headers {
+		pageHeader := parquet.NewPageHeader()
+		pageHeader.Type = h.PageType
+		pageHeader.CompressedPageSize = h.CompressedSize
+		pageHeader.UncompressedPageSize = h.UncompressedSize
+		if h.PageType == parquet.PageType_DATA_PAGE_V2 {
+			pageHeader.DataPageHeaderV2 = &parquet.DataPageHeaderV2{
+				NumValues:                  h.NumValues,
+				NumNulls:                   h.NumNulls,
+				NumRows:                    h.NumRows,
+				Encoding:                   h.Encoding,
+				DefinitionLevelsByteLength: h.DefLevelBytes,
+				RepetitionLevelsByteLength: h.RepLevelBytes,
+				IsCompressed:               true,
+			}
+		}
+
+		pageData, err := reader.ReadPageData(pr.PFile, h.Offset, pageHeader, col.MetaData.Codec, nil)
+		require.NoError(t, err)
+		require.NotEmpty(t, pageData)
+		require.Equal(t, h.UncompressedSize, int32(len(pageData)),
+			"page %d (type %v): uncompressed size mismatch", h.Index, h.PageType)
+	}
 }
 
 func TestDecodeDictionaryPage(t *testing.T) {


### PR DESCRIPTION
* handle DATA_PAGE_V2 correctly in ReadPageData
* use UncompressWithExpectedSize for page decompression validation
* return error from RowGroupToTableMap when page DataTable is nil
* use logicaltype=STRING instead of convertedtype=UTF8 in README examples