### PR TITLE
make WithKeyRetriever lowest priority for footer key

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,8 @@ TESTDATA_FILES   = $(TESTDATA_DIR)/datapage_v1-uncompressed-checksum.parquet \
                    $(TESTDATA_DIR)/encrypt_columns_and_footer.parquet.encrypted \
                    $(TESTDATA_DIR)/encrypt_columns_and_footer_ctr.parquet.encrypted \
                    $(TESTDATA_DIR)/encrypt_columns_and_footer_disable_aad_storage.parquet.encrypted \
-                   $(TESTDATA_DIR)/encrypt_columns_plaintext_footer.parquet.encrypted
+                   $(TESTDATA_DIR)/encrypt_columns_plaintext_footer.parquet.encrypted \
+                   $(TESTDATA_DIR)/uniform_encryption.parquet.encrypted
 
 # go option
 CGO_ENABLED := 0

--- a/README.md
+++ b/README.md
@@ -31,9 +31,24 @@ All configuration is per-instance via functional options, enabling safe concurre
 
 `WithNP`, `WithCaseInsensitive`, `WithCRCMode`, `WithFooterKey`, `WithColumnKey`, `WithKeyRetriever`, `WithAADPrefix`.
 
-### Reading Encrypted Files
+### Encryption
 
-The reader supports Apache Parquet modular encryption for encrypted footers and plaintext footers signed with AES-GCM. Data page headers, data pages, dictionary pages, column metadata, column indexes, offset indexes, and bloom filter headers/bitsets are decrypted when the footer supplies encryption metadata and the reader is configured with the required keys.
+The reader and writer support Apache Parquet modular encryption for encrypted footers (`PARE`) and plaintext footers signed with AES-GCM (`PAR1`). Page headers, data pages, dictionary pages, column metadata, column indexes, offset indexes, and bloom filter headers/bitsets are encrypted and decrypted when encryption metadata and the required keys are available.
+
+Both reader and writer use the same option names for shared key and AAD concepts:
+
+* `WithFooterKey` sets the footer key used for encrypted footers or plaintext-footer signatures.
+* `WithColumnKey` sets a column key for a dot-separated schema path without the root element, such as `name` or `address.city`. Columns without an explicit column key use the footer key.
+* `WithKeyRetriever` sets a `KeyRetriever` callback for KMS-backed key management. The callback receives the `key_metadata` bytes stored in the file (the KMS key ID) and returns the corresponding key bytes.
+* `WithAADPrefix` supplies the AAD prefix. It is required on read when the file was written with `supply_aad_prefix=true`.
+
+**Without a KMS**, supply keys directly with `WithFooterKey` and `WithColumnKey`. Key metadata is not consulted.
+
+**With a KMS**, `key_metadata` in the file stores the KMS key ID for each key. On read, the key ID is already in the file; the reader passes it to `WithKeyRetriever` automatically.
+
+When both explicit keys and `WithKeyRetriever` are configured, explicit keys always take priority: `WithFooterKey` over the retriever for the footer key, and `WithColumnKey` over the retriever for column keys. `WithKeyRetriever` is only called when no direct key is provided.
+
+### Reading Encrypted Files
 
 Use `WithFooterKey` for files encrypted with a single footer key:
 
@@ -45,17 +60,18 @@ pr, err := reader.NewParquetReader(
 )
 ```
 
-Use `WithColumnKey` for explicit per-column keys, or `WithKeyRetriever` when keys should be resolved from Parquet `key_metadata`. Both can be provided simultaneously — `WithColumnKey` takes priority over `WithKeyRetriever` for column keys, while `WithKeyRetriever` takes priority over `WithFooterKey` for the footer key:
+Use `WithColumnKey` for explicit per-column keys, or `WithKeyRetriever` for KMS-backed key management:
 
 ```go
+keyRetriever := func(keyMetadata []byte) ([]byte, error) {
+    // keyMetadata is the KMS key ID stored in the file by the writer
+    return lookupKey(keyMetadata)
+}
+
 pr, err := reader.NewParquetReader(
     fr,
     new(Student),
-    reader.WithFooterKey(footerKey),
-    reader.WithColumnKey("address.city", cityKey),
-    reader.WithKeyRetriever(func(keyMetadata []byte) ([]byte, error) {
-        return lookupKey(keyMetadata)
-    }),
+    reader.WithKeyRetriever(keyRetriever),
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,33 @@ parquet-go is a pure-go implementation of reading and writing the parquet format
 * Comprehensive encoding support
 * New logical types including geospatial types
 
+## Table of Contents
+
+- [Installation](#installation)
+- [Configuration](#configuration)
+  - [Writer Options](#writer-options)
+  - [Reader Options](#reader-options)
+  - [Encryption](#encryption)
+  - [Reading Encrypted Files](#reading-encrypted-files)
+- [Quick Start](#quick-start)
+  - [Writing Parquet Files](#writing-parquet-files)
+  - [Reading Parquet Files](#reading-parquet-files)
+- [Type System](#type-system)
+- [Encoding Support](#encoding-support)
+- [Compression Support](#compression-support)
+- [CRC Checksum Handling](#crc-checksum-handling)
+- [Repetition Types](#repetition-types)
+- [Schema Definition](#schema-definition)
+- [Writers](#writers)
+- [Readers](#readers)
+- [ParquetFile Interfaces](#parquetfile-interfaces)
+- [GeoParquet: Geospatial Logical Types](#geoparquet-geospatial-logical-types)
+- [Concurrency](#concurrency)
+- [Examples](#examples)
+- [Documentation](#documentation)
+- [Contributing](#contributing)
+- [License](#license)
+
 ## Installation
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -587,6 +587,10 @@ go build -tags example ./example/all_types         # Comprehensive sample
 |[new_logical](example/new_logical)|New logical types (FLOAT16, INTEGER)|
 |[geospatial](example/geospatial)|Geospatial types (GEOMETRY, GEOGRAPHY)|
 |[bloom_filter](example/bloom_filter)|Bloom filter|
+|[encrypt_read](example/encrypt_read)|Read encrypted Parquet file|
+|[encrypt_read_aad](example/encrypt_read_aad)|Read encrypted Parquet file with external AAD prefix|
+|[encrypt_read_plaintext_footer](example/encrypt_read_plaintext_footer)|Read encrypted Parquet file with plaintext footer|
+|[encrypt_read_uniform](example/encrypt_read_uniform)|Read uniformly encrypted Parquet file (single key for footer and all columns)|
 |[datapagev2](example/datapagev2)|Data Page V2|
 |[date](example/date)|Date type|
 |[all_types](example/all_types)|All type support|

--- a/example/encrypt_read_uniform/encrypt_read_uniform.go
+++ b/example/encrypt_read_uniform/encrypt_read_uniform.go
@@ -1,0 +1,81 @@
+//go:build example
+
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hangxie/parquet-go/v3/reader"
+	sourcehttp "github.com/hangxie/parquet-go/v3/source/http"
+)
+
+const fileURL = "https://raw.githubusercontent.com/apache/parquet-testing/master/data/uniform_encryption.parquet.encrypted"
+
+// footerKey is the single key used for both the footer and all column pages.
+// In uniform encryption there are no per-column keys, so WithFooterKey is sufficient.
+var footerKey = []byte("0123456789012345")
+
+// kmsKeys simulates a KMS that maps the key ID embedded in the file to the actual key.
+// For uniform encryption the file stores one key ID ("kf") for the footer and reuses
+// it for every column, so the retriever is called once regardless of column count.
+var kmsKeys = map[string][]byte{
+	"kf": footerKey,
+}
+
+func keyRetriever(keyMetadata []byte) ([]byte, error) {
+	key, ok := kmsKeys[string(keyMetadata)]
+	if !ok {
+		return nil, fmt.Errorf("unknown key ID: %q", string(keyMetadata))
+	}
+	return key, nil
+}
+
+func main() {
+	// Approach 1: supply the footer key directly — one key decrypts everything.
+	readWithFooterKey()
+
+	// Approach 2: use a key retriever — the reader passes the embedded key ID to
+	// the retriever, which looks up the actual key (e.g. from a KMS).
+	readWithKeyRetriever()
+}
+
+func readWithFooterKey() {
+	fr, err := sourcehttp.NewHttpReader(fileURL, false, false, map[string]string{})
+	if err != nil {
+		log.Fatal("open HTTP reader: ", err)
+	}
+	defer fr.Close()
+
+	pr, err := reader.NewParquetReader(fr, nil, reader.WithFooterKey(footerKey))
+	if err != nil {
+		log.Fatal("create parquet reader: ", err)
+	}
+	defer pr.ReadStop()
+
+	rows, err := pr.ReadByNumber(int(pr.GetNumRows()))
+	if err != nil {
+		log.Fatal("read rows: ", err)
+	}
+	log.Printf("WithFooterKey: %d rows", len(rows))
+}
+
+func readWithKeyRetriever() {
+	fr, err := sourcehttp.NewHttpReader(fileURL, false, false, map[string]string{})
+	if err != nil {
+		log.Fatal("open HTTP reader: ", err)
+	}
+	defer fr.Close()
+
+	pr, err := reader.NewParquetReader(fr, nil, reader.WithKeyRetriever(keyRetriever))
+	if err != nil {
+		log.Fatal("create parquet reader: ", err)
+	}
+	defer pr.ReadStop()
+
+	rows, err := pr.ReadByNumber(int(pr.GetNumRows()))
+	if err != nil {
+		log.Fatal("read rows: ", err)
+	}
+	log.Printf("WithKeyRetriever: %d rows", len(rows))
+}

--- a/reader/reader_encryption.go
+++ b/reader/reader_encryption.go
@@ -122,6 +122,10 @@ func readColumnMetaDataFromBytes(buf []byte) (*parquet.ColumnMetaData, error) {
 }
 
 func (pr *ParquetReader) resolveFooterKeyFromMetadata(keyMetadata []byte) ([]byte, error) {
+	if len(pr.footerKey) > 0 {
+		pr.resolvedFooterKey = append(pr.resolvedFooterKey[:0], pr.footerKey...)
+		return pr.footerKey, nil
+	}
 	if pr.keyRetriever != nil {
 		key, err := pr.keyRetriever(keyMetadata)
 		if err != nil {
@@ -132,11 +136,7 @@ func (pr *ParquetReader) resolveFooterKeyFromMetadata(keyMetadata []byte) ([]byt
 			return key, nil
 		}
 	}
-	if len(pr.footerKey) == 0 {
-		return nil, fmt.Errorf("footer decryption key is required")
-	}
-	pr.resolvedFooterKey = append(pr.resolvedFooterKey[:0], pr.footerKey...)
-	return pr.footerKey, nil
+	return nil, fmt.Errorf("footer decryption key is required")
 }
 
 func (pr *ParquetReader) resolveFooterKey() ([]byte, error) {

--- a/reader/reader_encryption_test.go
+++ b/reader/reader_encryption_test.go
@@ -140,6 +140,28 @@ func TestReadFooterDecryptsEncryptedColumnMetadata(t *testing.T) {
 	require.True(t, wantColumnMeta.Equals(pr.Footer.RowGroups[0].Columns[0].MetaData))
 }
 
+func TestReadFooterFooterKeyPrecedence(t *testing.T) {
+	t.Parallel()
+
+	footerKey := []byte("0123456789abcdef")
+	wrongFooterKey := []byte("abcdef0123456789")
+	aadPrefix := []byte("table/part-0")
+	fileUnique := []byte("file-unique")
+	keyMetadata := []byte("footer-key")
+	footer, wantColumnMeta := fileMetaDataWithFooterKeyEncryptedColumnMetadata(t, footerKey, aadPrefix, fileUnique)
+	file := buildEncryptedFooterFileWithKeyMetadata(t, footerKey, keyMetadata, aadPrefix, fileUnique, footer)
+
+	pr := &ParquetReader{PFile: buffer.NewBufferReaderFromBytesNoAlloc(file)}
+	// WithFooterKey wins: retriever returning wrongFooterKey is ignored
+	WithFooterKey(footerKey)(pr)
+	WithKeyRetriever(func([]byte) ([]byte, error) {
+		return wrongFooterKey, nil
+	})(pr)
+
+	require.NoError(t, pr.ReadFooter())
+	require.True(t, wantColumnMeta.Equals(pr.Footer.RowGroups[0].Columns[0].MetaData))
+}
+
 func TestReadFooterReusesRetrievedFooterKeyForColumnMetadata(t *testing.T) {
 	t.Parallel()
 

--- a/reader/reader_interop_test.go
+++ b/reader/reader_interop_test.go
@@ -11,10 +11,11 @@ import (
 )
 
 const (
-	encryptedFooterFile = "../build/testdata/encrypt_columns_and_footer.parquet.encrypted"
-	plaintextFooterFile = "../build/testdata/encrypt_columns_plaintext_footer.parquet.encrypted"
-	aadDisabledFile     = "../build/testdata/encrypt_columns_and_footer_disable_aad_storage.parquet.encrypted"
-	ctrFile             = "../build/testdata/encrypt_columns_and_footer_ctr.parquet.encrypted"
+	encryptedFooterFile  = "../build/testdata/encrypt_columns_and_footer.parquet.encrypted"
+	plaintextFooterFile  = "../build/testdata/encrypt_columns_plaintext_footer.parquet.encrypted"
+	aadDisabledFile      = "../build/testdata/encrypt_columns_and_footer_disable_aad_storage.parquet.encrypted"
+	ctrFile              = "../build/testdata/encrypt_columns_and_footer_ctr.parquet.encrypted"
+	uniformEncryptedFile = "../build/testdata/uniform_encryption.parquet.encrypted"
 )
 
 var encryptionKeys = map[string][]byte{
@@ -157,6 +158,44 @@ func TestInteropCTRMode(t *testing.T) {
 	defer func() { _ = pf.Close() }()
 
 	pr, err := NewParquetReader(pf, nil, WithKeyRetriever(retrieveEncryptionKey))
+	require.NoError(t, err)
+	defer func() { _ = pr.ReadStop() }()
+
+	require.Positive(t, pr.GetNumRows())
+	rows, err := pr.ReadByNumber(int(pr.GetNumRows()))
+	require.NoError(t, err)
+	require.NotEmpty(t, rows)
+}
+
+func TestInteropUniformEncryption_KeyRetriever(t *testing.T) {
+	t.Parallel()
+	encryptedTestdataAvailable(t)
+
+	pf, err := local.NewLocalFileReader(uniformEncryptedFile)
+	require.NoError(t, err)
+	defer func() { _ = pf.Close() }()
+
+	// uniform encryption uses the footer key (kf) for all columns — retriever is called once
+	pr, err := NewParquetReader(pf, nil, WithKeyRetriever(retrieveEncryptionKey))
+	require.NoError(t, err)
+	defer func() { _ = pr.ReadStop() }()
+
+	require.Positive(t, pr.GetNumRows())
+	rows, err := pr.ReadByNumber(int(pr.GetNumRows()))
+	require.NoError(t, err)
+	require.NotEmpty(t, rows)
+}
+
+func TestInteropUniformEncryption_FooterKey(t *testing.T) {
+	t.Parallel()
+	encryptedTestdataAvailable(t)
+
+	pf, err := local.NewLocalFileReader(uniformEncryptedFile)
+	require.NoError(t, err)
+	defer func() { _ = pf.Close() }()
+
+	// uniform encryption: supplying the footer key directly decrypts all columns
+	pr, err := NewParquetReader(pf, nil, WithFooterKey(encryptionKeys["kf"]))
 	require.NoError(t, err)
 	defer func() { _ = pr.ReadStop() }()
 


### PR DESCRIPTION
and test case and example for uniform encryption (footer key used everywhere).