### PR TITLE
use pointer to deal with optional compression level

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ func main() {
 * **Per-Column Codec**: You can specify a compression codec for a specific column using the `compression` tag in your Go struct (e.g., `parquet:"name=col, compression=GZIP"`). If not specified, the file-level default is used.
 * **Levels**: Codecs that support compression levels can be configured on writers using `writer.WithCompressionLevel(codec, level)`. Note that levels are set **per codec at the writer level**; all columns using a specific codec will share the same compression level. Per-column compression levels are not yet supported.
 * **LZ4**: Uses the standard LZ4 frame format with frame headers. This is the legacy Parquet compression type. User-facing levels are mapped via `1 << (8 + level)` to lz4 `CompressionLevel` constants.
-* **LZ4_RAW**: Uses raw LZ4 block compression without framing. This is the preferred LZ4 variant per the Parquet specification. User-facing levels are passed directly to `lz4.CompressorHC`.
+* **LZ4_RAW**: Uses raw LZ4 block compression without framing. This is the preferred LZ4 variant per the Parquet specification. User-facing levels are passed directly to `lz4.CompressorHC`. Level 0 is a valid compression level and is distinct from the default level (9).
 * **Decompression Safety**: All compression codecs enforce decompressed size limits (default 256MB) to prevent decompression bombs. Configure this via `compress.WithMaxDecompressedSize`.
 
 ## CRC Checksum Handling

--- a/internal/compress/brotli.go
+++ b/internal/compress/brotli.go
@@ -51,21 +51,25 @@ func brotliUncompress(buf []byte, maxSize int64) ([]byte, error) {
 	return limitedReadAll(brotliReader, maxSize)
 }
 
-func newBrotliCompressor(level int) (*codec, error) {
+func newBrotliCompressor(level *int) (*codec, error) {
+	l := brotli.DefaultCompression
+	if level != nil {
+		l = *level
+	}
 	// brotli.NewWriterLevel does not return an error, so validate via test encode
-	w := brotli.NewWriterLevel(nil, level)
+	w := brotli.NewWriterLevel(nil, l)
 	var testBuf bytes.Buffer
 	w.Reset(&testBuf)
 	if _, err := w.Write([]byte("test")); err != nil {
-		return nil, fmt.Errorf("invalid brotli compression level %d: %w", level, err)
+		return nil, fmt.Errorf("invalid brotli compression level %d: %w", l, err)
 	}
 	if err := w.Close(); err != nil {
-		return nil, fmt.Errorf("invalid brotli compression level %d: %w", level, err)
+		return nil, fmt.Errorf("invalid brotli compression level %d: %w", l, err)
 	}
 
 	writerPool := sync.Pool{
 		New: func() any {
-			return brotli.NewWriterLevel(nil, level)
+			return brotli.NewWriterLevel(nil, l)
 		},
 	}
 

--- a/internal/compress/compress.go
+++ b/internal/compress/compress.go
@@ -28,7 +28,7 @@ var defaultCodecs = map[parquet.CompressionCodec]*codec{}
 
 // codecFactories maps codecs to functions that create a codec at a given level.
 // Each codec file registers its factory in init() if it supports levels.
-var codecFactories = map[parquet.CompressionCodec]func(level int) (*codec, error){}
+var codecFactories = map[parquet.CompressionCodec]func(level *int) (*codec, error){}
 
 // Compressor provides per-instance compression and decompression for Parquet data.
 // Create instances with NewCompressor. Use DefaultCompressor for default settings.
@@ -42,7 +42,7 @@ type CompressorOption func(*compressorConfig) error
 
 type compressorConfig struct {
 	maxDecompressedSize int64
-	levels              map[parquet.CompressionCodec]int
+	levels              map[parquet.CompressionCodec]*int
 }
 
 // WithMaxDecompressedSize sets the maximum allowed decompressed data size.
@@ -59,7 +59,7 @@ func WithMaxDecompressedSize(size int64) CompressorOption {
 // NewCompressor if the codec does not support levels or the level is invalid.
 func WithCompressionLevel(codec parquet.CompressionCodec, level int) CompressorOption {
 	return func(cfg *compressorConfig) error {
-		cfg.levels[codec] = level
+		cfg.levels[codec] = &level
 		return nil
 	}
 }
@@ -69,7 +69,7 @@ func WithCompressionLevel(codec parquet.CompressionCodec, level int) CompressorO
 func NewCompressor(opts ...CompressorOption) (*Compressor, error) {
 	cfg := &compressorConfig{
 		maxDecompressedSize: DefaultMaxDecompressedSize,
-		levels:              make(map[parquet.CompressionCodec]int),
+		levels:              make(map[parquet.CompressionCodec]*int),
 	}
 	for _, opt := range opts {
 		if err := opt(cfg); err != nil {

--- a/internal/compress/compress_test.go
+++ b/internal/compress/compress_test.go
@@ -96,6 +96,35 @@ func TestCompressLargeData(t *testing.T) {
 	require.Equal(t, largeData, decompressed)
 }
 
+func TestDefaultCompressorCodecRoundTrip(t *testing.T) {
+	testCases := []struct {
+		name  string
+		codec parquet.CompressionCodec
+	}{
+		{"uncompressed", parquet.CompressionCodec_UNCOMPRESSED},
+		{"snappy", parquet.CompressionCodec_SNAPPY},
+		{"gzip", parquet.CompressionCodec_GZIP},
+		{"lz4", parquet.CompressionCodec_LZ4},
+		{"zstd", parquet.CompressionCodec_ZSTD},
+		{"brotli", parquet.CompressionCodec_BROTLI},
+		{"lz4raw", parquet.CompressionCodec_LZ4_RAW},
+	}
+
+	input := bytes.Repeat([]byte("default codec pool initialization test data "), 128)
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			compressed, err := Compress(input, tc.codec)
+			require.NoError(t, err)
+			require.NotNil(t, compressed)
+
+			decompressed, err := Uncompress(compressed, tc.codec)
+			require.NoError(t, err)
+			require.Equal(t, input, decompressed)
+		})
+	}
+}
+
 func TestErrorHandling(t *testing.T) {
 	// Test Uncompress with unsupported codec
 	_, err := Uncompress([]byte{1, 2, 3}, parquet.CompressionCodec(999))
@@ -269,6 +298,7 @@ func TestCompressorCompressionLevelRoundTrip(t *testing.T) {
 		{"zstd-level-22", parquet.CompressionCodec_ZSTD, 22},
 		{"brotli-level-0", parquet.CompressionCodec_BROTLI, 0},
 		{"brotli-level-11", parquet.CompressionCodec_BROTLI, 11},
+		{"lz4raw-level-0", parquet.CompressionCodec_LZ4_RAW, 0},
 		{"lz4raw-level-1", parquet.CompressionCodec_LZ4_RAW, 1},
 		{"lz4raw-level-9", parquet.CompressionCodec_LZ4_RAW, 9},
 		{"lz4-level-1", parquet.CompressionCodec_LZ4, 1},

--- a/internal/compress/gzip.go
+++ b/internal/compress/gzip.go
@@ -23,7 +23,6 @@ func init() {
 	}
 
 	codecFactories[parquet.CompressionCodec_GZIP] = newGZIPCompressor
-
 	defaultCodecs[parquet.CompressionCodec_GZIP] = &codec{
 		compress:   gzipCompress(&gzipWriterPool),
 		uncompress: gzipUncompress,
@@ -81,13 +80,24 @@ func gzipCompressWithLevel(level int) func([]byte) ([]byte, error) {
 	}
 }
 
-func newGZIPCompressor(level int) (*codec, error) {
-	if _, err := gzip.NewWriterLevel(nil, level); err != nil {
+func newGZIPCompressor(level *int) (*codec, error) {
+	l := gzip.DefaultCompression
+	if level != nil {
+		l = *level
+	}
+	if _, err := gzip.NewWriterLevel(nil, l); err != nil {
 		return nil, err
 	}
 
+	pool := &sync.Pool{
+		New: func() any {
+			w, _ := gzip.NewWriterLevel(nil, l)
+			return w
+		},
+	}
+
 	return &codec{
-		compress:   gzipCompressWithLevel(level),
+		compress:   gzipCompress(pool),
 		uncompress: gzipUncompress,
 	}, nil
 }

--- a/internal/compress/lz4.go
+++ b/internal/compress/lz4.go
@@ -74,13 +74,18 @@ func lz4CompressWithLevel(pool *sync.Pool, cl lz4.CompressionLevel) func([]byte)
 	}
 }
 
-func newLZ4Compressor(level int) (*codec, error) {
-	cl := lz4.CompressionLevel(1 << (8 + level))
+func newLZ4Compressor(level *int) (*codec, error) {
+	cl := lz4.CompressionLevel(1 << 12)
+	l := 4
+	if level != nil {
+		l = *level
+		cl = lz4.CompressionLevel(1 << (8 + l))
+	}
 
 	// Validate by creating a writer and applying the option
 	testWriter := lz4.NewWriter(nil)
 	if err := testWriter.Apply(lz4.CompressionLevelOption(cl)); err != nil {
-		return nil, fmt.Errorf("invalid lz4 compression level %d: %w", level, err)
+		return nil, fmt.Errorf("invalid lz4 compression level %d: %w", l, err)
 	}
 
 	writerPool := sync.Pool{

--- a/internal/compress/lz4raw.go
+++ b/internal/compress/lz4raw.go
@@ -61,14 +61,22 @@ func lz4RawUncompress(buf []byte, maxSize int64) ([]byte, error) {
 	}
 }
 
-func newLZ4RawCompressor(level int) (*codec, error) {
-	cl := lz4.CompressionLevel(level)
+func lz4RawCompressionLevel(level *int) lz4.CompressionLevel {
+	l := 9
+	if level != nil {
+		l = *level
+	}
+	return lz4.CompressionLevel(l)
+}
+
+func newLZ4RawCompressor(level *int) (*codec, error) {
+	cl := lz4RawCompressionLevel(level)
 	// Validate via test encode — CompressorHC does not validate level on construction
 	testHC := lz4.CompressorHC{Level: cl}
 	testSrc := []byte("test")
 	testDst := make([]byte, lz4.CompressBlockBound(len(testSrc)))
 	if _, err := testHC.CompressBlock(testSrc, testDst); err != nil {
-		return nil, fmt.Errorf("invalid lz4 raw compression level %d: %w", level, err)
+		return nil, fmt.Errorf("invalid lz4 raw compression level %d: %w", int(cl), err)
 	}
 
 	return &codec{

--- a/internal/compress/lz4raw_test.go
+++ b/internal/compress/lz4raw_test.go
@@ -76,6 +76,46 @@ func TestLz4RawUncompressSizeLimit(t *testing.T) {
 }
 
 func TestLz4RawCompressionLevel(t *testing.T) {
+	t.Run("level 0 round-trip", func(t *testing.T) {
+		c, err := NewCompressor(WithCompressionLevel(parquet.CompressionCodec_LZ4_RAW, 0))
+		require.NoError(t, err)
+
+		input := []byte("test data for lz4 raw level 0 testing")
+		compressed, err := c.Compress(input, parquet.CompressionCodec_LZ4_RAW)
+		require.NoError(t, err)
+		require.NotNil(t, compressed)
+
+		output, err := c.Uncompress(compressed, parquet.CompressionCodec_LZ4_RAW)
+		require.NoError(t, err)
+		require.Equal(t, input, output)
+	})
+
+	t.Run("default level is distinct from explicit level 0", func(t *testing.T) {
+		defaultCodec, err := newLZ4RawCompressor(nil)
+		require.NoError(t, err)
+
+		zero := 0
+		levelZeroCodec, err := newLZ4RawCompressor(&zero)
+		require.NoError(t, err)
+
+		require.Equal(t, 9, int(lz4RawCompressionLevel(nil)))
+		require.Equal(t, 0, int(lz4RawCompressionLevel(&zero)))
+
+		input := []byte("test data for lz4 raw default and level 0 testing")
+		defaultCompressed, err := defaultCodec.compress(input)
+		require.NoError(t, err)
+		levelZeroCompressed, err := levelZeroCodec.compress(input)
+		require.NoError(t, err)
+
+		defaultOutput, err := defaultCodec.uncompress(defaultCompressed, DefaultMaxDecompressedSize)
+		require.NoError(t, err)
+		require.Equal(t, input, defaultOutput)
+
+		levelZeroOutput, err := levelZeroCodec.uncompress(levelZeroCompressed, DefaultMaxDecompressedSize)
+		require.NoError(t, err)
+		require.Equal(t, input, levelZeroOutput)
+	})
+
 	t.Run("valid level round-trip", func(t *testing.T) {
 		c, err := NewCompressor(WithCompressionLevel(parquet.CompressionCodec_LZ4_RAW, 4))
 		require.NoError(t, err)

--- a/internal/compress/zstd.go
+++ b/internal/compress/zstd.go
@@ -50,11 +50,14 @@ func zstdUncompress(dec *zstd.Decoder) func([]byte, int64) ([]byte, error) {
 	}
 }
 
-func newZSTDCompressor(level int) (*codec, error) {
-	enc, err := zstd.NewWriter(nil,
-		zstd.WithEncoderLevel(zstd.EncoderLevelFromZstd(level)),
+func newZSTDCompressor(level *int) (*codec, error) {
+	opts := []zstd.EOption{
 		zstd.WithZeroFrames(true),
-	)
+	}
+	if level != nil {
+		opts = append(opts, zstd.WithEncoderLevel(zstd.EncoderLevelFromZstd(*level)))
+	}
+	enc, err := zstd.NewWriter(nil, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -170,11 +170,11 @@ func (pw *ParquetWriter) initBase(pFile source.ParquetFileWriter, opts ...Writer
 		for codec, level := range pw.compressionLevels {
 			opts = append(opts, compress.WithCompressionLevel(codec, level))
 		}
-		compressor, err := compress.NewCompressor(opts...)
+		c, err := compress.NewCompressor(opts...)
 		if err != nil {
 			return fmt.Errorf("WithCompressionLevel: %w", err)
 		}
-		pw.compressor = compressor
+		pw.compressor = c
 	}
 
 	if _, err := pw.PFile.Write([]byte("PAR1")); err != nil {


### PR DESCRIPTION
0 is a valid compression level for LZ4_RAW and it is not default, so we need to use pointer and nil indicates "using default".