### PR TITLE
Fix bug that siliently ignore invalid parameters

### DIFF
--- a/common/logicaltype.go
+++ b/common/logicaltype.go
@@ -10,12 +10,11 @@ import (
 
 // GetLogicalTypeFromTag returns the LogicalType from a Tag.
 // This is used when creating GROUP elements that need LogicalType annotation (e.g., VARIANT).
-func GetLogicalTypeFromTag(info *Tag) *parquet.LogicalType {
+func GetLogicalTypeFromTag(info *Tag) (*parquet.LogicalType, error) {
 	if len(info.logicalTypeFields) > 0 {
-		logicalType, _ := newLogicalTypeFromFieldsMap(info.logicalTypeFields)
-		return logicalType
+		return newLogicalTypeFromFieldsMap(info.logicalTypeFields)
 	}
-	return nil
+	return nil, nil
 }
 
 var logicalIntToConvertedTypeMap = map[struct {

--- a/common/logicaltype_test.go
+++ b/common/logicaltype_test.go
@@ -548,7 +548,8 @@ func TestGetLogicalTypeFromTag(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			result := GetLogicalTypeFromTag(tc.tag)
+			result, err := GetLogicalTypeFromTag(tc.tag)
+			require.NoError(t, err)
 			if tc.hasType {
 				require.NotNil(t, result)
 				if tc.validate != nil {

--- a/common/tag_schema.go
+++ b/common/tag_schema.go
@@ -109,6 +109,21 @@ func NewSchemaElementFromTagMap(info *Tag) (*parquet.SchemaElement, error) {
 	return schema, nil
 }
 
+// ValidateTagAnnotations validates converted and logical type annotations supplied on tags.
+func ValidateTagAnnotations(info *Tag) error {
+	if info.convertedType != "" {
+		if _, err := parquet.ConvertedTypeFromString(info.convertedType); err != nil {
+			return fmt.Errorf("field [%s] with convertedtype [%s]: %w", info.InName, info.convertedType, err)
+		}
+	}
+	if len(info.logicalTypeFields) > 0 {
+		if _, err := newLogicalTypeFromFieldsMap(info.logicalTypeFields); err != nil {
+			return fmt.Errorf("create logicaltype from field map: %w", err)
+		}
+	}
+	return nil
+}
+
 // ValidateSchemaElement checks if the ConvertedType and LogicalType are compatible with the physical Type.
 func validateLogicalTime(lt *parquet.LogicalType, pT *parquet.Type) error {
 	if lt.TIME == nil {

--- a/common/tag_schema.go
+++ b/common/tag_schema.go
@@ -67,8 +67,12 @@ func NewSchemaElementFromTagMap(info *Tag) (*parquet.SchemaElement, error) {
 		}
 	}
 
-	if ct, err := parquet.ConvertedTypeFromString(info.convertedType); err == nil {
-		schema.ConvertedType = &ct
+	if info.convertedType != "" {
+		if ct, err := parquet.ConvertedTypeFromString(info.convertedType); err == nil {
+			schema.ConvertedType = &ct
+		} else {
+			return nil, fmt.Errorf("field [%s] with convertedtype [%s]: %w", info.InName, info.convertedType, err)
+		}
 	}
 
 	var logicalType *parquet.LogicalType

--- a/common/tag_test.go
+++ b/common/tag_test.go
@@ -1258,6 +1258,38 @@ func TestStringToVariableName(t *testing.T) {
 	}
 }
 
+func TestNewSchemaElementFromTagMap_Errors(t *testing.T) {
+	t.Run("invalid convertedtype returns error", func(t *testing.T) {
+		tag := &Tag{
+			fieldAttr: fieldAttr{
+				Type:          "INT32",
+				convertedType: "INVALID_CONVERTED_TYPE",
+			},
+		}
+		schema, err := NewSchemaElementFromTagMap(tag)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "with convertedtype [INVALID_CONVERTED_TYPE]")
+		require.Nil(t, schema)
+	})
+}
+
+func TestGetLogicalTypeFromTag_Errors(t *testing.T) {
+	t.Run("invalid logicaltype returns error", func(t *testing.T) {
+		tag := &Tag{
+			fieldAttr: fieldAttr{
+				logicalTypeFields: map[string]string{
+					"logicaltype":           "DECIMAL",
+					"logicaltype.precision": "abc",
+				},
+			},
+		}
+		lt, err := GetLogicalTypeFromTag(tag)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "parse logicaltype.precision")
+		require.Nil(t, lt)
+	})
+}
+
 func TestHeadToUpper(t *testing.T) {
 	testCases := map[string]struct {
 		str      string

--- a/common/tag_test.go
+++ b/common/tag_test.go
@@ -1290,6 +1290,63 @@ func TestGetLogicalTypeFromTag_Errors(t *testing.T) {
 	})
 }
 
+func TestValidateTagAnnotations(t *testing.T) {
+	tests := []struct {
+		name        string
+		tag         *Tag
+		errContains string
+	}{
+		{
+			name: "valid_empty_annotations",
+			tag:  &Tag{InName: "Group"},
+		},
+		{
+			name: "valid_convertedtype",
+			tag: &Tag{
+				InName: "Group",
+				fieldAttr: fieldAttr{
+					convertedType: "MAP",
+				},
+			},
+		},
+		{
+			name: "invalid_convertedtype",
+			tag: &Tag{
+				InName: "Group",
+				fieldAttr: fieldAttr{
+					convertedType: "INVALID_CONVERTED_TYPE",
+				},
+			},
+			errContains: "with convertedtype [INVALID_CONVERTED_TYPE]",
+		},
+		{
+			name: "invalid_logicaltype",
+			tag: &Tag{
+				InName: "Group",
+				fieldAttr: fieldAttr{
+					logicalTypeFields: map[string]string{
+						"logicaltype":           "DECIMAL",
+						"logicaltype.precision": "bad",
+					},
+				},
+			},
+			errContains: "parse logicaltype.precision",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateTagAnnotations(tc.tag)
+			if tc.errContains != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.errContains)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
 func TestHeadToUpper(t *testing.T) {
 	testCases := map[string]struct {
 		str      string

--- a/schema/json.go
+++ b/schema/json.go
@@ -130,7 +130,10 @@ func NewSchemaHandlerFromJSON(str string) (sh *SchemaHandler, err error) {
 			var numChildren int32 = 2
 			schema.NumChildren = &numChildren
 			// Set LogicalType for VARIANT
-			logicalType := common.GetLogicalTypeFromTag(info)
+			logicalType, err := common.GetLogicalTypeFromTag(info)
+			if err != nil {
+				return nil, fmt.Errorf("get logicaltype from tag: %w", err)
+			}
 			if logicalType == nil {
 				logicalType = parquet.NewLogicalType()
 				logicalType.VARIANT = parquet.NewVariantType()

--- a/schema/json.go
+++ b/schema/json.go
@@ -17,6 +17,17 @@ func NewJSONSchemaItem() *JSONSchemaItemType {
 	return new(JSONSchemaItemType)
 }
 
+func parseJSONSchemaTag(tag string) (*common.Tag, error) {
+	info, err := common.StringToTag(tag)
+	if err != nil {
+		return nil, fmt.Errorf("parse tag: %w", err)
+	}
+	if err := common.ValidateTagAnnotations(info); err != nil {
+		return nil, fmt.Errorf("validate tag annotations: %w", err)
+	}
+	return info, nil
+}
+
 func NewSchemaHandlerFromJSON(str string) (sh *SchemaHandler, err error) {
 	schema := NewJSONSchemaItem()
 	if err := json.Unmarshal([]byte(str), schema); err != nil {
@@ -32,9 +43,9 @@ func NewSchemaHandlerFromJSON(str string) (sh *SchemaHandler, err error) {
 		ln := len(stack)
 		item := stack[ln-1]
 		stack = stack[:ln-1]
-		info, err := common.StringToTag(item.Tag)
+		info, err := parseJSONSchemaTag(item.Tag)
 		if err != nil {
-			return nil, fmt.Errorf("parse tag: %w", err)
+			return nil, err
 		}
 		var newInfo *common.Tag
 		switch info.Type {

--- a/schema/json_test.go
+++ b/schema/json_test.go
@@ -71,6 +71,40 @@ func TestNewSchemaHandlerFromJSON(t *testing.T) {
 			errorContains: "MAP needs exactly 2 fields",
 		},
 		{
+			name: "group_invalid_convertedtype",
+			jsonSchema: `
+			{
+			  "Tag": "name=parquet-go-root, repetitiontype=REQUIRED",
+			  "Fields": [
+				{
+				  "Tag": "name=nested, inname=Nested, convertedtype=INVALID_CONVERTED_TYPE, repetitiontype=REQUIRED",
+				  "Fields": [
+					{"Tag": "name=age, inname=Age, type=INT32, repetitiontype=REQUIRED"}
+				  ]
+				}
+			  ]
+			}
+			`,
+			errorContains: "with convertedtype [INVALID_CONVERTED_TYPE]",
+		},
+		{
+			name: "list_invalid_logicaltype",
+			jsonSchema: `
+			{
+			  "Tag": "name=parquet-go-root, repetitiontype=REQUIRED",
+			  "Fields": [
+				{
+				  "Tag": "name=items, inname=Items, type=LIST, logicaltype=DECIMAL, logicaltype.precision=bad, repetitiontype=REQUIRED",
+				  "Fields": [
+					{"Tag": "name=element, inname=Element, type=INT32, repetitiontype=REQUIRED"}
+				  ]
+				}
+			  ]
+			}
+			`,
+			errorContains: "parse logicaltype.precision",
+		},
+		{
 			name: "variant_type",
 			jsonSchema: `
 			{
@@ -81,6 +115,18 @@ func TestNewSchemaHandlerFromJSON(t *testing.T) {
 			}
 			`,
 			expectedElems: func() *int { e := 4; return &e }(), // root + variant group + metadata + value
+		},
+		{
+			name: "variant_invalid_convertedtype",
+			jsonSchema: `
+			{
+			  "Tag": "name=parquet-go-root, repetitiontype=REQUIRED",
+			  "Fields": [
+				{"Tag": "name=data, inname=Data, type=VARIANT, logicaltype=VARIANT, convertedtype=INVALID_CONVERTED_TYPE, repetitiontype=REQUIRED"}
+			  ]
+			}
+			`,
+			errorContains: "with convertedtype [INVALID_CONVERTED_TYPE]",
 		},
 		{
 			name: "variant_with_specification_version",

--- a/schema/schemabuild.go
+++ b/schema/schemabuild.go
@@ -19,6 +19,17 @@ func NewItem() *Item {
 	return item
 }
 
+func parseStructFieldTag(tag string) (*common.Tag, error) {
+	info, err := common.StringToTag(tag)
+	if err != nil {
+		return nil, fmt.Errorf("parse tag: %w", err)
+	}
+	if err := common.ValidateTagAnnotations(info); err != nil {
+		return nil, fmt.Errorf("validate tag annotations: %w", err)
+	}
+	return info, nil
+}
+
 // Create schema handler from a object
 func createVariantSchema(item *Item, stack *[]*Item, schemaElements *[]*parquet.SchemaElement, infos *[]*common.Tag) error {
 	// VARIANT is a GROUP with two required BYTE_ARRAY children: Metadata and Value
@@ -68,9 +79,9 @@ func createVariantSchema(item *Item, stack *[]*Item, schemaElements *[]*parquet.
 
 			newItem := NewItem()
 			var err error
-			newItem.Info, err = common.StringToTag(tagStr)
+			newItem.Info, err = parseStructFieldTag(tagStr)
 			if err != nil {
-				return fmt.Errorf("parse tag: %w", err)
+				return err
 			}
 			newItem.Info.InName = f.Name
 			newItem.GoType = f.Type
@@ -131,9 +142,9 @@ func createStructSchema(item *Item, stack *[]*Item, schemaElements *[]*parquet.S
 
 		newItem := NewItem()
 		var err error
-		newItem.Info, err = common.StringToTag(tagStr)
+		newItem.Info, err = parseStructFieldTag(tagStr)
 		if err != nil {
-			return fmt.Errorf("parse tag: %w", err)
+			return err
 		}
 		newItem.Info.InName = f.Name
 		newItem.GoType = f.Type

--- a/schema/schemabuild.go
+++ b/schema/schemabuild.go
@@ -29,7 +29,10 @@ func createVariantSchema(item *Item, stack *[]*Item, schemaElements *[]*parquet.
 
 	// Get the LogicalType from the Tag (handles specification_version)
 	// Always ensure VARIANT LogicalType is set
-	logicalType := common.GetLogicalTypeFromTag(item.Info)
+	logicalType, err := common.GetLogicalTypeFromTag(item.Info)
+	if err != nil {
+		return fmt.Errorf("get logicaltype from tag: %w", err)
+	}
 	if logicalType == nil || logicalType.VARIANT == nil {
 		logicalType = parquet.NewLogicalType()
 		logicalType.VARIANT = parquet.NewVariantType()

--- a/schema/schemabuild_test.go
+++ b/schema/schemabuild_test.go
@@ -142,6 +142,29 @@ func TestNewSchemaHandlerFromStruct(t *testing.T) {
 			expectedErrorText: "field [Key] with type []: not a valid Type string",
 		},
 		{
+			name: "nested_struct_invalid_convertedtype",
+			structDef: new(struct {
+				Nested struct {
+					Value int32 `parquet:"name=value, type=INT32"`
+				} `parquet:"name=nested, convertedtype=INVALID_CONVERTED_TYPE"`
+			}),
+			expectedErrorText: "with convertedtype [INVALID_CONVERTED_TYPE]",
+		},
+		{
+			name: "list_invalid_logicaltype",
+			structDef: new(struct {
+				Items []int32 `parquet:"name=items, type=LIST, logicaltype=DECIMAL, logicaltype.precision=bad, valuetype=INT32"`
+			}),
+			expectedErrorText: "parse logicaltype.precision",
+		},
+		{
+			name: "variant_invalid_convertedtype",
+			structDef: new(struct {
+				Data any `parquet:"name=data, type=VARIANT, logicaltype=VARIANT, convertedtype=INVALID_CONVERTED_TYPE"`
+			}),
+			expectedErrorText: "with convertedtype [INVALID_CONVERTED_TYPE]",
+		},
+		{
 			name: "map_good",
 			structDef: new(struct {
 				MapField1 map[string]*int32  `parquet:"name=map, type=MAP, convertedtype=MAP, keytype=BYTE_ARRAY, keyconvertedtype=UTF8, valuetype=INT32"`

--- a/writer/arrow.go
+++ b/writer/arrow.go
@@ -43,7 +43,9 @@ func NewArrowWriter(arrowSchema *arrow.Schema, pfile source.ParquetFileWriter, o
 	}
 	res.Footer.Schema = append(res.Footer.Schema, res.SchemaHandler.SchemaElements...)
 	res.marshalFunc = marshal.MarshalArrow
-	res.initBloomFilters()
+	if err = res.initBloomFilters(); err != nil {
+		return nil, fmt.Errorf("init bloom filters: %w", err)
+	}
 
 	res.stopped = false
 	return res, nil

--- a/writer/csv.go
+++ b/writer/csv.go
@@ -36,7 +36,9 @@ func NewCSVWriter(md []string, pfile source.ParquetFileWriter, opts ...WriterOpt
 	}
 	res.Footer.Schema = append(res.Footer.Schema, res.SchemaHandler.SchemaElements...)
 	res.marshalFunc = marshal.MarshalCSV
-	res.initBloomFilters()
+	if err = res.initBloomFilters(); err != nil {
+		return nil, fmt.Errorf("init bloom filters: %w", err)
+	}
 
 	res.stopped = false
 	return res, nil

--- a/writer/json.go
+++ b/writer/json.go
@@ -35,7 +35,9 @@ func NewJSONWriter(jsonSchema string, pfile source.ParquetFileWriter, opts ...Wr
 	}
 	res.Footer.Schema = append(res.Footer.Schema, res.SchemaHandler.SchemaElements...)
 	res.marshalFunc = marshal.MarshalJSON
-	res.initBloomFilters()
+	if err = res.initBloomFilters(); err != nil {
+		return nil, fmt.Errorf("init bloom filters: %w", err)
+	}
 
 	res.stopped = false
 	return res, nil

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -184,7 +184,9 @@ func NewParquetWriter(pFile source.ParquetFileWriter, obj any, opts ...WriterOpt
 		}
 	}
 
-	res.initBloomFilters()
+	if err := res.initBloomFilters(); err != nil {
+		return nil, fmt.Errorf("init bloom filters: %w", err)
+	}
 
 	// Enable writing after init completed successfully
 	res.stopped = false
@@ -199,7 +201,9 @@ func (pw *ParquetWriter) SetSchemaHandlerFromJSON(jsonSchema string) error {
 	}
 	pw.Footer.Schema = pw.Footer.Schema[:0]
 	pw.Footer.Schema = append(pw.Footer.Schema, pw.SchemaHandler.SchemaElements...)
-	pw.initBloomFilters()
+	if err := pw.initBloomFilters(); err != nil {
+		return fmt.Errorf("init bloom filters: %w", err)
+	}
 	pw.encodingsValidated = false
 	return nil
 }

--- a/writer/writer_index.go
+++ b/writer/writer_index.go
@@ -133,14 +133,15 @@ func (pw *ParquetWriter) serializeBloomFilters() error {
 		}
 		pw.bloomFilterData = append(pw.bloomFilterData, append(headerBuf, bf.Bitset()...))
 	}
-	pw.initBloomFilters()
-	return nil
+	return pw.initBloomFilters()
 }
 
 // initBloomFilters creates bloom filters for columns that have bloomfilter=true in their tags.
-func (pw *ParquetWriter) initBloomFilters() {
+// It returns an error if any column specifies an explicit bloomfiltersize outside the valid
+// range [bloomfilter.MinBytes, bloomfilter.MaxBytes].
+func (pw *ParquetWriter) initBloomFilters() error {
 	if pw.SchemaHandler == nil {
-		return
+		return nil
 	}
 	pw.bloomFilters = make(map[string]*bloomfilter.Filter)
 	for i, info := range pw.SchemaHandler.Infos {
@@ -151,7 +152,11 @@ func (pw *ParquetWriter) initBloomFilters() {
 		numBytes := int(info.BloomFilterSize)
 		if numBytes <= 0 {
 			numBytes = bloomfilter.DefaultNumBytes
+		} else if numBytes < bloomfilter.MinBytes || numBytes > bloomfilter.MaxBytes {
+			return fmt.Errorf("column %q: bloomfiltersize %d is out of valid range [%d, %d]",
+				path, numBytes, bloomfilter.MinBytes, bloomfilter.MaxBytes)
 		}
 		pw.bloomFilters[path] = bloomfilter.New(numBytes)
 	}
+	return nil
 }

--- a/writer/writer_index_test.go
+++ b/writer/writer_index_test.go
@@ -80,36 +80,29 @@ func TestWriteColumnIndexes(t *testing.T) {
 	})
 }
 
+func makeBloomPW(size int32) *ParquetWriter {
+	info := &common.Tag{}
+	info.BloomFilter = true
+	info.BloomFilterSize = size
+	return &ParquetWriter{
+		SchemaHandler: &schema.SchemaHandler{
+			SchemaElements: []*parquet.SchemaElement{{}, {}},
+			IndexMap:       map[int32]string{0: "root", 1: "root.col"},
+			Infos:          []*common.Tag{nil, info},
+		},
+	}
+}
+
 func TestInitBloomFilters(t *testing.T) {
 	t.Run("nil_schema_handler_is_safe", func(t *testing.T) {
 		pw := &ParquetWriter{}
-		pw.initBloomFilters()
+		require.NoError(t, pw.initBloomFilters())
 		require.Nil(t, pw.bloomFilters)
 	})
 
 	t.Run("bloom_filter_true_default_size", func(t *testing.T) {
-		info := &common.Tag{}
-		info.BloomFilter = true
-		info.BloomFilterSize = 0 // use default
-
-		pw := &ParquetWriter{
-			SchemaHandler: &schema.SchemaHandler{
-				SchemaElements: []*parquet.SchemaElement{
-					{}, // root (index 0)
-					{}, // leaf (index 1)
-				},
-				IndexMap: map[int32]string{
-					0: "root",
-					1: "root.col",
-				},
-				Infos: []*common.Tag{
-					nil,  // root has no info
-					info, // leaf has bloom filter enabled
-				},
-			},
-		}
-
-		pw.initBloomFilters()
+		pw := makeBloomPW(0) // 0 = use default
+		require.NoError(t, pw.initBloomFilters())
 		require.NotNil(t, pw.bloomFilters)
 		bf, ok := pw.bloomFilters["root.col"]
 		require.True(t, ok)
@@ -118,28 +111,8 @@ func TestInitBloomFilters(t *testing.T) {
 	})
 
 	t.Run("bloom_filter_true_custom_size", func(t *testing.T) {
-		info := &common.Tag{}
-		info.BloomFilter = true
-		info.BloomFilterSize = 2048
-
-		pw := &ParquetWriter{
-			SchemaHandler: &schema.SchemaHandler{
-				SchemaElements: []*parquet.SchemaElement{
-					{},
-					{},
-				},
-				IndexMap: map[int32]string{
-					0: "root",
-					1: "root.col",
-				},
-				Infos: []*common.Tag{
-					nil,
-					info,
-				},
-			},
-		}
-
-		pw.initBloomFilters()
+		pw := makeBloomPW(2048)
+		require.NoError(t, pw.initBloomFilters())
 		require.NotNil(t, pw.bloomFilters)
 		bf, ok := pw.bloomFilters["root.col"]
 		require.True(t, ok)
@@ -149,27 +122,46 @@ func TestInitBloomFilters(t *testing.T) {
 	t.Run("bloom_filter_false_skipped", func(t *testing.T) {
 		info := &common.Tag{}
 		info.BloomFilter = false
-
 		pw := &ParquetWriter{
 			SchemaHandler: &schema.SchemaHandler{
-				SchemaElements: []*parquet.SchemaElement{
-					{},
-					{},
-				},
-				IndexMap: map[int32]string{
-					0: "root",
-					1: "root.col",
-				},
-				Infos: []*common.Tag{
-					nil,
-					info,
-				},
+				SchemaElements: []*parquet.SchemaElement{{}, {}},
+				IndexMap:       map[int32]string{0: "root", 1: "root.col"},
+				Infos:          []*common.Tag{nil, info},
 			},
 		}
-
-		pw.initBloomFilters()
+		require.NoError(t, pw.initBloomFilters())
 		require.NotNil(t, pw.bloomFilters)
 		require.Empty(t, pw.bloomFilters)
+	})
+
+	t.Run("size_below_min_returns_error", func(t *testing.T) {
+		pw := makeBloomPW(bloomfilter.MinBytes - 1)
+		err := pw.initBloomFilters()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "bloomfiltersize")
+	})
+
+	t.Run("size_above_max_returns_error", func(t *testing.T) {
+		pw := makeBloomPW(bloomfilter.MaxBytes + 1)
+		err := pw.initBloomFilters()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "bloomfiltersize")
+	})
+
+	t.Run("size_at_min_is_valid", func(t *testing.T) {
+		pw := makeBloomPW(bloomfilter.MinBytes)
+		require.NoError(t, pw.initBloomFilters())
+		bf, ok := pw.bloomFilters["root.col"]
+		require.True(t, ok)
+		require.Equal(t, int32(bloomfilter.MinBytes), bf.NumBytes())
+	})
+
+	t.Run("size_at_max_is_valid", func(t *testing.T) {
+		pw := makeBloomPW(bloomfilter.MaxBytes)
+		require.NoError(t, pw.initBloomFilters())
+		bf, ok := pw.bloomFilters["root.col"]
+		require.True(t, ok)
+		require.Equal(t, int32(bloomfilter.MaxBytes), bf.NumBytes())
 	})
 }
 


### PR DESCRIPTION
initBloomFilters now returns an error when a column tag specifies an explicit bloomfiltersize outside [bloomfilter.MinBytes, bloomfilter.MaxBytes] instead of silently clamping the value. All five writer constructors and SetSchemaHandlerFromJSON propagate the error to the caller. Tests added for the boundary and out-of-range cases; existing tests updated to assert no-error on the new return value.