### PR TITLE
refactor: wrap bare return err with context

### DIFF
--- a/common/arrow.go
+++ b/common/arrow.go
@@ -91,7 +91,10 @@ func ArrowColToParquetCol(field arrow.Field, col arrow.Array) ([]any, error) {
 	default:
 		return nil, fmt.Errorf("unsupported Arrow type: %v", field.Type)
 	}
-	return recs, err
+	if err != nil {
+		return nil, fmt.Errorf("convert Arrow column %s: %w", field.Name, err)
+	}
+	return recs, nil
 }
 
 func nonNullableFieldContainsNullError(field arrow.Field, idx int) error {

--- a/common/logicaltype.go
+++ b/common/logicaltype.go
@@ -163,7 +163,7 @@ func newTimeLogicalType(mp map[string]string) (*parquet.TimeType, error) {
 		return nil, fmt.Errorf("parse logicaltype.isadjustedtoutc as boolean: %w", err)
 	}
 	if timeType.Unit, err = newTimeUnitFromString(mp["logicaltype.unit"]); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("parse TIME unit: %w", err)
 	}
 	return timeType, nil
 }
@@ -175,7 +175,7 @@ func newTimestampLogicalType(mp map[string]string) (*parquet.TimestampType, erro
 		return nil, fmt.Errorf("parse logicaltype.isadjustedtoutc as boolean: %w", err)
 	}
 	if timestampType.Unit, err = newTimeUnitFromString(mp["logicaltype.unit"]); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("parse TIMESTAMP unit: %w", err)
 	}
 	return timestampType, nil
 }
@@ -222,7 +222,7 @@ func newGeographyLogicalType(mp map[string]string) (*parquet.GeographyType, erro
 	if algoStr, ok := mp["logicaltype.algorithm"]; ok && algoStr != "" {
 		algo, err := newEdgeInterpolationAlgorithmFromString(algoStr)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("parse GEOGRAPHY algorithm: %w", err)
 		}
 		geographyType.Algorithm = algo
 	}
@@ -248,21 +248,21 @@ func newLogicalTypeFromFieldsMap(mp map[string]string) (*parquet.LogicalType, er
 		logicalType.ENUM = parquet.NewEnumType()
 	case "DECIMAL":
 		if logicalType.DECIMAL, err = newDecimalLogicalType(mp); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("build DECIMAL logical type: %w", err)
 		}
 	case "DATE":
 		logicalType.DATE = parquet.NewDateType()
 	case "TIME":
 		if logicalType.TIME, err = newTimeLogicalType(mp); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("build TIME logical type: %w", err)
 		}
 	case "TIMESTAMP":
 		if logicalType.TIMESTAMP, err = newTimestampLogicalType(mp); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("build TIMESTAMP logical type: %w", err)
 		}
 	case "INTEGER":
 		if logicalType.INTEGER, err = newIntegerLogicalType(mp); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("build INTEGER logical type: %w", err)
 		}
 	case "JSON":
 		logicalType.JSON = parquet.NewJsonType()
@@ -274,15 +274,15 @@ func newLogicalTypeFromFieldsMap(mp map[string]string) (*parquet.LogicalType, er
 		logicalType.FLOAT16 = parquet.NewFloat16Type()
 	case "VARIANT":
 		if logicalType.VARIANT, err = newVariantLogicalType(mp); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("build VARIANT logical type: %w", err)
 		}
 	case "GEOMETRY":
 		if logicalType.GEOMETRY, err = newGeometryLogicalType(mp); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("build GEOMETRY logical type: %w", err)
 		}
 	case "GEOGRAPHY":
 		if logicalType.GEOGRAPHY, err = newGeographyLogicalType(mp); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("build GEOGRAPHY logical type: %w", err)
 		}
 	default:
 		return nil, fmt.Errorf("unknown logicaltype: %s", val)

--- a/common/tag_schema.go
+++ b/common/tag_schema.go
@@ -103,7 +103,7 @@ func NewSchemaElementFromTagMap(info *Tag) (*parquet.SchemaElement, error) {
 	}
 
 	if err := ValidateSchemaElement(schema); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("validate schema element: %w", err)
 	}
 
 	return schema, nil
@@ -178,7 +178,7 @@ func validateLogicalType(schema *parquet.SchemaElement) error {
 		}
 	}
 	if err := validateLogicalTime(lt, schema.Type); err != nil {
-		return err
+		return fmt.Errorf("validate logical TIME: %w", err)
 	}
 	if lt.TIMESTAMP != nil {
 		if *schema.Type != parquet.Type_INT64 {
@@ -226,11 +226,11 @@ func ValidateSchemaElement(schema *parquet.SchemaElement) error {
 	}
 
 	if err := validateLogicalType(schema); err != nil {
-		return err
+		return fmt.Errorf("validate logical type: %w", err)
 	}
 
 	if err := validateConvertedType(schema); err != nil {
-		return err
+		return fmt.Errorf("validate converted type: %w", err)
 	}
 
 	return nil

--- a/internal/bloomfilter/read.go
+++ b/internal/bloomfilter/read.go
@@ -81,7 +81,7 @@ func ReadEncryptedBloomFilter(r io.ReadSeeker, offset int64, opt ReadOptions) (*
 	}
 	header, err := readBloomFilterHeader(bytes.NewReader(headerBytes))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("decode decrypted bloom filter header: %w", err)
 	}
 	if header.NumBytes <= 0 {
 		return nil, fmt.Errorf("invalid bloom filter header: numBytes=%d", header.NumBytes)

--- a/internal/compress/compress.go
+++ b/internal/compress/compress.go
@@ -73,7 +73,7 @@ func NewCompressor(opts ...CompressorOption) (*Compressor, error) {
 	}
 	for _, opt := range opts {
 		if err := opt(cfg); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("apply compressor option: %w", err)
 		}
 	}
 
@@ -150,7 +150,7 @@ func (c *Compressor) UncompressWithExpectedSize(buf []byte, codec parquet.Compre
 
 	result, err := c.Uncompress(buf, codec)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("uncompress %v: %w", codec, err)
 	}
 
 	if int64(len(result)) != expectedSize {
@@ -188,7 +188,7 @@ func limitedReadAll(r io.Reader, maxSize int64) ([]byte, error) {
 	limited := io.LimitReader(r, maxSize+1)
 	data, err := io.ReadAll(limited)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("read decompressed data: %w", err)
 	}
 
 	if int64(len(data)) > maxSize {

--- a/internal/compress/gzip.go
+++ b/internal/compress/gzip.go
@@ -52,7 +52,7 @@ func gzipUncompress(buf []byte, maxSize int64) ([]byte, error) {
 	rbuf := bytes.NewReader(buf)
 	gzipReader, err := gzip.NewReader(rbuf)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("gzip reader: %w", err)
 	}
 	defer func() {
 		_ = gzipReader.Close()
@@ -86,7 +86,7 @@ func newGZIPCompressor(level *int) (*codec, error) {
 		l = *level
 	}
 	if _, err := gzip.NewWriterLevel(nil, l); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("validate gzip level %d: %w", l, err)
 	}
 
 	pool := &sync.Pool{

--- a/internal/compress/lz4raw.go
+++ b/internal/compress/lz4raw.go
@@ -55,7 +55,7 @@ func lz4RawUncompress(buf []byte, maxSize int64) ([]byte, error) {
 			continue
 		}
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("lz4 decompress: %w", err)
 		}
 		return nil, fmt.Errorf("lz4 decompression failed unexpectedly")
 	}

--- a/internal/compress/snappy.go
+++ b/internal/compress/snappy.go
@@ -29,7 +29,7 @@ func init() {
 			}
 			result, err := snappy.Decode(nil, buf)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("snappy decode: %w", err)
 			}
 			return result, nil
 		},

--- a/internal/compress/zstd.go
+++ b/internal/compress/zstd.go
@@ -38,7 +38,7 @@ func zstdUncompress(dec *zstd.Decoder) func([]byte, int64) ([]byte, error) {
 
 		result, err := dec.DecodeAll(buf, nil)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("zstd decode: %w", err)
 		}
 
 		// Fallback for frames without content size in header (HasFCS=false)
@@ -59,7 +59,7 @@ func newZSTDCompressor(level *int) (*codec, error) {
 	}
 	enc, err := zstd.NewWriter(nil, opts...)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("create zstd encoder: %w", err)
 	}
 	dec, _ := zstd.NewReader(nil)
 	return &codec{

--- a/internal/encryption/decrypt.go
+++ b/internal/encryption/decrypt.go
@@ -55,7 +55,7 @@ func DecryptGCM(key, aad, module []byte) ([]byte, error) {
 	}
 	gcm, err := newGCMCipher(key)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("init AES-GCM cipher: %w", err)
 	}
 	nonce := module[:gcmNonceSize]
 	ciphertextAndTag := module[gcmNonceSize:]
@@ -78,7 +78,7 @@ func VerifyGCMTag(key, aad, nonce, plaintext, tag []byte) error {
 	}
 	gcm, err := newGCMCipher(key)
 	if err != nil {
-		return err
+		return fmt.Errorf("init AES-GCM cipher: %w", err)
 	}
 	// gcm.Seal re-encrypts the plaintext to derive the tag for comparison.
 	// Go's cipher.AEAD interface has no tag-only (GHASH-only) path, so the
@@ -99,7 +99,7 @@ func DecryptCTR(key, module []byte) ([]byte, error) {
 	}
 	block, err := newAESBlock(key)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("init AES block: %w", err)
 	}
 	iv := make([]byte, aes.BlockSize)
 	copy(iv, module[:ctrNonceSize])
@@ -131,7 +131,7 @@ func newAESBlock(key []byte) (cipher.Block, error) {
 func newGCMCipher(key []byte) (cipher.AEAD, error) {
 	block, err := newAESBlock(key)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("init AES block: %w", err)
 	}
 	gcm, err := cipher.NewGCMWithNonceSize(block, gcmNonceSize)
 	if err != nil {

--- a/internal/encryption/encrypt.go
+++ b/internal/encryption/encrypt.go
@@ -13,11 +13,11 @@ import (
 func EncryptGCM(key, aad, plaintext []byte) ([]byte, error) {
 	gcm, err := newGCMCipher(key)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("init AES-GCM cipher: %w", err)
 	}
 	nonce, err := randomNonce(gcmNonceSize)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("GCM nonce: %w", err)
 	}
 	module := append([]byte{}, nonce...)
 	module = gcm.Seal(module, nonce, plaintext, aad)
@@ -29,11 +29,11 @@ func EncryptGCM(key, aad, plaintext []byte) ([]byte, error) {
 func SignGCM(key, aad, plaintext []byte) ([]byte, error) {
 	gcm, err := newGCMCipher(key)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("init AES-GCM cipher: %w", err)
 	}
 	nonce, err := randomNonce(gcmNonceSize)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("GCM nonce: %w", err)
 	}
 	// gcm.Seal encrypts the full plaintext; only the appended tag is kept.
 	// Go's cipher.AEAD interface has no tag-only (GHASH-only) path, so the
@@ -51,11 +51,11 @@ func SignGCM(key, aad, plaintext []byte) ([]byte, error) {
 func EncryptCTR(key, plaintext []byte) ([]byte, error) {
 	block, err := newAESBlock(key)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("init AES block: %w", err)
 	}
 	nonce, err := randomNonce(ctrNonceSize)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("CTR nonce: %w", err)
 	}
 	iv := make([]byte, aes.BlockSize)
 	copy(iv, nonce)

--- a/internal/layout/chunk.go
+++ b/internal/layout/chunk.go
@@ -92,11 +92,11 @@ func populateStatistics(metaData *parquet.ColumnMetaData, pT *parquet.Type, minV
 	}
 	tmpBufMax, err := encoding.WritePlain([]any{maxVal}, *pT)
 	if err != nil {
-		return err
+		return fmt.Errorf("encode chunk max statistic: %w", err)
 	}
 	tmpBufMin, err := encoding.WritePlain([]any{minVal}, *pT)
 	if err != nil {
-		return err
+		return fmt.Errorf("encode chunk min statistic: %w", err)
 	}
 	if *pT == parquet.Type_BYTE_ARRAY {
 		tmpBufMax = tmpBufMax[4:]
@@ -113,7 +113,7 @@ func populateStatistics(metaData *parquet.ColumnMetaData, pT *parquet.Type, minV
 func pagesToChunk(pages []*Page, hasDictPage bool) (*Chunk, error) {
 	metadataPageIdx, statsStartIdx, err := validatePagesAndGetMetadataIdx(pages, hasDictPage)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("validate pages: %w", err)
 	}
 	if pages == nil || (hasDictPage && len(pages) < 2) {
 		return nil, nil
@@ -140,7 +140,7 @@ func pagesToChunk(pages []*Page, hasDictPage bool) (*Chunk, error) {
 	metaData.PathInSchema = pages[metadataPageIdx].Path
 
 	if err := populateStatistics(metaData, pT, minVal, maxVal, nullCount, omitStats); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("populate chunk statistics: %w", err)
 	}
 
 	// Aggregate geospatial statistics from pages

--- a/internal/layout/chunk_test.go
+++ b/internal/layout/chunk_test.go
@@ -9,6 +9,29 @@ import (
 	"github.com/hangxie/parquet-go/v3/parquet"
 )
 
+// TestPopulateStatistics_EncodeErrors exercises the wrapped error paths for
+// max- and min-value encoding when the value type does not match the parquet
+// type (WritePlain returns a type-assertion error).
+func TestPopulateStatistics_EncodeErrors(t *testing.T) {
+	pT := common.ToPtr(parquet.Type_INT32)
+
+	t.Run("max_encode_error", func(t *testing.T) {
+		meta := parquet.NewColumnMetaData()
+		// maxVal is a string but the type is INT32, so WritePlain fails.
+		err := populateStatistics(meta, pT, int32(1), "not-an-int", 0, false)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "encode chunk max statistic")
+	})
+
+	t.Run("min_encode_error", func(t *testing.T) {
+		meta := parquet.NewColumnMetaData()
+		// maxVal is valid INT32, but minVal is a string, so the min encode fails.
+		err := populateStatistics(meta, pT, "not-an-int", int32(1), 0, false)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "encode chunk min statistic")
+	})
+}
+
 func TestDecodeDictChunk(t *testing.T) {
 	// Create a chunk with dictionary and data pages
 	dictPage := NewDictPage()

--- a/internal/layout/dictpage.go
+++ b/internal/layout/dictpage.go
@@ -42,10 +42,10 @@ func DictRecToDictPageWithOption(dictRec *DictRecType, opt PageWriteOption) (*Pa
 
 	compressedData, err := page.dictPageCompress(opt.CompressType, dictRec.Type, opt.Compressor)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, fmt.Errorf("compress dictionary page: %w", err)
 	}
 	if err = serializePage(page, opt, compressedData); err != nil {
-		return nil, 0, err
+		return nil, 0, fmt.Errorf("serialize dictionary page: %w", err)
 	}
 	totSize += int64(len(page.RawData))
 	return page, totSize, nil
@@ -54,11 +54,11 @@ func DictRecToDictPageWithOption(dictRec *DictRecType, opt PageWriteOption) (*Pa
 func (page *Page) dictPageCompress(compressType parquet.CompressionCodec, pT parquet.Type, c *compress.Compressor) ([]byte, error) {
 	dataBuf, err := encoding.WritePlain(page.DataTable.Values, pT)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("encode dictionary values: %w", err)
 	}
 	dataEncodeBuf, err := resolveCompressor(c).Compress(dataBuf, compressType)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("compress dictionary buffer: %w", err)
 	}
 
 	page.Header = parquet.NewPageHeader()
@@ -95,7 +95,7 @@ func scanDictPageValues(table *Table, dictRec *DictRecType, startIdx int, pageSi
 	for r.endIdx < totalLn && r.size < pageSize {
 		if table.Values[r.endIdx] == nil {
 			if err := checkRequiredNil(table, r.endIdx); err != nil {
-				return r, err
+				return r, fmt.Errorf("dictionary scan index %d: %w", r.endIdx, err)
 			}
 			r.nullCount++
 			r.endIdx++
@@ -157,7 +157,7 @@ func TableToDictDataPagesWithOption(dictRec *DictRecType, table *Table, bitWidth
 
 		scan, err := scanDictPageValues(table, dictRec, i, opt.PageSize, omitStats, funcTable)
 		if err != nil {
-			return nil, 0, err
+			return nil, 0, fmt.Errorf("scan dict page values at %d: %w", i, err)
 		}
 
 		page := NewDataPage()
@@ -190,10 +190,10 @@ func TableToDictDataPagesWithOption(dictRec *DictRecType, table *Table, bitWidth
 
 		compressedData, compressErr := page.dictDataPageCompress(opt.CompressType, bitWidth, scan.values, opt.Compressor)
 		if compressErr != nil {
-			return nil, 0, compressErr
+			return nil, 0, fmt.Errorf("compress dict data page: %w", compressErr)
 		}
 		if err = serializePage(page, opt, compressedData); err != nil {
-			return nil, 0, err
+			return nil, 0, fmt.Errorf("serialize dict data page: %w", err)
 		}
 
 		totSize += int64(len(page.RawData))
@@ -215,7 +215,7 @@ func (page *Page) dictDataPageCompress(compressType parquet.CompressionCodec, bi
 			int32(bits.Len32(uint32(page.DataTable.MaxDefinitionLevel))),
 		)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("encode definition levels: %w", err)
 		}
 	}
 
@@ -226,7 +226,7 @@ func (page *Page) dictDataPageCompress(compressType parquet.CompressionCodec, bi
 			int32(bits.Len32(uint32(page.DataTable.MaxRepetitionLevel))),
 		)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("encode repetition levels: %w", err)
 		}
 	}
 
@@ -238,7 +238,7 @@ func (page *Page) dictDataPageCompress(compressType parquet.CompressionCodec, bi
 
 	dataEncodeBuf, err := resolveCompressor(c).Compress(dataBuf, compressType)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("compress dict data: %w", err)
 	}
 
 	page.Header = parquet.NewPageHeader()
@@ -255,7 +255,7 @@ func (page *Page) dictDataPageCompress(compressType parquet.CompressionCodec, bi
 	if page.MaxVal != nil {
 		tmpBuf, err := encoding.WritePlain([]any{page.MaxVal}, *page.Schema.Type)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("encode dict page max statistic: %w", err)
 		}
 		if *page.Schema.Type == parquet.Type_BYTE_ARRAY {
 			tmpBuf = tmpBuf[4:]
@@ -266,7 +266,7 @@ func (page *Page) dictDataPageCompress(compressType parquet.CompressionCodec, bi
 	if page.MinVal != nil {
 		tmpBuf, err := encoding.WritePlain([]any{page.MinVal}, *page.Schema.Type)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("encode dict page min statistic: %w", err)
 		}
 		if *page.Schema.Type == parquet.Type_BYTE_ARRAY {
 			tmpBuf = tmpBuf[4:]

--- a/internal/layout/page_read.go
+++ b/internal/layout/page_read.go
@@ -68,7 +68,7 @@ func ReadPageRawData(thriftReader *thrift.TBufferedTransport, schemaHandler *sch
 
 	pageHeader, err := readPageHeader(thriftReader, opt)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("read page header: %w", err)
 	}
 
 	var page *Page
@@ -88,12 +88,12 @@ func ReadPageRawData(thriftReader *thrift.TBufferedTransport, schemaHandler *sch
 	if opt.Decryptor != nil {
 		buf, err = readEncryptedPageBody(thriftReader, pageHeader, opt)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("read encrypted page body: %w", err)
 		}
 	} else {
 		buf = make([]byte, compressedPageSize)
 		if _, err := io.ReadFull(thriftReader, buf); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("read page body: %w", err)
 		}
 	}
 
@@ -220,8 +220,10 @@ func (p *Page) processDataPage(schemaHandler *schema.SchemaHandler, encodingType
 func ReadPageHeader(thriftReader *thrift.TBufferedTransport) (*parquet.PageHeader, error) {
 	protocol := thrift.NewTCompactProtocolConf(thriftReader, &thrift.TConfiguration{})
 	pageHeader := parquet.NewPageHeader()
-	err := pageHeader.Read(context.TODO(), protocol)
-	return pageHeader, err
+	if err := pageHeader.Read(context.TODO(), protocol); err != nil {
+		return pageHeader, fmt.Errorf("decode page header: %w", err)
+	}
+	return pageHeader, nil
 }
 
 func readPageHeader(thriftReader *thrift.TBufferedTransport, opt PageReadOptions) (*parquet.PageHeader, error) {
@@ -230,11 +232,11 @@ func readPageHeader(thriftReader *thrift.TBufferedTransport, opt PageReadOptions
 	}
 	module, err := encryption.ReadModule(thriftReader, opt.MaxPageSize)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("read encrypted page header module: %w", err)
 	}
 	pageHeader, err := decryptPageHeader(module, opt.Decryptor)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("decrypt page header: %w", err)
 	}
 	return pageHeader, nil
 }
@@ -251,7 +253,7 @@ func ReadPage(thriftReader *thrift.TBufferedTransport, schemaHandler *schema.Sch
 
 	pageHeader, err := readPageHeader(thriftReader, opt)
 	if err != nil {
-		return nil, 0, 0, err
+		return nil, 0, 0, fmt.Errorf("read page header: %w", err)
 	}
 
 	compressedPageSize := pageHeader.GetCompressedPageSize()
@@ -266,7 +268,7 @@ func ReadPage(thriftReader *thrift.TBufferedTransport, schemaHandler *schema.Sch
 		buf, err = readPageV1Data(thriftReader, pageHeader, colMetaData, opt.Compressor, opt)
 	}
 	if err != nil {
-		return nil, 0, 0, err
+		return nil, 0, 0, fmt.Errorf("read page data: %w", err)
 	}
 
 	path := make([]string, 0)
@@ -278,7 +280,7 @@ func ReadPage(thriftReader *thrift.TBufferedTransport, schemaHandler *schema.Sch
 	case parquet.PageType_DICTIONARY_PAGE:
 		page, err := readDictionaryPageBody(pageHeader, buf, path, name, schemaHandler, colMetaData)
 		if err != nil {
-			return nil, 0, 0, err
+			return nil, 0, 0, fmt.Errorf("read dictionary page body: %w", err)
 		}
 		return page, 0, 0, nil
 	case parquet.PageType_DATA_PAGE, parquet.PageType_DATA_PAGE_V2:
@@ -286,7 +288,10 @@ func ReadPage(thriftReader *thrift.TBufferedTransport, schemaHandler *schema.Sch
 		if err == nil && opt.Decryptor != nil {
 			opt.Decryptor.PageOrdinal++
 		}
-		return page, numValues, numRows, err
+		if err != nil {
+			return page, numValues, numRows, fmt.Errorf("read data page body: %w", err)
+		}
+		return page, numValues, numRows, nil
 	case parquet.PageType_INDEX_PAGE:
 		return nil, 0, 0, fmt.Errorf("unsupported page type: INDEX_PAGE")
 	default:

--- a/internal/layout/page_read_body.go
+++ b/internal/layout/page_read_body.go
@@ -31,7 +31,7 @@ func readPageV2Data(thriftReader *thrift.TBufferedTransport, pageHeader *parquet
 	if opt.Decryptor != nil {
 		plain, err := readEncryptedPageBody(thriftReader, pageHeader, opt)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("read encrypted v2 body: %w", err)
 		}
 		if int32(len(plain)) < rll+dll {
 			return nil, fmt.Errorf("ReadPage: decrypted data page v2 body too small")
@@ -45,13 +45,13 @@ func readPageV2Data(thriftReader *thrift.TBufferedTransport, pageHeader *parquet
 		dataBuf = make([]byte, compressedPageSize-rll-dll)
 
 		if _, err := io.ReadFull(thriftReader, repetitionLevelsBuf); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("read v2 repetition levels: %w", err)
 		}
 		if _, err := io.ReadFull(thriftReader, definitionLevelsBuf); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("read v2 definition levels: %w", err)
 		}
 		if _, err := io.ReadFull(thriftReader, dataBuf); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("read v2 data: %w", err)
 		}
 	}
 
@@ -63,7 +63,7 @@ func readPageV2Data(thriftReader *thrift.TBufferedTransport, pageHeader *parquet
 		expectedDataSize := int64(pageHeader.GetUncompressedPageSize()) - int64(rll) - int64(dll)
 		var err error
 		if dataBuf, err = resolveCompressor(c).UncompressWithExpectedSize(dataBuf, colMetaData.GetCodec(), expectedDataSize); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("decompress v2 data: %w", err)
 		}
 	}
 
@@ -76,7 +76,7 @@ func assembleLevelPrefixedBuf(rll, dll int32, repBuf, defBuf, dataBuf []byte) ([
 	if rll > 0 {
 		tmpBuf, err := encoding.WritePlainINT32([]any{int32(rll)})
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("encode repetition level length: %w", err)
 		}
 		buf = append(buf, tmpBuf...)
 		buf = append(buf, repBuf...)
@@ -84,7 +84,7 @@ func assembleLevelPrefixedBuf(rll, dll int32, repBuf, defBuf, dataBuf []byte) ([
 	if dll > 0 {
 		tmpBuf, err := encoding.WritePlainINT32([]any{int32(dll)})
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("encode definition level length: %w", err)
 		}
 		buf = append(buf, tmpBuf...)
 		buf = append(buf, defBuf...)
@@ -100,12 +100,12 @@ func readPageV1Data(thriftReader *thrift.TBufferedTransport, pageHeader *parquet
 	if opt.Decryptor != nil {
 		buf, err = readEncryptedPageBody(thriftReader, pageHeader, opt)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("read encrypted page body: %w", err)
 		}
 	} else {
 		buf = make([]byte, pageHeader.GetCompressedPageSize())
 		if _, err := io.ReadFull(thriftReader, buf); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("read page body: %w", err)
 		}
 	}
 	if err := common.ValidatePageCRC(pageHeader.IsSetCrc(), pageHeader.GetCrc(), opt.CRCMode, buf); err != nil {
@@ -128,7 +128,7 @@ func readDictionaryPageBody(pageHeader *parquet.PageHeader, buf []byte, path []s
 	table.Values, err = encoding.ReadPlain(bytes.NewReader(buf), colMetaData.GetType(),
 		uint64(pageHeader.DictionaryPageHeader.GetNumValues()), uint64(bitWidth))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("decode dictionary values: %w", err)
 	}
 	page.DataTable = table
 	return page, nil
@@ -152,11 +152,11 @@ func readDataPageBody(pageHeader *parquet.PageHeader, buf []byte, path []string,
 	bytesReader := bytes.NewReader(buf)
 	repetitionLevels, err := readLevelValues(bytesReader, maxRepetitionLevel, numValues)
 	if err != nil {
-		return nil, 0, 0, err
+		return nil, 0, 0, fmt.Errorf("read repetition levels: %w", err)
 	}
 	definitionLevels, err := readLevelValues(bytesReader, maxDefinitionLevel, numValues)
 	if err != nil {
-		return nil, 0, 0, err
+		return nil, 0, 0, fmt.Errorf("read definition levels: %w", err)
 	}
 
 	var numNulls uint64 = 0
@@ -174,7 +174,7 @@ func readDataPageBody(pageHeader *parquet.PageHeader, buf []byte, path []string,
 	values, err := ReadDataPageValues(bytesReader, encodingType, colMetaData.GetType(), ct,
 		uint64(len(definitionLevels))-numNulls, uint64(se.GetTypeLength()))
 	if err != nil {
-		return nil, 0, 0, err
+		return nil, 0, 0, fmt.Errorf("read data page values: %w", err)
 	}
 
 	table := new(Table)

--- a/internal/layout/page_read_encryption.go
+++ b/internal/layout/page_read_encryption.go
@@ -42,7 +42,7 @@ func decryptPageHeader(module []byte, decryptor *PageDecryptor) (*parquet.PageHe
 		}
 		pageHeader, err := readPageHeaderFromBytes(plain)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("decode decrypted page header: %w", err)
 		}
 		if pageHeader.GetType() == parquet.PageType_DATA_PAGE || pageHeader.GetType() == parquet.PageType_DATA_PAGE_V2 {
 			return pageHeader, nil
@@ -59,7 +59,7 @@ func readPageHeaderFromBytes(buf []byte) (*parquet.PageHeader, error) {
 	protocol := thrift.NewTCompactProtocolConf(thrift.NewStreamTransportR(bytes.NewReader(buf)), &thrift.TConfiguration{})
 	pageHeader := parquet.NewPageHeader()
 	if err := pageHeader.Read(context.TODO(), protocol); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("decode page header: %w", err)
 	}
 	return pageHeader, nil
 }
@@ -67,7 +67,7 @@ func readPageHeaderFromBytes(buf []byte) (*parquet.PageHeader, error) {
 func readEncryptedPageBody(thriftReader *thrift.TBufferedTransport, pageHeader *parquet.PageHeader, opt PageReadOptions) ([]byte, error) {
 	module, err := encryption.ReadModule(thriftReader, opt.MaxPageSize)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("read encrypted page module: %w", err)
 	}
 
 	moduleType := encryptedPageModuleType(pageHeader)

--- a/internal/layout/page_read_levels.go
+++ b/internal/layout/page_read_levels.go
@@ -29,20 +29,20 @@ func (p *Page) extractV2LevelBuffers() ([]byte, error) {
 	repetitionLevelsBuf, definitionLevelsBuf := make([]byte, rll), make([]byte, dll)
 	dataBuf := make([]byte, len(p.RawData)-int(rll)-int(dll))
 	if _, err := bytesReader.Read(repetitionLevelsBuf); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("read v2 repetition levels: %w", err)
 	}
 	if _, err := bytesReader.Read(definitionLevelsBuf); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("read v2 definition levels: %w", err)
 	}
 	if _, err := bytesReader.Read(dataBuf); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("read v2 data: %w", err)
 	}
 
 	buf := make([]byte, 0)
 	if rll > 0 {
 		tmpBuf, err := encoding.WritePlainINT32([]any{int32(rll)})
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("encode repetition level length: %w", err)
 		}
 		buf = append(buf, tmpBuf...)
 		buf = append(buf, repetitionLevelsBuf...)
@@ -50,7 +50,7 @@ func (p *Page) extractV2LevelBuffers() ([]byte, error) {
 	if dll > 0 {
 		tmpBuf, err := encoding.WritePlainINT32([]any{int32(dll)})
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("encode definition level length: %w", err)
 		}
 		buf = append(buf, tmpBuf...)
 		buf = append(buf, definitionLevelsBuf...)
@@ -65,7 +65,7 @@ func readLevelValues(bytesReader *bytes.Reader, maxLevel int32, numValues uint64
 		bitWidth := uint64(bits.Len32(uint32(maxLevel)))
 		levels, err := ReadDataPageValues(bytesReader, parquet.Encoding_RLE, parquet.Type_INT64, -1, numValues, bitWidth)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("decode level values: %w", err)
 		}
 		if uint64(len(levels)) > numValues {
 			levels = levels[:numValues]
@@ -87,7 +87,7 @@ func (p *Page) GetRLDLFromRawData(schemaHandler *schema.SchemaHandler) (int64, i
 	if p.Header.GetType() == parquet.PageType_DATA_PAGE_V2 {
 		buf, err = p.extractV2LevelBuffers()
 		if err != nil {
-			return 0, 0, err
+			return 0, 0, fmt.Errorf("extract v2 level buffers: %w", err)
 		}
 	} else if p.CompressType != parquet.CompressionCodec_UNCOMPRESSED {
 		buf, err = resolveCompressor(p.compressor).UncompressWithExpectedSize(p.RawData, p.CompressType, int64(p.Header.GetUncompressedPageSize()))
@@ -126,11 +126,11 @@ func (p *Page) decodeDataPageLevels(buf []byte, schemaHandler *schema.SchemaHand
 	bytesReader := bytes.NewReader(buf)
 	repetitionLevels, err := readLevelValues(bytesReader, maxRepetitionLevel, numValues)
 	if err != nil {
-		return 0, 0, err
+		return 0, 0, fmt.Errorf("read repetition levels: %w", err)
 	}
 	definitionLevels, err := readLevelValues(bytesReader, maxDefinitionLevel, numValues)
 	if err != nil {
-		return 0, 0, err
+		return 0, 0, fmt.Errorf("read definition levels: %w", err)
 	}
 
 	table := new(Table)

--- a/internal/layout/page_read_values.go
+++ b/internal/layout/page_read_values.go
@@ -94,22 +94,22 @@ func ReadDataPageValues(bytesReader *bytes.Reader, encodingMethod parquet.Encodi
 	case parquet.Encoding_PLAIN_DICTIONARY, parquet.Encoding_RLE_DICTIONARY:
 		b, err := bytesReader.ReadByte()
 		if err != nil {
-			return res, err
+			return res, fmt.Errorf("read dictionary bit width: %w", err)
 		}
 		bitWidth = uint64(b)
 
 		buf, err := encoding.ReadRLEBitPackedHybrid(bytesReader, bitWidth, uint64(bytesReader.Len()))
 		if err != nil {
-			return res, err
+			return res, fmt.Errorf("decode dictionary indices: %w", err)
 		}
 		if uint64(len(buf)) < cnt {
 			return res, fmt.Errorf("expected %d values but got %d from RLE/bit-packed hybrid decoder", cnt, len(buf))
 		}
-		return buf[:cnt], err
+		return buf[:cnt], nil
 	case parquet.Encoding_RLE:
 		values, err := encoding.ReadRLEBitPackedHybrid(bytesReader, bitWidth, 0)
 		if err != nil {
-			return res, err
+			return res, fmt.Errorf("decode RLE values: %w", err)
 		}
 		if uint64(len(values)) < cnt {
 			return res, fmt.Errorf("expected %d values but got %d from RLE/bit-packed hybrid decoder", cnt, len(values))
@@ -119,7 +119,7 @@ func ReadDataPageValues(bytesReader *bytes.Reader, encodingMethod parquet.Encodi
 	case parquet.Encoding_BIT_PACKED:
 		values, err := encoding.ReadBitPackedCount(bytesReader, cnt, bitWidth)
 		if err != nil {
-			return res, err
+			return res, fmt.Errorf("decode bit-packed values: %w", err)
 		}
 		convertRLEValuesForType(values, dataType)
 		return values, nil

--- a/internal/layout/page_write.go
+++ b/internal/layout/page_write.go
@@ -35,7 +35,7 @@ func serializePage(page *Page, opt PageWriteOption, compressedData ...[]byte) er
 	ts.Protocol = thrift.NewTCompactProtocolFactoryConf(&thrift.TConfiguration{}).GetProtocol(ts.Transport)
 	pageHeaderBuf, err := ts.Write(context.TODO(), page.Header)
 	if err != nil {
-		return err
+		return fmt.Errorf("serialize page header: %w", err)
 	}
 
 	for _, d := range compressedData {
@@ -68,7 +68,7 @@ func scanPageValues(table *Table, startIdx int, pageSize int32, omitStats bool, 
 	for r.endIdx < totalLn && r.size < pageSize {
 		if table.Values[r.endIdx] == nil {
 			if err := checkRequiredNil(table, r.endIdx); err != nil {
-				return r, err
+				return r, fmt.Errorf("page scan index %d: %w", r.endIdx, err)
 			}
 			r.nullCount++
 			r.endIdx++
@@ -114,13 +114,13 @@ func compressAndSerializePage(page *Page, opt PageWriteOption) error {
 	if opt.DataPageVersion == 2 {
 		repLevels, defLevels, compressedValues, err := page.dataPageV2Compress(opt.CompressType, opt.Compressor)
 		if err != nil {
-			return err
+			return fmt.Errorf("compress data page v2: %w", err)
 		}
 		return serializePage(page, opt, repLevels, defLevels, compressedValues)
 	}
 	compressedData, err := page.dataPageCompress(opt.CompressType, opt.Compressor)
 	if err != nil {
-		return err
+		return fmt.Errorf("compress data page: %w", err)
 	}
 	return serializePage(page, opt, compressedData)
 }
@@ -143,7 +143,7 @@ func TableToDataPagesWithOption(table *Table, opt PageWriteOption) ([]*Page, int
 
 		scan, err := scanPageValues(table, i, opt.PageSize, omitStats, funcTable)
 		if err != nil {
-			return nil, 0, err
+			return nil, 0, fmt.Errorf("scan page values at %d: %w", i, err)
 		}
 
 		page := NewDataPage()
@@ -170,7 +170,7 @@ func TableToDataPagesWithOption(table *Table, opt PageWriteOption) ([]*Page, int
 		page.computeLevelHistograms()
 
 		if err = compressAndSerializePage(page, opt); err != nil {
-			return nil, 0, err
+			return nil, 0, fmt.Errorf("compress and serialize page at %d: %w", i, err)
 		}
 
 		totSize += int64(len(page.RawData))

--- a/internal/layout/page_write_encode.go
+++ b/internal/layout/page_write_encode.go
@@ -112,7 +112,7 @@ func (page *Page) setPageStatistics(stats *parquet.Statistics) error {
 	if page.MaxVal != nil {
 		tmpBuf, err := encoding.WritePlain([]any{page.MaxVal}, *page.Schema.Type)
 		if err != nil {
-			return err
+			return fmt.Errorf("encode page max statistic: %w", err)
 		}
 		if *page.Schema.Type == parquet.Type_BYTE_ARRAY {
 			tmpBuf = tmpBuf[4:]
@@ -123,7 +123,7 @@ func (page *Page) setPageStatistics(stats *parquet.Statistics) error {
 	if page.MinVal != nil {
 		tmpBuf, err := encoding.WritePlain([]any{page.MinVal}, *page.Schema.Type)
 		if err != nil {
-			return err
+			return fmt.Errorf("encode page min statistic: %w", err)
 		}
 		if *page.Schema.Type == parquet.Type_BYTE_ARRAY {
 			tmpBuf = tmpBuf[4:]
@@ -170,7 +170,7 @@ func (page *Page) dataPageCompress(compressType parquet.CompressionCodec, c *com
 	// valuesRawBuf := encoding.WritePlain(valuesBuf)
 	valuesRawBuf, err := page.EncodingValues(valuesBuf)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("encode data page values: %w", err)
 	}
 
 	var definitionLevelBuf []byte
@@ -180,7 +180,7 @@ func (page *Page) dataPageCompress(compressType parquet.CompressionCodec, c *com
 			int32(bits.Len32(uint32(page.DataTable.MaxDefinitionLevel))),
 		)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("encode definition levels: %w", err)
 		}
 	}
 
@@ -191,14 +191,14 @@ func (page *Page) dataPageCompress(compressType parquet.CompressionCodec, c *com
 			int32(bits.Len32(uint32(page.DataTable.MaxRepetitionLevel))),
 		)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("encode repetition levels: %w", err)
 		}
 	}
 
 	dataBuf := slices.Concat(repetitionLevelBuf, definitionLevelBuf, valuesRawBuf)
 	dataEncodeBuf, err := resolveCompressor(c).Compress(dataBuf, compressType)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("compress data page: %w", err)
 	}
 
 	page.Header = parquet.NewPageHeader()
@@ -213,7 +213,7 @@ func (page *Page) dataPageCompress(compressType parquet.CompressionCodec, c *com
 
 	page.Header.DataPageHeader.Statistics = parquet.NewStatistics()
 	if err = page.setPageStatistics(page.Header.DataPageHeader.Statistics); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("set page statistics: %w", err)
 	}
 
 	return dataEncodeBuf, nil
@@ -243,7 +243,7 @@ func (page *Page) dataPageV2Compress(compressType parquet.CompressionCodec, c *c
 	// valuesRawBuf := encoding.WritePlain(valuesBuf)
 	valuesRawBuf, err := page.EncodingValues(valuesBuf)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, fmt.Errorf("encode v2 page values: %w", err)
 	}
 
 	var definitionLevelBuf []byte
@@ -256,7 +256,7 @@ func (page *Page) dataPageV2Compress(compressType parquet.CompressionCodec, c *c
 			int32(bits.Len32(uint32(page.DataTable.MaxDefinitionLevel))),
 			parquet.Type_INT64)
 		if err != nil {
-			return nil, nil, nil, err
+			return nil, nil, nil, fmt.Errorf("encode v2 definition levels: %w", err)
 		}
 	}
 
@@ -274,7 +274,7 @@ func (page *Page) dataPageV2Compress(compressType parquet.CompressionCodec, c *c
 			int32(bits.Len32(uint32(page.DataTable.MaxRepetitionLevel))),
 			parquet.Type_INT64)
 		if err != nil {
-			return nil, nil, nil, err
+			return nil, nil, nil, fmt.Errorf("encode v2 repetition levels: %w", err)
 		}
 	} else {
 		// When MaxRepetitionLevel is 0, every entry is a top-level row
@@ -283,7 +283,7 @@ func (page *Page) dataPageV2Compress(compressType parquet.CompressionCodec, c *c
 
 	dataEncodeBuf, err := resolveCompressor(c).Compress(valuesRawBuf, compressType)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, fmt.Errorf("compress v2 page: %w", err)
 	}
 
 	// If compression didn't reduce size, store data uncompressed and set
@@ -311,7 +311,7 @@ func (page *Page) dataPageV2Compress(compressType parquet.CompressionCodec, c *c
 
 	page.Header.DataPageHeaderV2.Statistics = parquet.NewStatistics()
 	if err = page.setPageStatistics(page.Header.DataPageHeaderV2.Statistics); err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, fmt.Errorf("set v2 page statistics: %w", err)
 	}
 
 	return repetitionLevelBuf, definitionLevelBuf, dataEncodeBuf, nil

--- a/internal/layout/page_write_test.go
+++ b/internal/layout/page_write_test.go
@@ -1636,6 +1636,35 @@ func TestCompressAndSerializePage_ErrorPaths(t *testing.T) {
 	})
 }
 
+// TestTableToDataPagesWithOption_ErrorPaths exercises the wrapped errors in
+// TableToDataPagesWithOption: the scanPageValues "page scan index" wrap
+// triggered by checkRequiredNil.
+func TestTableToDataPagesWithOption_ErrorPaths(t *testing.T) {
+	t.Run("scan_required_nil", func(t *testing.T) {
+		table := &Table{
+			Schema: &parquet.SchemaElement{
+				Type:           common.ToPtr(parquet.Type_INT32),
+				RepetitionType: common.ToPtr(parquet.FieldRepetitionType_REQUIRED),
+				Name:           "test_col",
+			},
+			Values:             []any{nil}, // nil at REQUIRED max DL triggers checkRequiredNil
+			DefinitionLevels:   []int32{0},
+			RepetitionLevels:   []int32{0},
+			MaxDefinitionLevel: 0,
+			Path:               []string{"test_col"},
+			Info:               &common.Tag{},
+		}
+		_, _, err := TableToDataPagesWithOption(table, PageWriteOption{
+			PageSize:        1024,
+			CompressType:    parquet.CompressionCodec_UNCOMPRESSED,
+			DataPageVersion: 1,
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "scan page values")
+		require.Contains(t, err.Error(), "page scan index")
+	})
+}
+
 func TestDataPageCompress_RequiredNilError(t *testing.T) {
 	page := NewDataPage()
 	page.Schema = &parquet.SchemaElement{

--- a/marshal/arrow.go
+++ b/marshal/arrow.go
@@ -1,6 +1,8 @@
 package marshal
 
 import (
+	"fmt"
+
 	"github.com/hangxie/parquet-go/v3/common"
 	"github.com/hangxie/parquet-go/v3/internal/layout"
 	"github.com/hangxie/parquet-go/v3/schema"
@@ -24,10 +26,10 @@ func MarshalArrow(records []any, schemaHandler *schema.SchemaHandler) (*map[stri
 
 		var err error
 		if table.MaxDefinitionLevel, err = schemaHandler.MaxDefinitionLevel(table.Path); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("max definition level for %s: %w", pathStr, err)
 		}
 		if table.MaxRepetitionLevel, err = schemaHandler.MaxRepetitionLevel(table.Path); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("max repetition level for %s: %w", pathStr, err)
 		}
 
 		table.Schema = schemaHandler.SchemaElements[schemaHandler.MapIndex[pathStr]]

--- a/marshal/csv.go
+++ b/marshal/csv.go
@@ -26,10 +26,10 @@ func MarshalCSV(records []any, schemaHandler *schema.SchemaHandler) (*map[string
 
 		var err error
 		if table.MaxDefinitionLevel, err = schemaHandler.MaxDefinitionLevel(table.Path); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("max definition level for %s: %w", pathStr, err)
 		}
 		if table.MaxRepetitionLevel, err = schemaHandler.MaxRepetitionLevel(table.Path); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("max repetition level for %s: %w", pathStr, err)
 		}
 
 		table.RepetitionType = parquet.FieldRepetitionType_OPTIONAL

--- a/marshal/json.go
+++ b/marshal/json.go
@@ -3,6 +3,7 @@ package marshal
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"strings"
 
@@ -146,7 +147,7 @@ func marshalJSONPrimitive(node *Node, se *parquet.SchemaElement, res map[string]
 	table := res[node.PathMap.Path]
 	val, err := types.JSONTypeToParquetTypeWithLogical(node.Val, se.Type, se.ConvertedType, se.LogicalType, int(se.GetTypeLength()), int(se.GetScale()))
 	if err != nil {
-		return err
+		return fmt.Errorf("convert JSON value for %s: %w", node.PathMap.Path, err)
 	}
 	table.Values = append(table.Values, val)
 	table.DefinitionLevels = append(table.DefinitionLevels, node.DL)
@@ -164,7 +165,7 @@ func processJSONNode(node *Node, res map[string]*layout.Table, schemaHandler *sc
 	se := schemaHandler.SchemaElements[schemaIndex]
 
 	if newStack, handled, err := HandleVariant(node, se, res, schemaHandler, nodeBuf, stack); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("handle variant for %s: %w", pathStr, err)
 	} else if handled {
 		return newStack, nil
 	}
@@ -184,7 +185,7 @@ func processJSONNode(node *Node, res map[string]*layout.Table, schemaHandler *sc
 		}
 	default:
 		if err := marshalJSONPrimitive(node, se, res); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("marshal JSON primitive for %s: %w", pathStr, err)
 		}
 	}
 	return stack, nil
@@ -194,7 +195,7 @@ func processJSONNode(node *Node, res map[string]*layout.Table, schemaHandler *sc
 func MarshalJSON(ss []any, schemaHandler *schema.SchemaHandler) (tb *map[string]*layout.Table, err error) {
 	res, err := setupTableMap(schemaHandler, len(ss))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("setup table map: %w", err)
 	}
 	pathMap := schemaHandler.PathMap
 	nodeBuf := NewNodeBuf(1)
@@ -214,7 +215,7 @@ func MarshalJSON(ss []any, schemaHandler *schema.SchemaHandler) (tb *map[string]
 		d.UseNumber()
 		var ui any
 		if err := d.Decode(&ui); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("decode JSON row %d: %w", i, err)
 		}
 
 		node := nodeBuf.GetNode()
@@ -228,7 +229,7 @@ func MarshalJSON(ss []any, schemaHandler *schema.SchemaHandler) (tb *map[string]
 			stack = stack[:ln-1]
 
 			if stack, err = processJSONNode(node, res, schemaHandler, nodeBuf, stack); err != nil {
-				return nil, err
+				return nil, fmt.Errorf("process JSON node row %d: %w", i, err)
 			}
 		}
 	}

--- a/marshal/marshal.go
+++ b/marshal/marshal.go
@@ -179,7 +179,7 @@ func (p *ParquetSlice) Marshal(node *Node, nodeBuf *NodeBufType, stack []*Node) 
 
 	rlNow, err := p.schemaHandler.MaxRepetitionLevel(common.StrToPath(path))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("max repetition level for %s: %w", path, err)
 	}
 	for j := ln - 1; j >= 0; j-- {
 		newNode := nodeBuf.GetNode()
@@ -214,7 +214,7 @@ func (p *ParquetMap) Marshal(node *Node, nodeBuf *NodeBufType, stack []*Node) ([
 
 	rlNow, err := p.schemaHandler.MaxRepetitionLevel(common.StrToPath(path))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("max repetition level for %s: %w", path, err)
 	}
 	for j := len(keys) - 1; j >= 0; j-- {
 		key := keys[j]
@@ -255,7 +255,7 @@ func marshalPrimitiveValue(node *Node, res map[string]*layout.Table, schemaHandl
 	}
 	val, err := types.InterfaceToParquetType(v, se.Type)
 	if err != nil {
-		return err
+		return fmt.Errorf("convert value for %s: %w", node.PathMap.Path, err)
 	}
 	table.Values = append(table.Values, val)
 	table.DefinitionLevels = append(table.DefinitionLevels, node.DL)
@@ -325,7 +325,7 @@ func processNode(node *Node, res map[string]*layout.Table, schemaHandler *schema
 	// []byte should be treated as primitive BYTE_ARRAY, not as a LIST
 	if isByteSlice(node) {
 		if err := marshalPrimitiveValue(node, res, schemaHandler); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("marshal byte slice for %s: %w", node.PathMap.Path, err)
 		}
 		return stack, nil
 	}
@@ -333,7 +333,7 @@ func processNode(node *Node, res map[string]*layout.Table, schemaHandler *schema
 	m := selectMarshaler(node, schemaHandler)
 	if m == nil {
 		if err := marshalPrimitiveValue(node, res, schemaHandler); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("marshal primitive for %s: %w", node.PathMap.Path, err)
 		}
 		return stack, nil
 	}
@@ -341,7 +341,7 @@ func processNode(node *Node, res map[string]*layout.Table, schemaHandler *schema
 	oldLen := len(stack)
 	var err error
 	if stack, err = m.Marshal(node, nodeBuf, stack); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("marshal %s: %w", node.PathMap.Path, err)
 	}
 	if len(stack) == oldLen {
 		appendNilToChildren(node, res, schemaHandler)
@@ -353,7 +353,7 @@ func Marshal(srcInterface []any, schemaHandler *schema.SchemaHandler) (tb *map[s
 	src := reflect.ValueOf(srcInterface)
 	res, err := setupTableMap(schemaHandler, len(srcInterface))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("setup table map: %w", err)
 	}
 	pathMap := schemaHandler.PathMap
 	nodeBuf := NewNodeBuf(1)
@@ -381,7 +381,7 @@ func Marshal(srcInterface []any, schemaHandler *schema.SchemaHandler) (tb *map[s
 			}
 
 			if stack, err = processNode(node, res, schemaHandler, nodeBuf, stack); err != nil {
-				return nil, err
+				return nil, fmt.Errorf("process node %s: %w", node.PathMap.Path, err)
 			}
 		}
 	}
@@ -400,10 +400,10 @@ func setupTableMap(schemaHandler *schema.SchemaHandler, numElements int) (map[st
 			table.Path = common.StrToPath(pathStr)
 			var err error
 			if table.MaxDefinitionLevel, err = schemaHandler.MaxDefinitionLevel(table.Path); err != nil {
-				return nil, err
+				return nil, fmt.Errorf("max definition level for %v: %w", table.Path, err)
 			}
 			if table.MaxRepetitionLevel, err = schemaHandler.MaxRepetitionLevel(table.Path); err != nil {
-				return nil, err
+				return nil, fmt.Errorf("max repetition level for %v: %w", table.Path, err)
 			}
 			table.RepetitionType = schema.GetRepetitionType()
 			table.Schema = schemaHandler.SchemaElements[schemaHandler.MapIndex[pathStr]]
@@ -467,7 +467,7 @@ func HandleVariant(
 	// If the variant group is present, its definition level should be at its max
 	childDL, err := schemaHandler.MaxDefinitionLevel(common.StrToPath(node.PathMap.Path))
 	if err != nil {
-		return nil, true, err
+		return nil, true, fmt.Errorf("max definition level for variant %s: %w", node.PathMap.Path, err)
 	}
 
 	// Push Metadata

--- a/marshal/unmarshal.go
+++ b/marshal/unmarshal.go
@@ -112,10 +112,10 @@ func buildTableContext(path []string, sh *schema.SchemaHandler) (tableContext, e
 		tc.schemaIndexs[i] = int(sh.MapIndex[curPathStr])
 		var err error
 		if tc.repetitionLevels[i], err = sh.MaxRepetitionLevel(path[:i+1]); err != nil {
-			return tc, err
+			return tc, fmt.Errorf("max repetition level for %s: %w", curPathStr, err)
 		}
 		if tc.definitionLevels[i], err = sh.MaxDefinitionLevel(path[:i+1]); err != nil {
-			return tc, err
+			return tc, fmt.Errorf("max definition level for %s: %w", curPathStr, err)
 		}
 	}
 	return tc, nil
@@ -366,7 +366,7 @@ func (s *unmarshalState) processValue(root reflect.Value, prefixIndex int, tc *t
 			return setPrimitiveValue(po, val)
 		}
 		if err != nil {
-			return err
+			return fmt.Errorf("process value at index %d for %v: %w", index, tc.path, err)
 		}
 		if done {
 			return nil
@@ -378,7 +378,7 @@ func (s *unmarshalState) processValue(root reflect.Value, prefixIndex int, tc *t
 func (s *unmarshalState) processTable(root reflect.Value, prefixIndex int, table *layout.Table, bgn, end int) error {
 	tc, err := buildTableContext(table.Path, s.schemaHandler)
 	if err != nil {
-		return err
+		return fmt.Errorf("build table context for %s: %w", table.Path, err)
 	}
 
 	for _, rc := range s.sliceRecords {
@@ -396,7 +396,7 @@ func (s *unmarshalState) processTable(root reflect.Value, prefixIndex int, table
 
 	for i := bgn; i < end; i++ {
 		if err := s.processValue(root, prefixIndex, &tc, table.RepetitionLevels[i], table.DefinitionLevels[i], table.Values[i]); err != nil {
-			return err
+			return fmt.Errorf("process row %d of %v: %w", i, table.Path, err)
 		}
 	}
 	return nil
@@ -429,12 +429,12 @@ func Unmarshal(tableMap *map[string]*layout.Table, bgn, end int, dstInterface an
 			continue
 		}
 		if err := state.processTable(root, prefixIndex, table, tableBgn[name], tableEnd[name]); err != nil {
-			return err
+			return fmt.Errorf("process table %s: %w", name, err)
 		}
 	}
 
 	if err := processVariantReconstruction(variantReconstructors, root, prefixPath, schemaHandler, tableBgn, tableEnd, state.sliceRecords); err != nil {
-		return err
+		return fmt.Errorf("reconstruct variants: %w", err)
 	}
 
 	for i := len(state.sliceRecordsStack) - 1; i >= 0; i-- {

--- a/marshal/unmarshal_json.go
+++ b/marshal/unmarshal_json.go
@@ -108,7 +108,7 @@ func convertSliceToJSONFriendly(val reflect.Value, schemaHandler *schema.SchemaH
 	for i := range val.Len() {
 		converted, err := convertValueToJSONFriendlyWithContext(val.Index(i), schemaHandler, elementPath, converter)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("convert list element %d: %w", i, err)
 		}
 		result[i] = converted
 	}
@@ -141,13 +141,13 @@ func convertMapToJSONFriendly(val reflect.Value, schemaHandler *schema.SchemaHan
 	for _, key := range val.MapKeys() {
 		converted, err := convertValueToJSONFriendlyWithContext(key, schemaHandler, keyPath, converter)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("convert map key: %w", err)
 		}
 		keyStr := fmt.Sprint(converted)
 
 		converted, err = convertValueToJSONFriendlyWithContext(val.MapIndex(key), schemaHandler, valuePath, converter)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("convert map value for key %q: %w", keyStr, err)
 		}
 		result[keyStr] = converted
 	}
@@ -220,7 +220,7 @@ func convertStructToJSONFriendly(val reflect.Value, schemaHandler *schema.Schema
 
 		converted, err := convertValueToJSONFriendlyWithContext(fieldVal, schemaHandler, fieldPath, converter)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("convert field %s: %w", field.Name, err)
 		}
 		result[fInfo.name] = converted
 	}

--- a/marshal/unmarshal_variant.go
+++ b/marshal/unmarshal_variant.go
@@ -176,7 +176,7 @@ func setVariantValue(root reflect.Value, variantPath, prefixPath string, _ *sche
 
 	po, err := navigateToVariantTarget(root, path, prefixIndex, variant, rowIdx, sliceRecords)
 	if err != nil {
-		return err
+		return fmt.Errorf("navigate variant target %s: %w", variantPath, err)
 	}
 
 	return assignVariantToTarget(po, variant)

--- a/marshal/variant_reconstruct.go
+++ b/marshal/variant_reconstruct.go
@@ -103,7 +103,7 @@ func (r *ShreddedVariantReconstructor) getValueAtRow(table *layout.Table, rowIdx
 		// Check definition level to see if value is present
 		maxDL, err := r.SchemaHandler.MaxDefinitionLevel(table.Path)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("max definition level for %v: %w", table.Path, err)
 		}
 		if table.DefinitionLevels[i] >= maxDL {
 			values = append(values, table.Values[i])
@@ -120,7 +120,7 @@ func (r *ShreddedVariantReconstructor) getValueAtRow(table *layout.Table, rowIdx
 	isRepeated := false
 	maxRL, err := r.SchemaHandler.MaxRepetitionLevel(table.Path)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("max repetition level for %v: %w", table.Path, err)
 	}
 	if maxRL > 0 {
 		isRepeated = true
@@ -169,7 +169,7 @@ func (r *ShreddedVariantReconstructor) reconstructChildValues(pathPrefix, childN
 	}
 	val, err := r.reconstructValue(pathPrefix+common.ParGoPathDelimiter+childName, rowIdx, tableBgn, tableEnd, metadata)
 	if err != nil {
-		return nil, false, err
+		return nil, false, fmt.Errorf("reconstruct child %s/%s: %w", pathPrefix, childName, err)
 	}
 	if slice, ok := val.([]any); ok {
 		return slice, true, nil
@@ -185,7 +185,7 @@ func (r *ShreddedVariantReconstructor) isChildTablesRepeated(childTables map[str
 		for _, table := range tables {
 			maxRL, err := r.SchemaHandler.MaxRepetitionLevel(table.Path)
 			if err != nil {
-				return false, err
+				return false, fmt.Errorf("max repetition level for %v: %w", table.Path, err)
 			}
 			if maxRL > 0 {
 				return true, nil
@@ -201,17 +201,17 @@ func (r *ShreddedVariantReconstructor) reconstructVariantGroup(
 ) (any, error) {
 	metadataValues, metadataSet, err := r.reconstructChildValues(pathPrefix, names.meta, rowIdx, tableBgn, tableEnd, nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("variant %s metadata: %w", pathPrefix, err)
 	}
 	valueValues, valueSet, err := r.reconstructChildValues(pathPrefix, names.value, rowIdx, tableBgn, tableEnd, nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("variant %s value: %w", pathPrefix, err)
 	}
 
 	typedMeta := effectiveMetadataForTyped(metadataValues, metadataSet, metadata)
 	typedValueValues, typedValueSet, err := r.reconstructChildValues(pathPrefix, names.typed, rowIdx, tableBgn, tableEnd, typedMeta)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("variant %s typed value: %w", pathPrefix, err)
 	}
 
 	if !metadataSet && !valueSet && !typedValueSet {
@@ -227,13 +227,13 @@ func (r *ShreddedVariantReconstructor) reconstructVariantGroup(
 	if !isRepeated {
 		isRepeated, err = r.isChildTablesRepeated(childTables)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("check child repeatedness: %w", err)
 		}
 	}
 
 	results, err := buildVariantResults(maxLen, metadataValues, valueValues, typedValueValues, metadata)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("build variant results: %w", err)
 	}
 	return variantResultsToAny(results, isRepeated)
 }
@@ -244,7 +244,7 @@ func (r *ShreddedVariantReconstructor) reconstructElementChildren(
 ) (any, error) {
 	tableValues, maxLen, err := r.collectChildValues(pathPrefix, rowIdx, tableBgn, tableEnd, metadata, childTables)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("collect child values for %s: %w", pathPrefix, err)
 	}
 	if maxLen == 0 {
 		return nil, nil
@@ -272,7 +272,7 @@ func (r *ShreddedVariantReconstructor) collectChildValues(
 	for childName := range childTables {
 		val, err := r.reconstructValue(pathPrefix+common.ParGoPathDelimiter+childName, rowIdx, tableBgn, tableEnd, metadata)
 		if err != nil {
-			return nil, 0, err
+			return nil, 0, fmt.Errorf("reconstruct child %s/%s: %w", pathPrefix, childName, err)
 		}
 		if slice, ok := val.([]any); ok {
 			tableValues[childName] = slice
@@ -309,7 +309,7 @@ func (r *ShreddedVariantReconstructor) reconstructMapChildren(
 		childPath := pathPrefix + common.ParGoPathDelimiter + childName
 		val, err := r.reconstructValue(childPath, rowIdx, tableBgn, tableEnd, metadata)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("reconstruct map child %s: %w", childPath, err)
 		}
 		if val == nil {
 			continue
@@ -397,7 +397,7 @@ func (r *ShreddedVariantReconstructor) reconstructValue(pathPrefix string, rowId
 func (r *ShreddedVariantReconstructor) Reconstruct(rowIdx int, tableBgn, tableEnd map[string]int) (types.Variant, error) {
 	val, err := r.reconstructValue(r.Path, rowIdx, tableBgn, tableEnd, nil)
 	if err != nil {
-		return types.Variant{}, err
+		return types.Variant{}, fmt.Errorf("reconstruct variant at %s row %d: %w", r.Path, rowIdx, err)
 	}
 	if val == nil {
 		// Return a NULL variant

--- a/marshal/variant_reconstruct_helpers.go
+++ b/marshal/variant_reconstruct_helpers.go
@@ -25,7 +25,7 @@ var defaultVariantMetadata = []byte{0x01, 0x00, 0x00}
 func resolveMetadata(val any, fallback []byte) ([]byte, error) {
 	b, err := toByteSlice(val, "metadata")
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("resolve variant metadata: %w", err)
 	}
 	if len(b) > 0 {
 		return b, nil
@@ -61,14 +61,14 @@ func buildVariantResults(maxLen int, metadataValues, valueValues, typedValueValu
 		}
 		elMetadata, err := resolveMetadata(metaVal, metadata)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("variant element %d metadata: %w", i, err)
 		}
 
 		var elValue []byte
 		if i < len(valueValues) && valueValues[i] != nil {
 			elValue, err = toByteSlice(valueValues[i], "value")
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("variant element %d value: %w", i, err)
 			}
 		}
 

--- a/reader/bloom.go
+++ b/reader/bloom.go
@@ -123,11 +123,11 @@ func (pr *ParquetReader) readBloomFilterForColumn(pf source.ParquetFileReader, r
 	}
 	aadPrefix, aadFileUnique, err := pr.footerAADParts(algorithm)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("footer AAD: %w", err)
 	}
 	key, err := pr.resolveColumnKey(columnChunk)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("resolve column key: %w", err)
 	}
 	rowGroupOrdinal := int16(rowGroupIndex)
 	if rowGroup != nil && rowGroup.IsSetOrdinal() {

--- a/reader/columnbuffer.go
+++ b/reader/columnbuffer.go
@@ -53,13 +53,13 @@ func NewColumnBuffer(pFile source.ParquetFileReader, footer *parquet.FileMetaDat
 	if schemaHandler.MapIndex != nil {
 		if _, exists := schemaHandler.MapIndex[pathStr]; exists {
 			if _, err := schemaHandler.GetType(pathStr); err != nil {
-				return nil, err
+				return nil, fmt.Errorf("get type for %s: %w", pathStr, err)
 			}
 		}
 	}
 	newPFile, err := pFile.Clone()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("clone file reader: %w", err)
 	}
 	var opt layout.PageReadOptions
 	if opts != nil {
@@ -74,12 +74,10 @@ func NewColumnBuffer(pFile source.ParquetFileReader, footer *parquet.FileMetaDat
 		PageReadOptions:  opt,
 	}
 
-	if err = res.NextRowGroup(); err == io.EOF {
-		err = nil
-	} else if err != nil {
-		return nil, err
+	if err := res.NextRowGroup(); err != nil && err != io.EOF {
+		return nil, fmt.Errorf("advance to first row group: %w", err)
 	}
-	return res, err
+	return res, nil
 }
 
 func (cbt *ColumnBufferType) NextRowGroup() error {
@@ -120,7 +118,7 @@ func (cbt *ColumnBufferType) NextRowGroup() error {
 	cbt.ColumnOrdinal = int16(i)
 	if cbt.Reader != nil {
 		if err := cbt.Reader.configureOptionalPageDecryptor(cbt, rowGroups[cbt.RowGroupIndex-1], int16(i)); err != nil {
-			return err
+			return fmt.Errorf("configure page decryptor: %w", err)
 		}
 	}
 	if columnChunks[i].FilePath != nil {
@@ -213,17 +211,17 @@ func (cbt *ColumnBufferType) ReadPageForSkip() (*layout.Page, error) {
 		}
 		page, err := layout.ReadPageRawData(cbt.ThriftReader, cbt.SchemaHandler, cbt.ChunkHeader.MetaData, &cbt.PageReadOptions)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("read page raw data: %w", err)
 		}
 
 		numValues, numRows, err := page.GetRLDLFromRawData(cbt.SchemaHandler)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("read repetition/definition levels: %w", err)
 		}
 
 		if page.Header.GetType() == parquet.PageType_DICTIONARY_PAGE {
 			if err := page.GetValueFromRawData(cbt.SchemaHandler); err != nil {
-				return nil, err
+				return nil, fmt.Errorf("decode dictionary page: %w", err)
 			}
 			cbt.DictPage = page
 			return page, nil
@@ -241,7 +239,7 @@ func (cbt *ColumnBufferType) ReadPageForSkip() (*layout.Page, error) {
 	}
 
 	if err := cbt.NextRowGroup(); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("move to next row group: %w", err)
 	}
 
 	return cbt.ReadPageForSkip()
@@ -311,7 +309,7 @@ func (cbt *ColumnBufferType) skipEntireRowGroups(num int64) (int64, error) {
 				// We've skipped all available rows
 				return num, io.EOF
 			}
-			return num, err
+			return num, fmt.Errorf("skip row group: %w", err)
 		}
 	}
 	return num, nil
@@ -330,7 +328,7 @@ func (cbt *ColumnBufferType) skipByReadingPages(num int64) (int64, error) {
 		}
 		page, err = cbt.ReadPageForSkip()
 		if err != nil {
-			return 0, err
+			return 0, fmt.Errorf("read page for skip: %w", err)
 		}
 	}
 
@@ -340,7 +338,7 @@ func (cbt *ColumnBufferType) skipByReadingPages(num int64) (int64, error) {
 
 	if page != nil {
 		if err = page.GetValueFromRawData(cbt.SchemaHandler); err != nil {
-			return 0, err
+			return 0, fmt.Errorf("decode page values during skip: %w", err)
 		}
 
 		page.Decode(cbt.DictPage)
@@ -380,7 +378,7 @@ func (cbt *ColumnBufferType) SkipRows(num int64) (int64, error) {
 		if errors.Is(err, io.EOF) {
 			return originalNum - num, nil
 		}
-		return 0, err
+		return 0, fmt.Errorf("skip row groups: %w", err)
 	}
 
 	// Finally, skip remaining rows by reading pages.
@@ -389,7 +387,7 @@ func (cbt *ColumnBufferType) SkipRows(num int64) (int64, error) {
 	// = (originalNum - remaining) + num = originalNum - remaining + num.
 	remaining := num
 	if num, err = cbt.skipByReadingPages(remaining); err != nil {
-		return 0, err
+		return 0, fmt.Errorf("skip by reading pages: %w", err)
 	}
 
 	return originalNum - remaining + num, nil
@@ -426,7 +424,7 @@ func (cbt *ColumnBufferType) ReadRows(num int64) (*layout.Table, int64, error) {
 	}
 	// Propagate non-EOF errors; treat io.EOF as normal completion
 	if err != nil && !errors.Is(err, io.EOF) {
-		return res, num, err
+		return res, num, fmt.Errorf("read rows: %w", err)
 	}
 	return res, num, nil
 }

--- a/reader/columnreader.go
+++ b/reader/columnreader.go
@@ -2,6 +2,7 @@ package reader
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 
@@ -17,7 +18,7 @@ func NewParquetColumnReader(pFile source.ParquetFileReader, opts ...ReaderOption
 	res.PFile = pFile
 
 	if err := applyReaderDefaults(res, opts); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("apply reader options: %w", err)
 	}
 	if err := res.ReadFooter(); err != nil {
 		return nil, fmt.Errorf("read footer: %w", err)
@@ -51,7 +52,7 @@ func (pr *ParquetReader) SkipRows(num int64) error {
 		sem <- struct{}{}
 		g.Go(func() error {
 			defer func() { <-sem }()
-			if _, err := pr.ColumnBuffers[pathStr].SkipRows(int64(num)); err != nil && err == io.EOF {
+			if _, err := pr.ColumnBuffers[pathStr].SkipRows(int64(num)); err != nil && errors.Is(err, io.EOF) {
 				return nil
 			} else if err != nil {
 				return fmt.Errorf("skip rows for column %s: %w", pathStr, err)
@@ -129,7 +130,7 @@ func (pr *ParquetReader) ReadColumnByPath(pathStr string, num int64) (values []a
 		if err != nil {
 			return []any{}, []int32{}, []int32{}, fmt.Errorf("convert path %v: %w", pathStr, err)
 		}
-		return []any{}, []int32{}, []int32{}, err
+		return []any{}, []int32{}, []int32{}, nil
 	}
 
 	if _, ok := pr.SchemaHandler.MapIndex[pathStr]; !ok {

--- a/reader/encryption.go
+++ b/reader/encryption.go
@@ -34,11 +34,11 @@ func (pr *ParquetReader) readEncryptedFooter(size uint32) error {
 
 	key, err := pr.resolveFooterKeyFromMetadata(fileCrypto.GetKeyMetadata())
 	if err != nil {
-		return err
+		return fmt.Errorf("resolve footer key: %w", err)
 	}
 	aadPrefix, aadFileUnique, err := pr.footerAADParts(fileCrypto.GetEncryptionAlgorithm())
 	if err != nil {
-		return err
+		return fmt.Errorf("footer AAD: %w", err)
 	}
 
 	module, err := encryption.DecodeModule(section[consumed:])
@@ -62,12 +62,12 @@ func (pr *ParquetReader) readEncryptedFooter(size uint32) error {
 func readFileCryptoMetaData(buf []byte) (*parquet.FileCryptoMetaData, int, error) {
 	mem := thrift.NewTMemoryBufferLen(len(buf))
 	if _, err := mem.Write(buf); err != nil {
-		return nil, 0, err
+		return nil, 0, fmt.Errorf("buffer file crypto metadata: %w", err)
 	}
 	protocol := thrift.NewTCompactProtocolConf(mem, &thrift.TConfiguration{})
 	meta := parquet.NewFileCryptoMetaData()
 	if err := meta.Read(context.TODO(), protocol); err != nil {
-		return nil, 0, err
+		return nil, 0, fmt.Errorf("decode file crypto metadata: %w", err)
 	}
 	remaining := int(mem.RemainingBytes())
 	return meta, len(buf) - remaining, nil
@@ -77,7 +77,7 @@ func readFileMetaDataFromBytes(buf []byte) (*parquet.FileMetaData, error) {
 	footer := parquet.NewFileMetaData()
 	protocol := thrift.NewTCompactProtocolConf(thrift.NewTBufferedTransport(thrift.NewStreamTransportR(bytes.NewReader(buf)), len(buf)), &thrift.TConfiguration{})
 	if err := footer.Read(context.TODO(), protocol); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("decode file metadata: %w", err)
 	}
 	return footer, nil
 }
@@ -94,7 +94,7 @@ func (pr *ParquetReader) verifyPlaintextFooter(section []byte) error {
 	}
 	key, err := pr.resolveOptionalFooterKeyFromMetadata(footer.GetFooterSigningKeyMetadata())
 	if err != nil {
-		return err
+		return fmt.Errorf("resolve footer signing key: %w", err)
 	}
 	if len(key) == 0 {
 		pr.Footer = footer
@@ -102,7 +102,7 @@ func (pr *ParquetReader) verifyPlaintextFooter(section []byte) error {
 	}
 	aadPrefix, aadFileUnique, err := pr.footerAADParts(footer.GetEncryptionAlgorithm())
 	if err != nil {
-		return err
+		return fmt.Errorf("footer AAD: %w", err)
 	}
 	if err := encryption.VerifyGCMTag(
 		key,
@@ -121,7 +121,7 @@ func readColumnMetaDataFromBytes(buf []byte) (*parquet.ColumnMetaData, error) {
 	meta := parquet.NewColumnMetaData()
 	protocol := thrift.NewTCompactProtocolConf(thrift.NewStreamTransportR(bytes.NewReader(buf)), &thrift.TConfiguration{})
 	if err := meta.Read(context.TODO(), protocol); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("decode column metadata: %w", err)
 	}
 	return meta, nil
 }
@@ -204,7 +204,7 @@ func (pr *ParquetReader) retrieveKeyFromMetadata(keyMetadata []byte) ([]byte, er
 		entry.key = append([]byte(nil), key...)
 	})
 	if entry.err != nil {
-		return nil, entry.err
+		return nil, fmt.Errorf("retrieve key: %w", entry.err)
 	}
 	return append([]byte(nil), entry.key...), nil
 }
@@ -219,7 +219,7 @@ func (pr *ParquetReader) decryptEncryptedColumnMetadata() error {
 	}
 	aadPrefix, aadFileUnique, err := pr.footerAADParts(algorithm)
 	if err != nil {
-		return err
+		return fmt.Errorf("footer AAD: %w", err)
 	}
 
 	for rowGroupIndex, rowGroup := range pr.Footer.RowGroups {
@@ -232,7 +232,7 @@ func (pr *ParquetReader) decryptEncryptedColumnMetadata() error {
 		}
 		for columnOrdinal, chunk := range rowGroup.GetColumns() {
 			if err := pr.decryptEncryptedColumnMetadataChunk(chunk, rowGroupIndex, int16(columnOrdinal), rowGroupOrdinal, aadPrefix, aadFileUnique); err != nil {
-				return err
+				return fmt.Errorf("decrypt column metadata: %w", err)
 			}
 		}
 	}
@@ -359,16 +359,16 @@ func (pr *ParquetReader) configurePageDecryptorWithKeyRequirement(cbt *ColumnBuf
 	}
 	aadPrefix, aadFileUnique, err := pr.footerAADParts(algorithm)
 	if err != nil {
-		return err
+		return fmt.Errorf("footer AAD: %w", err)
 	}
 	key, err := pr.resolveOptionalColumnKey(cbt.ChunkHeader)
 	if err != nil {
-		return err
+		return fmt.Errorf("resolve column key: %w", err)
 	}
 	if len(key) == 0 {
 		if requireKey {
 			_, err := pr.resolveColumnKey(cbt.ChunkHeader)
-			return err
+			return fmt.Errorf("require column key: %w", err)
 		}
 		return nil
 	}
@@ -396,8 +396,10 @@ func (pr *ParquetReader) requirePageDecryptor(cbt *ColumnBufferType) error {
 	if cbt == nil || cbt.ChunkHeader == nil || cbt.ChunkHeader.GetCryptoMetadata() == nil || cbt.PageReadOptions.Decryptor != nil {
 		return nil
 	}
-	_, err := pr.resolveColumnKey(cbt.ChunkHeader)
-	return err
+	if _, err := pr.resolveColumnKey(cbt.ChunkHeader); err != nil {
+		return fmt.Errorf("require column key: %w", err)
+	}
+	return nil
 }
 
 func (pr *ParquetReader) reconfigureDecryptorForBuffer(cbt *ColumnBufferType) error {

--- a/reader/index.go
+++ b/reader/index.go
@@ -18,7 +18,7 @@ import (
 func (pr *ParquetReader) ReadColumnIndex(rowGroupIndex, columnIndex int) (*parquet.ColumnIndex, error) {
 	column, rowGroupOrdinal, columnOrdinal, err := pr.indexColumn(rowGroupIndex, columnIndex)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("locate column for column index: %w", err)
 	}
 	if !column.IsSetColumnIndexOffset() || !column.IsSetColumnIndexLength() {
 		return nil, nil
@@ -26,7 +26,7 @@ func (pr *ParquetReader) ReadColumnIndex(rowGroupIndex, columnIndex int) (*parqu
 
 	buf, err := pr.readIndexModule(column, rowGroupOrdinal, columnOrdinal, column.GetColumnIndexOffset(), column.GetColumnIndexLength(), encryption.ModuleColumnIndex)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("read column index module: %w", err)
 	}
 	index := parquet.NewColumnIndex()
 	if err := readCompactThrift(buf, index); err != nil {
@@ -40,7 +40,7 @@ func (pr *ParquetReader) ReadColumnIndex(rowGroupIndex, columnIndex int) (*parqu
 func (pr *ParquetReader) ReadOffsetIndex(rowGroupIndex, columnIndex int) (*parquet.OffsetIndex, error) {
 	column, rowGroupOrdinal, columnOrdinal, err := pr.indexColumn(rowGroupIndex, columnIndex)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("locate column for offset index: %w", err)
 	}
 	if !column.IsSetOffsetIndexOffset() || !column.IsSetOffsetIndexLength() {
 		return nil, nil
@@ -48,7 +48,7 @@ func (pr *ParquetReader) ReadOffsetIndex(rowGroupIndex, columnIndex int) (*parqu
 
 	buf, err := pr.readIndexModule(column, rowGroupOrdinal, columnOrdinal, column.GetOffsetIndexOffset(), column.GetOffsetIndexLength(), encryption.ModuleOffsetIndex)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("read offset index module: %w", err)
 	}
 	index := parquet.NewOffsetIndex()
 	if err := readCompactThrift(buf, index); err != nil {
@@ -99,11 +99,11 @@ func (pr *ParquetReader) readIndexModule(column *parquet.ColumnChunk, rowGroupOr
 	}
 	aadPrefix, aadFileUnique, err := pr.footerAADParts(algorithm)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("footer AAD: %w", err)
 	}
 	key, err := pr.resolveColumnKey(column)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("resolve column key: %w", err)
 	}
 	if _, err := pf.Seek(offset, io.SeekStart); err != nil {
 		return nil, fmt.Errorf("seek to index offset %d: %w", offset, err)

--- a/reader/page.go
+++ b/reader/page.go
@@ -94,7 +94,7 @@ func readPageHeader(pFile io.ReadSeeker, offset int64) (*parquet.PageHeader, int
 
 	pageHeader := parquet.NewPageHeader()
 	if err := pageHeader.Read(context.Background(), proto); err != nil {
-		return nil, 0, err
+		return nil, 0, fmt.Errorf("decode page header: %w", err)
 	}
 
 	headerSize := trackingTransport.pos - offset

--- a/reader/reader.go
+++ b/reader/reader.go
@@ -51,7 +51,7 @@ func NewParquetReader(pFile source.ParquetFileReader, obj any, opts ...ReaderOpt
 	res.PFile = pFile
 
 	if err = applyReaderDefaults(res, opts); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("apply reader options: %w", err)
 	}
 	if err = res.ReadFooter(); err != nil {
 		return nil, fmt.Errorf("read footer: %w", err)
@@ -130,12 +130,12 @@ func (pr *ParquetReader) SetSchemaHandlerFromJSON(jsonSchema string) error {
 func (pr *ParquetReader) newColumnBuffer(pathStr string) (*ColumnBufferType, error) {
 	cb, err := NewColumnBuffer(pr.PFile, pr.Footer, pr.SchemaHandler, pathStr, &layout.PageReadOptions{CRCMode: pr.crcMode, MaxPageSize: layout.DefaultMaxPageSize})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("new column buffer for %s: %w", pathStr, err)
 	}
 	cb.Reader = pr
 	if err := pr.reconfigureOptionalDecryptorForBuffer(cb); err != nil {
 		_ = cb.PFile.Close()
-		return nil, err
+		return nil, fmt.Errorf("configure decryptor for %s: %w", pathStr, err)
 	}
 	return cb, nil
 }
@@ -199,16 +199,14 @@ func (pr *ParquetReader) GetFooterSize() (uint32, error) {
 		return 0, fmt.Errorf("PFile is nil")
 	}
 
-	var err error
 	buf := make([]byte, 4)
-	if _, err = pr.PFile.Seek(-8, io.SeekEnd); err != nil {
-		return 0, err
+	if _, err := pr.PFile.Seek(-8, io.SeekEnd); err != nil {
+		return 0, fmt.Errorf("seek to footer size: %w", err)
 	}
-	if _, err = io.ReadFull(pr.PFile, buf); err != nil {
-		return 0, err
+	if _, err := io.ReadFull(pr.PFile, buf); err != nil {
+		return 0, fmt.Errorf("read footer size: %w", err)
 	}
-	size := binary.LittleEndian.Uint32(buf)
-	return size, err
+	return binary.LittleEndian.Uint32(buf), nil
 }
 
 func (pr *ParquetReader) getFooterTail() (uint32, string, error) {
@@ -218,10 +216,10 @@ func (pr *ParquetReader) getFooterTail() (uint32, string, error) {
 
 	buf := make([]byte, 8)
 	if _, err := pr.PFile.Seek(-8, io.SeekEnd); err != nil {
-		return 0, "", err
+		return 0, "", fmt.Errorf("seek to footer tail: %w", err)
 	}
 	if _, err := io.ReadFull(pr.PFile, buf); err != nil {
-		return 0, "", err
+		return 0, "", fmt.Errorf("read footer tail: %w", err)
 	}
 	return binary.LittleEndian.Uint32(buf[:4]), string(buf[4:]), nil
 }
@@ -235,11 +233,11 @@ func (pr *ParquetReader) ReadFooter() error {
 	switch magic {
 	case common.MagicBytesEncrypted:
 		if err := pr.readEncryptedFooter(size); err != nil {
-			return err
+			return fmt.Errorf("read encrypted footer: %w", err)
 		}
 	default:
 		if err := pr.readPlainFooter(size); err != nil {
-			return err
+			return fmt.Errorf("read plain footer: %w", err)
 		}
 	}
 	if err := pr.decryptEncryptedColumnMetadata(); err != nil {
@@ -270,7 +268,7 @@ func (pr *ParquetReader) readPlainFooter(size uint32) error {
 			return fmt.Errorf("read plaintext footer section: %w", err)
 		}
 		if err := pr.verifyPlaintextFooter(section); err != nil {
-			return err
+			return fmt.Errorf("verify plaintext footer: %w", err)
 		}
 	}
 	return nil
@@ -361,7 +359,7 @@ func (pr *ParquetReader) read(dstInterface any, prefixPath string) error {
 		return nil
 	}
 	if err := pr.fetchColumnData(num, prefixPath, tmap); err != nil {
-		return err
+		return fmt.Errorf("fetch column data: %w", err)
 	}
 	return pr.unmarshalToResult(num, tmap, dstInterface, prefixPath)
 }

--- a/schema/arrow.go
+++ b/schema/arrow.go
@@ -29,7 +29,6 @@ func ConvertArrowToParquetSchema(schema *arrow.Schema) ([]string, error) {
 	}
 
 	metaData := make([]string, len(schema.Fields()))
-	var err error
 	for k, v := range schema.Fields() {
 		repetitionType := parquet.FieldRepetitionType_REQUIRED
 		if v.Nullable {
@@ -106,7 +105,7 @@ func ConvertArrowToParquetSchema(schema *arrow.Schema) ([]string, error) {
 				fmt.Errorf("unsupported arrow format: %s", fieldType.Name())
 		}
 	}
-	return metaData, err
+	return metaData, nil
 }
 
 // NewSchemaHandlerFromArrow creates a schema handler from arrow format.
@@ -121,7 +120,7 @@ func NewSchemaHandlerFromArrow(arrowSchema *arrow.Schema) (
 
 	fields, err := ConvertArrowToParquetSchema(arrowSchema)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("convert arrow to parquet schema: %w", err)
 	}
 
 	rootSchema := parquet.NewSchemaElement()
@@ -141,12 +140,12 @@ func NewSchemaHandlerFromArrow(arrowSchema *arrow.Schema) (
 	for _, field := range fields {
 		info, err := common.StringToTag(field)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("parse tag %q: %w", field, err)
 		}
 		infos = append(infos, info)
 		schema, err := common.NewSchemaElementFromTagMap(info)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("build schema element for %s: %w", info.InName, err)
 		}
 		schemaList = append(schemaList, schema)
 	}

--- a/schema/gettype.go
+++ b/schema/gettype.go
@@ -295,7 +295,7 @@ func (sh *SchemaHandler) GetTypes() []reflect.Type {
 func (sh *SchemaHandler) GetType(prefixPath string) (reflect.Type, error) {
 	prefixPath, err := sh.ConvertToInPathStr(prefixPath)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("convert path %s: %w", prefixPath, err)
 	}
 
 	ts := sh.GetTypes()

--- a/schema/json.go
+++ b/schema/json.go
@@ -45,7 +45,7 @@ func NewSchemaHandlerFromJSON(str string) (sh *SchemaHandler, err error) {
 		stack = stack[:ln-1]
 		info, err := parseJSONSchemaTag(item.Tag)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("parse JSON schema tag: %w", err)
 		}
 		var newInfo *common.Tag
 		switch info.Type {

--- a/schema/schemabuild.go
+++ b/schema/schemabuild.go
@@ -81,7 +81,7 @@ func createVariantSchema(item *Item, stack *[]*Item, schemaElements *[]*parquet.
 			var err error
 			newItem.Info, err = parseStructFieldTag(tagStr)
 			if err != nil {
-				return err
+				return fmt.Errorf("parse tag for field %s: %w", f.Name, err)
 			}
 			newItem.Info.InName = f.Name
 			newItem.GoType = f.Type
@@ -144,7 +144,7 @@ func createStructSchema(item *Item, stack *[]*Item, schemaElements *[]*parquet.S
 		var err error
 		newItem.Info, err = parseStructFieldTag(tagStr)
 		if err != nil {
-			return err
+			return fmt.Errorf("parse tag for field %s: %w", f.Name, err)
 		}
 		newItem.Info.InName = f.Name
 		newItem.GoType = f.Type
@@ -262,11 +262,11 @@ func NewSchemaHandlerFromStruct(obj any) (sh *SchemaHandler, err error) {
 
 		if item.Info.Type == "VARIANT" {
 			if err = createVariantSchema(item, &stack, &schemaElements, &infos); err != nil {
-				return nil, err
+				return nil, fmt.Errorf("create variant schema for %s: %w", item.Info.InName, err)
 			}
 		} else if item.GoType.Kind() == reflect.Struct {
 			if err = createStructSchema(item, &stack, &schemaElements, &infos); err != nil {
-				return nil, err
+				return nil, fmt.Errorf("create struct schema for %s: %w", item.Info.InName, err)
 			}
 		} else if item.GoType.Kind() == reflect.Slice &&
 			item.Info.Type != "BYTE_ARRAY" && item.Info.Type != "FIXED_LEN_BYTE_ARRAY" &&

--- a/schema/schemahandler.go
+++ b/schema/schemahandler.go
@@ -96,7 +96,7 @@ func (sh *SchemaHandler) ValidateEncodingsForDataPageVersion(version int32) erro
 			continue
 		}
 		if err := common.ValidateEncodingForDataPageVersion(info.InName, info.Encoding, version); err != nil {
-			return err
+			return fmt.Errorf("validate encoding for %s: %w", info.InName, err)
 		}
 	}
 	return nil
@@ -164,7 +164,7 @@ func (sh *SchemaHandler) MaxDefinitionLevel(path []string) (int32, error) {
 	for i := 2; i <= ln; i++ {
 		rt, err := sh.GetRepetitionType(path[:i])
 		if err != nil {
-			return 0, err
+			return 0, fmt.Errorf("get repetition type for %v: %w", path[:i], err)
 		}
 		if rt != parquet.FieldRepetitionType_REQUIRED {
 			res++
@@ -180,7 +180,7 @@ func (sh *SchemaHandler) GetRepetitionLevelIndex(path []string, rl int32) (int32
 	for i := 2; i <= ln; i++ {
 		rt, err := sh.GetRepetitionType(path[:i])
 		if err != nil {
-			return 0, err
+			return 0, fmt.Errorf("get repetition type for %v: %w", path[:i], err)
 		}
 		if rt == parquet.FieldRepetitionType_REPEATED {
 			res++
@@ -200,7 +200,7 @@ func (sh *SchemaHandler) MaxRepetitionLevel(path []string) (int32, error) {
 	for i := 2; i <= ln; i++ {
 		rt, err := sh.GetRepetitionType(path[:i])
 		if err != nil {
-			return 0, err
+			return 0, fmt.Errorf("get repetition type for %v: %w", path[:i], err)
 		}
 		if rt == parquet.FieldRepetitionType_REPEATED {
 			res++

--- a/schema/statistics.go
+++ b/schema/statistics.go
@@ -48,7 +48,7 @@ func DecodeStatisticsMinMax(se *parquet.SchemaElement, stats *parquet.Statistics
 		}
 		vals, err := encoding.ReadPlain(bytes.NewReader(data), pT, 1, bitWidth)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("decode statistic value: %w", err)
 		}
 		if len(vals) == 0 {
 			return nil, nil

--- a/types/date.go
+++ b/types/date.go
@@ -1,12 +1,15 @@
 package types
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
 
 // ParseDateString parses a date string in format "2006-01-02" and returns days since Unix epoch.
 func ParseDateString(s string) (int32, error) {
 	t, err := time.Parse("2006-01-02", s)
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("parse date %q: %w", s, err)
 	}
 	epochDate := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
 	days := int32(t.Sub(epochDate).Hours() / 24)

--- a/types/int96.go
+++ b/types/int96.go
@@ -38,7 +38,7 @@ func INT96ToTime(int96 string) (time.Time, error) {
 func ParseINT96String(s string) (string, error) {
 	t, err := time.Parse(time.RFC3339Nano, s)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("parse INT96 timestamp %q: %w", s, err)
 	}
 	return TimeToINT96(t.UTC()), nil
 }

--- a/types/string.go
+++ b/types/string.go
@@ -11,6 +11,14 @@ import (
 	"github.com/hangxie/parquet-go/v3/parquet"
 )
 
+// wrapScanErr returns a contextualized parse error or nil when err is nil.
+func wrapScanErr(typeName, s string, err error) error {
+	if err != nil {
+		return fmt.Errorf("parse %s %q: %w", typeName, s, err)
+	}
+	return nil
+}
+
 // Scan a string to parquet value; length and scale just for decimal
 func StrToParquetType(s string, pT *parquet.Type, cT *parquet.ConvertedType, length, scale int) (any, error) {
 	if cT == nil {
@@ -18,15 +26,15 @@ func StrToParquetType(s string, pT *parquet.Type, cT *parquet.ConvertedType, len
 		case parquet.Type_BOOLEAN:
 			var v bool
 			_, err := fmt.Sscanf(s, "%t", &v)
-			return v, err
+			return v, wrapScanErr("BOOLEAN", s, err)
 		case parquet.Type_INT32:
 			var v int32
 			_, err := fmt.Sscanf(s, "%d", &v)
-			return v, err
+			return v, wrapScanErr("INT32", s, err)
 		case parquet.Type_INT64:
 			var v int64
 			_, err := fmt.Sscanf(s, "%d", &v)
-			return v, err
+			return v, wrapScanErr("INT64", s, err)
 		case parquet.Type_INT96:
 			if res, err := ParseINT96String(s); err == nil {
 				return res, nil
@@ -36,11 +44,11 @@ func StrToParquetType(s string, pT *parquet.Type, cT *parquet.ConvertedType, len
 		case parquet.Type_FLOAT:
 			var v float32
 			_, err := fmt.Sscanf(s, "%f", &v)
-			return v, err
+			return v, wrapScanErr("FLOAT", s, err)
 		case parquet.Type_DOUBLE:
 			var v float64
 			_, err := fmt.Sscanf(s, "%f", &v)
-			return v, err
+			return v, wrapScanErr("DOUBLE", s, err)
 		case parquet.Type_BYTE_ARRAY:
 			if decoded, err := base64.StdEncoding.DecodeString(s); err == nil {
 				return string(decoded), nil
@@ -62,70 +70,70 @@ func StrToParquetType(s string, pT *parquet.Type, cT *parquet.ConvertedType, len
 	case parquet.ConvertedType_INT_8:
 		var v int8
 		_, err := fmt.Sscanf(s, "%d", &v)
-		return int32(v), err
+		return int32(v), wrapScanErr("INT_8", s, err)
 	case parquet.ConvertedType_INT_16:
 		var v int16
 		_, err := fmt.Sscanf(s, "%d", &v)
-		return int32(v), err
+		return int32(v), wrapScanErr("INT_16", s, err)
 	case parquet.ConvertedType_INT_32:
 		var v int32
 		_, err := fmt.Sscanf(s, "%d", &v)
-		return int32(v), err
+		return int32(v), wrapScanErr("INT_32", s, err)
 	case parquet.ConvertedType_UINT_8:
 		var v uint8
 		_, err := fmt.Sscanf(s, "%d", &v)
-		return int32(v), err
+		return int32(v), wrapScanErr("UINT_8", s, err)
 	case parquet.ConvertedType_UINT_16:
 		var v uint16
 		_, err := fmt.Sscanf(s, "%d", &v)
-		return int32(v), err
+		return int32(v), wrapScanErr("UINT_16", s, err)
 	case parquet.ConvertedType_UINT_32:
 		var v uint32
 		_, err := fmt.Sscanf(s, "%d", &v)
-		return int32(v), err
+		return int32(v), wrapScanErr("UINT_32", s, err)
 	case parquet.ConvertedType_DATE:
 		if v, err := ParseDateString(s); err == nil {
 			return v, nil
 		}
 		var v int32
 		_, err := fmt.Sscanf(s, "%d", &v)
-		return int32(v), err
+		return int32(v), wrapScanErr("DATE", s, err)
 	case parquet.ConvertedType_TIME_MILLIS:
 		if nanos, err := ParseTimeString(s); err == nil {
 			return int32(nanos / int64(time.Millisecond)), nil
 		}
 		var v int32
 		_, err := fmt.Sscanf(s, "%d", &v)
-		return int32(v), err
+		return int32(v), wrapScanErr("TIME_MILLIS", s, err)
 	case parquet.ConvertedType_UINT_64:
 		var vt uint64
 		_, err := fmt.Sscanf(s, "%d", &vt)
-		return int64(vt), err
+		return int64(vt), wrapScanErr("UINT_64", s, err)
 	case parquet.ConvertedType_INT_64:
 		var v int64
 		_, err := fmt.Sscanf(s, "%d", &v)
-		return v, err
+		return v, wrapScanErr("INT_64", s, err)
 	case parquet.ConvertedType_TIME_MICROS:
 		if nanos, err := ParseTimeString(s); err == nil {
 			return nanos / int64(time.Microsecond), nil
 		}
 		var v int64
 		_, err := fmt.Sscanf(s, "%d", &v)
-		return v, err
+		return v, wrapScanErr("TIME_MICROS", s, err)
 	case parquet.ConvertedType_TIMESTAMP_MILLIS:
 		if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
 			return t.UnixNano() / int64(time.Millisecond), nil
 		}
 		var v int64
 		_, err := fmt.Sscanf(s, "%d", &v)
-		return v, err
+		return v, wrapScanErr("TIMESTAMP_MILLIS", s, err)
 	case parquet.ConvertedType_TIMESTAMP_MICROS:
 		if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
 			return t.UnixNano() / int64(time.Microsecond), nil
 		}
 		var v int64
 		_, err := fmt.Sscanf(s, "%d", &v)
-		return v, err
+		return v, wrapScanErr("TIMESTAMP_MICROS", s, err)
 	case parquet.ConvertedType_INTERVAL:
 		if res, err := ParseIntervalString(s); err == nil {
 			return res, nil
@@ -168,7 +176,10 @@ func StrToParquetType(s string, pT *parquet.Type, cT *parquet.ConvertedType, len
 func strToLogicalType(s string, lT *parquet.LogicalType, pT *parquet.Type, length int) (any, bool, error) {
 	if lT.IsSetFLOAT16() {
 		v, err := ParseFloat16String(s)
-		return v, true, err
+		if err != nil {
+			return v, true, fmt.Errorf("parse FLOAT16 %q: %w", s, err)
+		}
+		return v, true, nil
 	}
 	if lT.IsSetUUID() {
 		if u, err := uuid.Parse(s); err == nil {
@@ -189,8 +200,10 @@ func strToLogicalType(s string, lT *parquet.LogicalType, pT *parquet.Type, lengt
 			return v, true, nil
 		}
 		var v int32
-		_, err := fmt.Sscanf(s, "%d", &v)
-		return int32(v), true, err
+		if _, err := fmt.Sscanf(s, "%d", &v); err != nil {
+			return int32(v), true, fmt.Errorf("parse DATE %q: %w", s, err)
+		}
+		return int32(v), true, nil
 	}
 	if lT.IsSetDECIMAL() {
 		v, err := strToDecimalLogical(s, lT.GetDECIMAL(), pT, length)

--- a/types/string_test.go
+++ b/types/string_test.go
@@ -768,3 +768,87 @@ func TestStrToParquetTypeWithLogical_Comprehensive(t *testing.T) {
 		})
 	}
 }
+
+// TestStrToParquetTypeWithLogical_Errors covers wrap paths reachable via the
+// public API: FLOAT16 and DATE in strToLogicalType propagate errors with
+// handled=true.
+func TestStrToParquetTypeWithLogical_Errors(t *testing.T) {
+	tests := []struct {
+		name   string
+		s      string
+		pT     *parquet.Type
+		lT     *parquet.LogicalType
+		errMsg string
+	}{
+		{
+			name:   "float16_invalid",
+			s:      "not-a-float",
+			pT:     parquet.TypePtr(parquet.Type_FIXED_LEN_BYTE_ARRAY),
+			lT:     &parquet.LogicalType{FLOAT16: &parquet.Float16Type{}},
+			errMsg: "parse FLOAT16",
+		},
+		{
+			name:   "date_invalid",
+			s:      "not-a-date",
+			pT:     parquet.TypePtr(parquet.Type_INT32),
+			lT:     &parquet.LogicalType{DATE: &parquet.DateType{}},
+			errMsg: "parse DATE",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := StrToParquetTypeWithLogical(tt.s, tt.pT, nil, tt.lT, 12, 0)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.errMsg)
+		})
+	}
+}
+
+// TestStrToTimeLogical_Errors covers the wrapped Sscanf-failure paths in
+// strToTimeLogical. Reached directly because strToLogicalType swallows these
+// errors as fallthrough signals to StrToParquetType.
+func TestStrToTimeLogical_Errors(t *testing.T) {
+	tests := []struct {
+		name   string
+		s      string
+		t      *parquet.TimeType
+		errMsg string
+	}{
+		{
+			name:   "millis_invalid",
+			s:      "not-a-time",
+			t:      createTimeLogicalType(true, false, false).GetTIME(),
+			errMsg: "parse TIME_MILLIS",
+		},
+		{
+			name:   "micros_invalid",
+			s:      "not-a-time",
+			t:      createTimeLogicalType(false, true, false).GetTIME(),
+			errMsg: "parse time",
+		},
+		{
+			name:   "nanos_invalid",
+			s:      "not-a-time",
+			t:      createTimeLogicalType(false, false, true).GetTIME(),
+			errMsg: "parse time",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := strToTimeLogical(tt.s, tt.t)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.errMsg)
+		})
+	}
+}
+
+// TestStrToTimestampLogical_Errors covers the wrapped Sscanf-failure path in
+// strToTimestampLogical. Reached directly for the same reason as
+// TestStrToTimeLogical_Errors.
+func TestStrToTimestampLogical_Errors(t *testing.T) {
+	ts := createTimestampLogicalType(true, false, false, true).GetTIMESTAMP()
+	_, err := strToTimestampLogical("not-a-timestamp", ts)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "parse timestamp")
+}

--- a/types/time.go
+++ b/types/time.go
@@ -143,10 +143,14 @@ func strToTimeLogical(s string, t *parquet.TimeType) (any, error) {
 	}
 	if t.Unit.IsSetMILLIS() {
 		var v int32
-		_, err := fmt.Sscanf(s, "%d", &v)
-		return v, err
+		if _, err := fmt.Sscanf(s, "%d", &v); err != nil {
+			return v, fmt.Errorf("parse TIME_MILLIS %q: %w", s, err)
+		}
+		return v, nil
 	}
 	var v int64
-	_, err := fmt.Sscanf(s, "%d", &v)
-	return v, err
+	if _, err := fmt.Sscanf(s, "%d", &v); err != nil {
+		return v, fmt.Errorf("parse time %q: %w", s, err)
+	}
+	return v, nil
 }

--- a/types/timestamp.go
+++ b/types/timestamp.go
@@ -114,8 +114,10 @@ func strToTimestampLogical(s string, ts *parquet.TimestampType) (any, error) {
 			}
 		}
 		var v int64
-		_, err := fmt.Sscanf(s, "%d", &v)
-		return v, err
+		if _, err := fmt.Sscanf(s, "%d", &v); err != nil {
+			return v, fmt.Errorf("parse timestamp %q: %w", s, err)
+		}
+		return v, nil
 	}
 	return nil, fmt.Errorf("timestamp unit not set")
 }

--- a/types/variant_decode.go
+++ b/types/variant_decode.go
@@ -40,7 +40,10 @@ func decodeVariantValue(data []byte, meta *variantMetadata) (any, error) {
 	}
 
 	_, val, err := decodeVariantValueAt(data, 0, meta)
-	return val, err
+	if err != nil {
+		return val, fmt.Errorf("decode variant value: %w", err)
+	}
+	return val, nil
 }
 
 // decodeVariantValueAt decodes a variant value starting at the given offset

--- a/types/variant_go_encode.go
+++ b/types/variant_go_encode.go
@@ -92,7 +92,7 @@ func buildFieldNameToID(metadata []byte, context string) (map[string]int, error)
 func encodeStructAsVariant(val reflect.Value, metadata []byte) ([]byte, error) {
 	fieldNameToID, err := buildFieldNameToID(metadata, "struct")
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("build struct field map: %w", err)
 	}
 
 	fieldIDs := make([]int, 0, val.NumField())
@@ -123,7 +123,7 @@ func encodeStructAsVariant(val reflect.Value, metadata []byte) ([]byte, error) {
 func encodeMapAsVariant(obj map[string]any, metadata []byte) ([]byte, error) {
 	fieldNameToID, err := buildFieldNameToID(metadata, "object")
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("build object field map: %w", err)
 	}
 
 	fieldIDs := make([]int, 0, len(obj))
@@ -225,7 +225,7 @@ func AnyToVariant(v any) (Variant, error) {
 	// 3. Encode value with metadata
 	val, err := EncodeGoValueAsVariantWithMetadata(v, metadata)
 	if err != nil {
-		return Variant{}, err
+		return Variant{}, fmt.Errorf("encode value as variant: %w", err)
 	}
 
 	return Variant{

--- a/writer/arrow.go
+++ b/writer/arrow.go
@@ -33,7 +33,7 @@ func NewArrowWriter(arrowSchema *arrow.Schema, pfile source.ParquetFileWriter, o
 	// ArrowWriter defaults to GZIP; user opts come after and can override.
 	allOpts := append([]WriterOption{WithCompressionCodec(parquet.CompressionCodec_GZIP)}, opts...)
 	if err := res.initBase(pfile, allOpts...); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("init arrow writer base: %w", err)
 	}
 
 	var err error
@@ -47,7 +47,7 @@ func NewArrowWriter(arrowSchema *arrow.Schema, pfile source.ParquetFileWriter, o
 		return nil, fmt.Errorf("init bloom filters: %w", err)
 	}
 	if err = res.validateEncryptionColumnKeys(); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("validate encryption column keys: %w", err)
 	}
 
 	res.stopped = false

--- a/writer/bloomfilter.go
+++ b/writer/bloomfilter.go
@@ -84,11 +84,11 @@ func (pw *ParquetWriter) serializeBloomFilters() error {
 			key, _, _ := pw.columnKey(cc.MetaData.GetPathInSchema())
 			headerModule, err := pw.encryptThriftModule(key, encryption.ModuleBloomFilterHeader, rowGroupOrdinal, int16(columnOrdinal), headerBuf)
 			if err != nil {
-				return err
+				return fmt.Errorf("encrypt bloom filter header for column %s: %w", path, err)
 			}
 			bitsetModule, err := pw.encryptThriftModule(key, encryption.ModuleBloomFilterBitset, rowGroupOrdinal, int16(columnOrdinal), bf.Bitset())
 			if err != nil {
-				return err
+				return fmt.Errorf("encrypt bloom filter bitset for column %s: %w", path, err)
 			}
 			pw.bloomFilterData = append(pw.bloomFilterData, append(headerModule, bitsetModule...))
 		} else {

--- a/writer/csv.go
+++ b/writer/csv.go
@@ -26,7 +26,7 @@ func NewCSVWriterFromWriter(md []string, w io.Writer, opts ...WriterOption) (*CS
 func NewCSVWriter(md []string, pfile source.ParquetFileWriter, opts ...WriterOption) (*CSVWriter, error) {
 	res := new(CSVWriter)
 	if err := res.initBase(pfile, opts...); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("init CSV writer base: %w", err)
 	}
 
 	var err error
@@ -40,7 +40,7 @@ func NewCSVWriter(md []string, pfile source.ParquetFileWriter, opts ...WriterOpt
 		return nil, fmt.Errorf("init bloom filters: %w", err)
 	}
 	if err = res.validateEncryptionColumnKeys(); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("validate encryption column keys: %w", err)
 	}
 
 	res.stopped = false

--- a/writer/index.go
+++ b/writer/index.go
@@ -24,7 +24,7 @@ func (pw *ParquetWriter) writeColumnIndexes(ts *thrift.TSerializer) error {
 			if pw.encryptionState != nil && columnChunk.GetCryptoMetadata() != nil {
 				key, err := pw.keyForEncryptedColumn(columnChunk)
 				if err != nil {
-					return err
+					return fmt.Errorf("column index key row group %d column %d: %w", rowGroupIndex, columnOrdinal, err)
 				}
 				rowGroupOrdinal := int16(rowGroupIndex)
 				if rowGroup.IsSetOrdinal() {
@@ -32,7 +32,7 @@ func (pw *ParquetWriter) writeColumnIndexes(ts *thrift.TSerializer) error {
 				}
 				module, err := pw.encryptThriftModule(key, encryption.ModuleColumnIndex, rowGroupOrdinal, int16(columnOrdinal), columnIndexBuf)
 				if err != nil {
-					return err
+					return fmt.Errorf("encrypt column index row group %d column %d: %w", rowGroupOrdinal, columnOrdinal, err)
 				}
 				columnIndexBuf = module
 			}
@@ -67,7 +67,7 @@ func (pw *ParquetWriter) writeOffsetIndexes(ts *thrift.TSerializer) error {
 			if pw.encryptionState != nil && columnChunk.GetCryptoMetadata() != nil {
 				key, err := pw.keyForEncryptedColumn(columnChunk)
 				if err != nil {
-					return err
+					return fmt.Errorf("offset index key row group %d column %d: %w", rowGroupIndex, columnOrdinal, err)
 				}
 				rowGroupOrdinal := int16(rowGroupIndex)
 				if rowGroup.IsSetOrdinal() {
@@ -75,7 +75,7 @@ func (pw *ParquetWriter) writeOffsetIndexes(ts *thrift.TSerializer) error {
 				}
 				module, err := pw.encryptThriftModule(key, encryption.ModuleOffsetIndex, rowGroupOrdinal, int16(columnOrdinal), offsetIndexBuf)
 				if err != nil {
-					return err
+					return fmt.Errorf("encrypt offset index row group %d column %d: %w", rowGroupOrdinal, columnOrdinal, err)
 				}
 				offsetIndexBuf = module
 			}

--- a/writer/json.go
+++ b/writer/json.go
@@ -25,7 +25,7 @@ func NewJSONWriterFromWriter(jsonSchema string, w io.Writer, opts ...WriterOptio
 func NewJSONWriter(jsonSchema string, pfile source.ParquetFileWriter, opts ...WriterOption) (*JSONWriter, error) {
 	res := new(JSONWriter)
 	if err := res.initBase(pfile, opts...); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("init JSON writer base: %w", err)
 	}
 
 	var err error
@@ -39,7 +39,7 @@ func NewJSONWriter(jsonSchema string, pfile source.ParquetFileWriter, opts ...Wr
 		return nil, fmt.Errorf("init bloom filters: %w", err)
 	}
 	if err = res.validateEncryptionColumnKeys(); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("validate encryption column keys: %w", err)
 	}
 
 	res.stopped = false

--- a/writer/ops.go
+++ b/writer/ops.go
@@ -28,15 +28,15 @@ func (pw *ParquetWriter) WriteStop() error {
 	pw.RenameSchema()
 
 	if err = pw.writeColumnIndexes(ts); err != nil {
-		return err
+		return fmt.Errorf("write column indexes: %w", err)
 	}
 
 	if err = pw.writeOffsetIndexes(ts); err != nil {
-		return err
+		return fmt.Errorf("write offset indexes: %w", err)
 	}
 
 	if err = pw.writeBloomFilters(); err != nil {
-		return err
+		return fmt.Errorf("write bloom filters: %w", err)
 	}
 
 	// Set ColumnOrders so readers can correctly interpret min/max statistics.
@@ -63,7 +63,7 @@ func (pw *ParquetWriter) WriteStop() error {
 			}
 			for columnOrdinal, column := range rowGroup.Columns {
 				if err := pw.encryptColumnMetadata(rowGroupOrdinal, int16(columnOrdinal), column); err != nil {
-					return err
+					return fmt.Errorf("encrypt column metadata row group %d column %d: %w", rowGroupOrdinal, columnOrdinal, err)
 				}
 			}
 		}
@@ -75,7 +75,7 @@ func (pw *ParquetWriter) WriteStop() error {
 	}
 	footerBuf, tailMagic, err := pw.encryptFooter(footerBuf)
 	if err != nil {
-		return err
+		return fmt.Errorf("encrypt footer: %w", err)
 	}
 
 	if _, err = pw.PFile.Write(footerBuf); err != nil {
@@ -212,7 +212,7 @@ func (pw *ParquetWriter) Flush(flag bool) error {
 	if (pw.size+pw.objsSize >= pw.rowGroupSize || flag) && len(pw.pagesMapBuf) > 0 {
 		chunkMap, err := pw.buildChunkMap()
 		if err != nil {
-			return err
+			return fmt.Errorf("build chunk map: %w", err)
 		}
 		pw.DictRecs.Clear()
 
@@ -221,14 +221,14 @@ func (pw *ParquetWriter) Flush(flag bool) error {
 		rowGroupOrdinal := int16(len(pw.Footer.RowGroups))
 		for k := range len(rowGroup.Chunks) {
 			if err := pw.writeChunkPages(rowGroup.Chunks[k], rowGroupOrdinal, int16(k)); err != nil {
-				return err
+				return fmt.Errorf("write chunk pages row group %d column %d: %w", rowGroupOrdinal, k, err)
 			}
 		}
 
 		pw.Footer.RowGroups = append(pw.Footer.RowGroups, rowGroup.RowGroupHeader)
 
 		if err := pw.serializeBloomFilters(); err != nil {
-			return err
+			return fmt.Errorf("serialize bloom filters: %w", err)
 		}
 
 		pw.size = 0

--- a/writer/pages.go
+++ b/writer/pages.go
@@ -33,7 +33,10 @@ func (pw *ParquetWriter) tableToDictPages(name string, table *layout.Table, comp
 		Compressor:   pw.compressor,
 	})
 	convMu.Unlock()
-	return pages, err
+	if err != nil {
+		return nil, fmt.Errorf("build dict pages: %w", err)
+	}
+	return pages, nil
 }
 
 func (pw *ParquetWriter) tableToPlainPages(table *layout.Table, compressionType parquet.CompressionCodec) ([]*layout.Page, error) {
@@ -44,7 +47,10 @@ func (pw *ParquetWriter) tableToPlainPages(table *layout.Table, compressionType 
 		WriteCRC:        pw.writeCRC,
 		Compressor:      pw.compressor,
 	})
-	return pages, err
+	if err != nil {
+		return nil, fmt.Errorf("build data pages: %w", err)
+	}
+	return pages, nil
 }
 
 func (pw *ParquetWriter) convertTableToPages(name string, table *layout.Table, convMu *sync.Mutex) ([]*layout.Page, error) {
@@ -246,13 +252,13 @@ func (pw *ParquetWriter) writeChunkPages(chunk *layout.Chunk, rowGroupOrdinal, c
 		plainRawLen := len(page.RawData)
 		if pw.encryptionState != nil {
 			if err := pw.encryptPage(page, key, rowGroupOrdinal, columnOrdinal, pageOrdinal); err != nil {
-				return err
+				return fmt.Errorf("encrypt page row group %d column %d page %d: %w", rowGroupOrdinal, columnOrdinal, pageOrdinal, err)
 			}
 			chunk.ChunkHeader.MetaData.TotalCompressedSize += int64(len(page.RawData) - plainRawLen)
 		}
 		if isDataPage {
 			if err := pw.recordDataPage(page, columnIndex, offsetIndex, dataPageIdx, dataPageCount, &firstRowIndex); err != nil {
-				return err
+				return fmt.Errorf("record data page %d: %w", dataPageIdx, err)
 			}
 			dataPageIdx++
 		}

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -189,7 +189,7 @@ func (pw *ParquetWriter) initBase(pFile source.ParquetFileWriter, opts ...Writer
 	if pw.encryptionConfig != nil {
 		state, err := newEncryptionState(*pw.encryptionConfig)
 		if err != nil {
-			return err
+			return fmt.Errorf("init encryption state: %w", err)
 		}
 		pw.encryptionState = state
 	}
@@ -208,7 +208,7 @@ func (pw *ParquetWriter) initBase(pFile source.ParquetFileWriter, opts ...Writer
 func NewParquetWriter(pFile source.ParquetFileWriter, obj any, opts ...WriterOption) (*ParquetWriter, error) {
 	res := new(ParquetWriter)
 	if err := res.initBase(pFile, opts...); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("init writer base: %w", err)
 	}
 	res.marshalFunc = marshal.Marshal
 
@@ -237,7 +237,7 @@ func NewParquetWriter(pFile source.ParquetFileWriter, obj any, opts ...WriterOpt
 		return nil, fmt.Errorf("init bloom filters: %w", err)
 	}
 	if err := res.validateEncryptionColumnKeys(); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("validate encryption column keys: %w", err)
 	}
 
 	// Enable writing after init completed successfully
@@ -257,7 +257,7 @@ func (pw *ParquetWriter) SetSchemaHandlerFromJSON(jsonSchema string) error {
 		return fmt.Errorf("init bloom filters: %w", err)
 	}
 	if err := pw.validateEncryptionColumnKeys(); err != nil {
-		return err
+		return fmt.Errorf("validate encryption column keys: %w", err)
 	}
 	pw.encodingsValidated = false
 	return nil


### PR DESCRIPTION
Wrap each bare `return err` across reader/, writer/, marshal/, schema/, internal/, and common/ using `fmt.Errorf("<action>: %w", err)`. Include identifying values (row group, column, page ordinals, schema path) where available so error chains describe the failing operation. Excludes auto-generated parquet/parquet.go and example/ per #289.

EDIT this is for https://github.com/hangxie/parquet-go/issues/289