### PR TITLE
feat(reader): support encrypted columns in low-level page inspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ Reader behavior by footer and column mode:
 - Plaintext footer (`PAR1`): the file can be opened without keys. If a footer key is supplied or resolved, the reader verifies the plaintext-footer AES-GCM signature and fails `ReadFooter`/`NewParquetReader` when verification fails. Without the footer key, the footer is readable but not authenticated by this reader.
 - Mixed plaintext/encrypted columns: plaintext-column reads can succeed without encryption keys. Full row reads or partial reads that include an encrypted column fail if that column's key is unavailable.
 - Indexes and bloom filters: the column index, offset index, bloom filter header, and bloom filter bitset inherit their column's encryption state. For an encrypted column they are encrypted with the same key as the column data; for a plaintext column they are stored in plaintext and can be read without any keys.
-- Low-level page inspection: `GetAllPageHeaders`, `GetFirstDataPageHeader`, and `ReadDictionaryPageValues` operate on raw page bytes and reject encrypted columns even when keys are configured. Use row or column read APIs to decrypt encrypted page data.
+- Low-level page inspection: `GetAllPageHeaders` and `GetFirstDataPageHeader` transparently decrypt encrypted page headers when the reader has the right keys, and return the standard `"decryption key required for column"` error otherwise. The offset-based `ReadDictionaryPageValues` is plaintext-only because an offset cannot identify which column's key to use; for encrypted columns, use `ReadDictionaryPageValuesInColumn(rowGroupIndex, columnIndex int)`, which derives offset, codec, and physical type from the column metadata and decrypts when keys are available.
 
 Read a file encrypted with a single footer key:
 

--- a/internal/layout/page_read_encryption.go
+++ b/internal/layout/page_read_encryption.go
@@ -30,6 +30,14 @@ type PageDecryptor struct {
 	PageOrdinal     int16
 }
 
+// DecryptPageHeader decrypts an encrypted page header module and returns the
+// parsed page header. The decryptor must have its ordinal state set as if the
+// caller were reading pages sequentially: for data-page headers the data-page
+// AAD is tried first, and for dictionary headers a 0 page ordinal is used.
+func DecryptPageHeader(module []byte, decryptor *PageDecryptor) (*parquet.PageHeader, error) {
+	return decryptPageHeader(module, decryptor)
+}
+
 func decryptPageHeader(module []byte, decryptor *PageDecryptor) (*parquet.PageHeader, error) {
 	tries := []encryption.ModuleType{encryption.ModuleDataPageHeader, encryption.ModuleDictionaryPageHeader}
 	var lastErr error

--- a/reader/encryption_test.go
+++ b/reader/encryption_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hangxie/parquet-go/v3/internal/layout"
 	"github.com/hangxie/parquet-go/v3/parquet"
 	"github.com/hangxie/parquet-go/v3/source/buffer"
+	"github.com/hangxie/parquet-go/v3/source/local"
 	"github.com/hangxie/parquet-go/v3/source/writerfile"
 	"github.com/hangxie/parquet-go/v3/writer"
 )
@@ -585,7 +586,29 @@ func TestNewColumnBufferConfiguresPageDecryptor(t *testing.T) {
 	require.Equal(t, key, cb.PageReadOptions.Decryptor.Key)
 }
 
-func TestPageInspectionRejectsEncryptedColumns(t *testing.T) {
+func TestPageInspectionRejectsEncryptedColumnsWithoutKeys(t *testing.T) {
+	t.Parallel()
+
+	footerKey := []byte("0123456789abcdef")
+	data := buildPlaintextFooterEncryptedColumnData(t, footerKey, []byte("abcdef0123456789"))
+
+	pr, err := NewParquetReader(buffer.NewBufferReaderFromBytesNoAlloc(data), new(encryptedReaderRecord))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, pr.ReadStop()) }()
+
+	nameColumn := encryptedColumnIndex(t, pr, "name")
+
+	_, err = pr.GetAllPageHeaders(0, nameColumn)
+	require.ErrorContains(t, err, "decryption key required for column name")
+
+	_, err = pr.GetFirstDataPageHeader(0, nameColumn)
+	require.ErrorContains(t, err, "decryption key required for column name")
+
+	_, err = pr.ReadDictionaryPageValuesInColumn(0, nameColumn)
+	require.ErrorContains(t, err, "decryption key required for column name")
+}
+
+func TestReadDictionaryPageValuesByOffsetRejectsEncryptedOffset(t *testing.T) {
 	t.Parallel()
 
 	pr := &ParquetReader{
@@ -611,17 +634,370 @@ func TestPageInspectionRejectsEncryptedColumns(t *testing.T) {
 		},
 	}
 
-	_, err := pr.GetAllPageHeaders(0, 0)
-	require.ErrorContains(t, err, "not supported for encrypted columns")
-
-	_, err = pr.GetFirstDataPageHeader(0, 0)
-	require.ErrorContains(t, err, "not supported for encrypted columns")
-
-	_, err = pr.ReadDictionaryPageValues(4, parquet.CompressionCodec_UNCOMPRESSED, parquet.Type_INT32)
-	require.ErrorContains(t, err, "not supported for encrypted columns")
+	_, err := pr.ReadDictionaryPageValues(4, parquet.CompressionCodec_UNCOMPRESSED, parquet.Type_INT32)
+	require.ErrorContains(t, err, "ReadDictionaryPageValuesInColumn")
 
 	require.False(t, (*ParquetReader)(nil).pageOffsetEncrypted(4))
 	require.False(t, (&ParquetReader{}).pageOffsetEncrypted(4))
+}
+
+func TestPageInspectionDecryptsEncryptedColumns(t *testing.T) {
+	t.Parallel()
+
+	footerKey := []byte("0123456789abcdef")
+	nameKey := []byte("abcdef0123456789")
+
+	algorithms := []struct {
+		name    string
+		algoOpt writer.WriterOption
+	}{
+		{name: "AES-GCM", algoOpt: writer.WithEncryptionAlgorithm(writer.EncryptionAESGCMV1)},
+		{name: "AES-GCM-CTR", algoOpt: writer.WithEncryptionAlgorithm(writer.EncryptionAESGCMCTRV1)},
+	}
+
+	for _, algo := range algorithms {
+		algo := algo
+		t.Run(algo.name, func(t *testing.T) {
+			t.Parallel()
+
+			data := buildEncryptedInspectionFile(t, footerKey, nameKey, algo.algoOpt)
+
+			pr, err := NewParquetReader(
+				buffer.NewBufferReaderFromBytesNoAlloc(data),
+				new(encryptedReaderRecord),
+				WithFooterKey(footerKey),
+				WithColumnKey("name", nameKey),
+			)
+			require.NoError(t, err)
+			defer func() { require.NoError(t, pr.ReadStop()) }()
+
+			nameColumn := encryptedColumnIndex(t, pr, "name")
+
+			headers, err := pr.GetAllPageHeaders(0, nameColumn)
+			require.NoError(t, err)
+			require.NotEmpty(t, headers)
+
+			var seenDataPage, seenDictPage bool
+			for _, h := range headers {
+				require.Positive(t, h.CompressedSize)
+				require.Positive(t, h.UncompressedSize)
+				switch h.PageType {
+				case parquet.PageType_DATA_PAGE, parquet.PageType_DATA_PAGE_V2:
+					seenDataPage = true
+				case parquet.PageType_DICTIONARY_PAGE:
+					seenDictPage = true
+				}
+			}
+			require.True(t, seenDictPage)
+			require.True(t, seenDataPage)
+
+			firstData, err := pr.GetFirstDataPageHeader(0, nameColumn)
+			require.NoError(t, err)
+			require.Contains(t, []parquet.PageType{parquet.PageType_DATA_PAGE, parquet.PageType_DATA_PAGE_V2}, firstData.PageType)
+
+			values, err := pr.ReadDictionaryPageValuesInColumn(0, nameColumn)
+			require.NoError(t, err)
+			require.NotEmpty(t, values)
+			seen := map[string]bool{}
+			for _, v := range values {
+				str, ok := v.(string)
+				require.True(t, ok)
+				seen[str] = true
+			}
+			require.True(t, seen["alpha"] || seen["beta"] || seen["gamma"])
+		})
+	}
+}
+
+func TestReadDictionaryPageValuesInColumnErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("invalid row group index", func(t *testing.T) {
+		t.Parallel()
+		pr := &ParquetReader{Footer: &parquet.FileMetaData{RowGroups: []*parquet.RowGroup{{Columns: []*parquet.ColumnChunk{{}}}}}}
+		_, err := pr.ReadDictionaryPageValuesInColumn(-1, 0)
+		require.ErrorContains(t, err, "invalid row group index")
+		_, err = pr.ReadDictionaryPageValuesInColumn(99, 0)
+		require.ErrorContains(t, err, "invalid row group index")
+	})
+
+	t.Run("invalid column index", func(t *testing.T) {
+		t.Parallel()
+		pr := &ParquetReader{Footer: &parquet.FileMetaData{RowGroups: []*parquet.RowGroup{{Columns: []*parquet.ColumnChunk{{}}}}}}
+		_, err := pr.ReadDictionaryPageValuesInColumn(0, -1)
+		require.ErrorContains(t, err, "invalid column index")
+		_, err = pr.ReadDictionaryPageValuesInColumn(0, 99)
+		require.ErrorContains(t, err, "invalid column index")
+	})
+
+	t.Run("nil column metadata", func(t *testing.T) {
+		t.Parallel()
+		pr := &ParquetReader{Footer: &parquet.FileMetaData{RowGroups: []*parquet.RowGroup{{Columns: []*parquet.ColumnChunk{{}}}}}}
+		_, err := pr.ReadDictionaryPageValuesInColumn(0, 0)
+		require.ErrorContains(t, err, "metadata is nil")
+	})
+
+	t.Run("no dictionary page", func(t *testing.T) {
+		t.Parallel()
+		pr := &ParquetReader{
+			Footer: &parquet.FileMetaData{
+				RowGroups: []*parquet.RowGroup{
+					{Columns: []*parquet.ColumnChunk{{MetaData: &parquet.ColumnMetaData{Type: parquet.Type_INT32, PathInSchema: []string{"leaf"}, DataPageOffset: 8}}}},
+				},
+			},
+		}
+		_, err := pr.ReadDictionaryPageValuesInColumn(0, 0)
+		require.ErrorContains(t, err, "does not have a dictionary page")
+	})
+
+	t.Run("offset does not point to dictionary page", func(t *testing.T) {
+		t.Parallel()
+		testFile := getTestParquetFile(t)
+		buf, err := local.NewLocalFileReader(testFile)
+		require.NoError(t, err)
+		pr, err := NewParquetReader(buf, new(TestPageRecord), WithNP(1))
+		require.NoError(t, err)
+		defer func() { _ = pr.ReadStop() }()
+
+		// Forge a dictionary page offset that actually points to a data page,
+		// so the read succeeds but the page type mismatches.
+		dataPageOffset := pr.Footer.RowGroups[0].Columns[0].MetaData.GetDataPageOffset()
+		pr.Footer.RowGroups[0].Columns[0].MetaData.DictionaryPageOffset = &dataPageOffset
+		_, err = pr.ReadDictionaryPageValuesInColumn(0, 0)
+		require.ErrorContains(t, err, "expected dictionary page")
+	})
+}
+
+func TestPageInspectionDecryptorErrors(t *testing.T) {
+	t.Parallel()
+
+	pr := &ParquetReader{}
+	column := &parquet.ColumnChunk{
+		CryptoMetadata: &parquet.ColumnCryptoMetaData{
+			ENCRYPTION_WITH_FOOTER_KEY: parquet.NewEncryptionWithFooterKey(),
+		},
+	}
+
+	_, err := pr.pageInspectionDecryptor(nil, column, 0, 0)
+	require.ErrorContains(t, err, "encrypted column missing file encryption algorithm")
+}
+
+func TestPageInspectionDecryptorAADPrefixError(t *testing.T) {
+	t.Parallel()
+
+	// Algorithm requires the supplied AAD prefix but the reader was not
+	// configured with one, so footerAADParts returns an error.
+	pr := &ParquetReader{
+		FileCrypto: &parquet.FileCryptoMetaData{
+			EncryptionAlgorithm: &parquet.EncryptionAlgorithm{
+				AES_GCM_V1: &parquet.AesGcmV1{
+					AadFileUnique:   []byte("file-unique"),
+					SupplyAadPrefix: boolPtr(true),
+				},
+			},
+		},
+	}
+	column := &parquet.ColumnChunk{
+		CryptoMetadata: &parquet.ColumnCryptoMetaData{
+			ENCRYPTION_WITH_FOOTER_KEY: parquet.NewEncryptionWithFooterKey(),
+		},
+	}
+
+	_, err := pr.pageInspectionDecryptor(nil, column, 0, 0)
+	require.ErrorContains(t, err, "AAD prefix is required")
+}
+
+func TestPageBodyDiskSize(t *testing.T) {
+	t.Parallel()
+
+	t.Run("plaintext returns CompressedPageSize", func(t *testing.T) {
+		t.Parallel()
+		header := &parquet.PageHeader{CompressedPageSize: 17}
+		size, err := pageBodyDiskSize(bytes.NewReader(nil), header, nil)
+		require.NoError(t, err)
+		require.Equal(t, int64(17), size)
+	})
+
+	t.Run("encrypted reads length prefix", func(t *testing.T) {
+		t.Parallel()
+		var prefix [4]byte
+		binary.LittleEndian.PutUint32(prefix[:], 123)
+		size, err := pageBodyDiskSize(bytes.NewReader(prefix[:]), &parquet.PageHeader{}, &layout.PageDecryptor{})
+		require.NoError(t, err)
+		require.Equal(t, int64(4+123), size)
+	})
+
+	t.Run("length too short to read", func(t *testing.T) {
+		t.Parallel()
+		_, err := pageBodyDiskSize(bytes.NewReader([]byte{1, 2}), &parquet.PageHeader{}, &layout.PageDecryptor{})
+		require.ErrorContains(t, err, "read encrypted page body length")
+	})
+
+	t.Run("length exceeds max page size", func(t *testing.T) {
+		t.Parallel()
+		var prefix [4]byte
+		binary.LittleEndian.PutUint32(prefix[:], uint32(layout.DefaultMaxPageSize+1))
+		_, err := pageBodyDiskSize(bytes.NewReader(prefix[:]), &parquet.PageHeader{}, &layout.PageDecryptor{})
+		require.ErrorContains(t, err, "exceeds limit")
+	})
+}
+
+func TestReadPageBodyErrors(t *testing.T) {
+	t.Parallel()
+
+	key := []byte("0123456789abcdef")
+	decryptor := &layout.PageDecryptor{
+		Algorithm:     layout.PageEncryptionAESGCM,
+		Key:           key,
+		AADPrefix:     []byte("prefix"),
+		AADFileUnique: []byte("file-unique"),
+	}
+
+	t.Run("read encrypted body fails", func(t *testing.T) {
+		t.Parallel()
+		// Empty buffer — encryption.ReadModule will fail reading the length.
+		_, err := readPageBody(bytes.NewReader(nil), 0, &parquet.PageHeader{Type: parquet.PageType_DICTIONARY_PAGE}, parquet.CompressionCodec_UNCOMPRESSED, common.CRCIgnore, decryptor)
+		require.ErrorContains(t, err, "read encrypted page body")
+	})
+
+	t.Run("decrypt fails with wrong key", func(t *testing.T) {
+		t.Parallel()
+		header := &parquet.PageHeader{Type: parquet.PageType_DICTIONARY_PAGE}
+		// Build a well-formed module encrypted with the right key, then try to
+		// decrypt with a different decryptor key so DecryptGCM fails the tag.
+		aad := encryption.AAD(decryptor.AADPrefix, decryptor.AADFileUnique, encryption.ModuleDictionaryPage, 0, 0, 0)
+		mod, err := encryption.EncryptGCM(key, aad, []byte("hello"))
+		require.NoError(t, err)
+		encoded, err := encryption.EncodeModule(mod)
+		require.NoError(t, err)
+
+		wrongKeyDecryptor := *decryptor
+		wrongKeyDecryptor.Key = []byte("abcdef0123456789")
+		_, err = readPageBody(bytes.NewReader(encoded), 0, header, parquet.CompressionCodec_UNCOMPRESSED, common.CRCIgnore, &wrongKeyDecryptor)
+		require.ErrorContains(t, err, "decrypt page body")
+	})
+
+	t.Run("decompress fails on bogus data", func(t *testing.T) {
+		t.Parallel()
+		// Plaintext path: feed bytes that aren't valid GZIP.
+		header := &parquet.PageHeader{CompressedPageSize: 8, UncompressedPageSize: 64}
+		buf := make([]byte, 8) // not a valid gzip stream
+		_, err := readPageBody(bytes.NewReader(buf), 0, header, parquet.CompressionCodec_GZIP, common.CRCIgnore, nil)
+		require.ErrorContains(t, err, "decompress page data")
+	})
+}
+
+func TestReadPageHeaderEncryptedErrors(t *testing.T) {
+	t.Parallel()
+
+	decryptor := &layout.PageDecryptor{
+		Algorithm:     layout.PageEncryptionAESGCM,
+		Key:           []byte("0123456789abcdef"),
+		AADPrefix:     []byte("prefix"),
+		AADFileUnique: []byte("file-unique"),
+	}
+
+	t.Run("read module length fails", func(t *testing.T) {
+		t.Parallel()
+		_, _, err := readPageHeader(bytes.NewReader(nil), 0, decryptor)
+		require.ErrorContains(t, err, "read encrypted page header module")
+	})
+
+	t.Run("decrypt fails", func(t *testing.T) {
+		t.Parallel()
+		// Build a module encrypted with a different key so DecryptPageHeader fails.
+		aad := encryption.AAD(decryptor.AADPrefix, decryptor.AADFileUnique, encryption.ModuleDataPageHeader, 0, 0, 0)
+		header := &parquet.PageHeader{
+			Type:                 parquet.PageType_DATA_PAGE,
+			CompressedPageSize:   4,
+			UncompressedPageSize: 4,
+			DataPageHeader:       &parquet.DataPageHeader{NumValues: 1, Encoding: parquet.Encoding_PLAIN, DefinitionLevelEncoding: parquet.Encoding_RLE, RepetitionLevelEncoding: parquet.Encoding_RLE},
+		}
+		plain := serializeThrift(t, header)
+		mod, err := encryption.EncryptGCM([]byte("abcdef0123456789"), aad, plain)
+		require.NoError(t, err)
+		encoded, err := encryption.EncodeModule(mod)
+		require.NoError(t, err)
+
+		_, _, err = readPageHeader(bytes.NewReader(encoded), 0, decryptor)
+		require.ErrorContains(t, err, "decrypt page header")
+	})
+}
+
+func TestPageInspectionDecryptorUsesRowGroupOrdinal(t *testing.T) {
+	t.Parallel()
+
+	key := []byte("0123456789abcdef")
+	pr := &ParquetReader{
+		FileCrypto: &parquet.FileCryptoMetaData{
+			EncryptionAlgorithm: &parquet.EncryptionAlgorithm{
+				AES_GCM_V1: &parquet.AesGcmV1{
+					AadPrefix:     []byte("prefix"),
+					AadFileUnique: []byte("file-unique"),
+				},
+			},
+		},
+	}
+	applyReaderOptionsForTest(t, pr, WithFooterKey(key))
+
+	column := &parquet.ColumnChunk{
+		CryptoMetadata: &parquet.ColumnCryptoMetaData{
+			ENCRYPTION_WITH_FOOTER_KEY: parquet.NewEncryptionWithFooterKey(),
+		},
+	}
+	rg := &parquet.RowGroup{Ordinal: int16Ptr(42)}
+
+	dec, err := pr.pageInspectionDecryptor(rg, column, 1, 2)
+	require.NoError(t, err)
+	require.NotNil(t, dec)
+	require.Equal(t, int16(42), dec.RowGroupOrdinal)
+	require.Equal(t, int16(2), dec.ColumnOrdinal)
+}
+
+// buildEncryptedInspectionFile writes a small encrypted parquet file with both
+// a dictionary page and at least one data page per encrypted column, so the
+// page-inspection helpers have something to walk.
+func buildEncryptedInspectionFile(t *testing.T, footerKey, nameKey []byte, algoOpt writer.WriterOption) []byte {
+	t.Helper()
+
+	var out bytes.Buffer
+	pw, err := writer.NewParquetWriter(
+		writerfile.NewWriterFile(&out),
+		new(encryptedReaderRecord),
+		writer.WithNP(1),
+		writer.WithRowGroupSize(128),
+		writer.WithPageSize(32),
+		writer.WithCompressionCodec(parquet.CompressionCodec_UNCOMPRESSED),
+		algoOpt,
+		writer.WithFooterKey(footerKey, []byte("footer-key")),
+		writer.WithColumnKey("name", nameKey, []byte("name-key")),
+		writer.WithAADPrefix([]byte("reader-test")),
+		writer.WithAADFileUnique([]byte("reader-test-001")),
+	)
+	require.NoError(t, err)
+	// Small page size + multiple unique names ensures the dictionary is written
+	// and we get more than one data page after it.
+	require.NoError(t, pw.Write(encryptedReaderRecord{ID: 1, Name: "alpha"}))
+	require.NoError(t, pw.Write(encryptedReaderRecord{ID: 2, Name: "beta"}))
+	require.NoError(t, pw.Write(encryptedReaderRecord{ID: 3, Name: "gamma"}))
+	require.NoError(t, pw.Write(encryptedReaderRecord{ID: 4, Name: "alpha"}))
+	require.NoError(t, pw.Write(encryptedReaderRecord{ID: 5, Name: "beta"}))
+	require.NoError(t, pw.Write(encryptedReaderRecord{ID: 6, Name: "gamma"}))
+	require.NoError(t, pw.WriteStop())
+	return out.Bytes()
+}
+
+// encryptedColumnIndex finds the leaf-name column in the first row group.
+func encryptedColumnIndex(t *testing.T, pr *ParquetReader, leaf string) int {
+	t.Helper()
+	for i, c := range pr.Footer.RowGroups[0].Columns {
+		path := c.MetaData.GetPathInSchema()
+		if len(path) > 0 && strings.EqualFold(path[len(path)-1], leaf) {
+			return i
+		}
+	}
+	t.Fatalf("column with leaf %q not found", leaf)
+	return -1
 }
 
 func TestConfigurePageDecryptor(t *testing.T) {

--- a/reader/page.go
+++ b/reader/page.go
@@ -3,6 +3,7 @@ package reader
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"fmt"
 	"io"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/hangxie/parquet-go/v3/common"
 	"github.com/hangxie/parquet-go/v3/internal/compress"
 	"github.com/hangxie/parquet-go/v3/internal/encoding"
+	"github.com/hangxie/parquet-go/v3/internal/encryption"
 	"github.com/hangxie/parquet-go/v3/internal/layout"
 	"github.com/hangxie/parquet-go/v3/parquet"
 )
@@ -79,33 +81,62 @@ func (p *positionTracker) Open() error {
 	return nil
 }
 
-// readPageHeader reads a page header from the given offset
-// This is an internal helper function used by readAllPageHeaders
-func readPageHeader(pFile io.ReadSeeker, offset int64) (*parquet.PageHeader, int64, error) {
-	// Seek to page header position
-	_, err := pFile.Seek(offset, io.SeekStart)
-	if err != nil {
+// readPageHeader reads a page header from the given offset. When decryptor is
+// non-nil the page header is read as a length-prefixed encrypted module and
+// decrypted in place. The returned headerSize is the number of bytes consumed
+// on disk by the header (including the 4-byte length prefix for encrypted
+// modules).
+func readPageHeader(pFile io.ReadSeeker, offset int64, decryptor *layout.PageDecryptor) (*parquet.PageHeader, int64, error) {
+	if _, err := pFile.Seek(offset, io.SeekStart); err != nil {
 		return nil, 0, fmt.Errorf("seek to page: %w", err)
 	}
 
-	// Create a position-tracking transport
-	trackingTransport := &positionTracker{r: pFile, pos: offset}
-	proto := thrift.NewTCompactProtocolConf(trackingTransport, nil)
+	if decryptor == nil {
+		trackingTransport := &positionTracker{r: pFile, pos: offset}
+		proto := thrift.NewTCompactProtocolConf(trackingTransport, nil)
 
-	pageHeader := parquet.NewPageHeader()
-	if err := pageHeader.Read(context.Background(), proto); err != nil {
-		return nil, 0, fmt.Errorf("decode page header: %w", err)
+		pageHeader := parquet.NewPageHeader()
+		if err := pageHeader.Read(context.Background(), proto); err != nil {
+			return nil, 0, fmt.Errorf("decode page header: %w", err)
+		}
+
+		headerSize := trackingTransport.pos - offset
+		if _, err := pFile.Seek(trackingTransport.pos, io.SeekStart); err != nil {
+			return nil, 0, fmt.Errorf("seek after header: %w", err)
+		}
+		return pageHeader, headerSize, nil
 	}
 
-	headerSize := trackingTransport.pos - offset
-
-	// Seek to end of header
-	_, err = pFile.Seek(trackingTransport.pos, io.SeekStart)
+	module, err := encryption.ReadModule(pFile, layout.DefaultMaxPageSize)
 	if err != nil {
-		return nil, 0, fmt.Errorf("seek after header: %w", err)
+		return nil, 0, fmt.Errorf("read encrypted page header module: %w", err)
 	}
-
+	pageHeader, err := layout.DecryptPageHeader(module, decryptor)
+	if err != nil {
+		return nil, 0, fmt.Errorf("decrypt page header: %w", err)
+	}
+	headerSize := int64(4 + len(module))
 	return pageHeader, headerSize, nil
+}
+
+// pageBodyDiskSize returns the on-disk size of a page body given the page
+// header. For plaintext pages the size is the compressed page size; for
+// encrypted pages the size is the 4-byte length prefix plus the encrypted
+// module body. The reader is positioned at the start of the body and is left
+// positioned immediately after the body when this returns.
+func pageBodyDiskSize(pFile io.ReadSeeker, pageHeader *parquet.PageHeader, decryptor *layout.PageDecryptor) (int64, error) {
+	if decryptor == nil {
+		return int64(pageHeader.CompressedPageSize), nil
+	}
+	var lengthBuf [4]byte
+	if _, err := io.ReadFull(pFile, lengthBuf[:]); err != nil {
+		return 0, fmt.Errorf("read encrypted page body length: %w", err)
+	}
+	bodyLen := int64(binary.LittleEndian.Uint32(lengthBuf[:]))
+	if bodyLen < 0 || bodyLen > layout.DefaultMaxPageSize {
+		return 0, fmt.Errorf("encrypted page body length %d exceeds limit %d", bodyLen, layout.DefaultMaxPageSize)
+	}
+	return 4 + bodyLen, nil
 }
 
 // ExtractPageHeaderInfo converts a parquet.PageHeader to PageHeaderInfo
@@ -166,9 +197,11 @@ func ExtractPageHeaderInfo(pageHeader *parquet.PageHeader, offset int64, index i
 	return info
 }
 
-// readAllPageHeaders reads all page headers from a column chunk
-// Returns a slice of PageHeaderInfo containing metadata about each page
-func readAllPageHeaders(pFile io.ReadSeeker, columnChunk *parquet.ColumnChunk) ([]PageHeaderInfo, error) {
+// readAllPageHeaders reads all page headers from a column chunk. When
+// decryptor is non-nil page headers are decrypted and body lengths are read
+// from the encrypted module prefix. The decryptor's PageOrdinal is advanced
+// after each data page so the next header's AAD matches the file layout.
+func readAllPageHeaders(pFile io.ReadSeeker, columnChunk *parquet.ColumnChunk, decryptor *layout.PageDecryptor) ([]PageHeaderInfo, error) {
 	meta := columnChunk.MetaData
 	if meta == nil {
 		return nil, fmt.Errorf("column chunk metadata is nil")
@@ -187,7 +220,7 @@ func readAllPageHeaders(pFile io.ReadSeeker, columnChunk *parquet.ColumnChunk) (
 
 	// Read pages until we've read all values
 	for totalValuesRead < meta.NumValues {
-		pageHeader, headerSize, err := readPageHeader(pFile, currentOffset)
+		pageHeader, headerSize, err := readPageHeader(pFile, currentOffset, decryptor)
 		if err != nil {
 			return nil, fmt.Errorf("read page header at offset %d: %w", currentOffset, err)
 		}
@@ -204,18 +237,23 @@ func readAllPageHeaders(pFile io.ReadSeeker, columnChunk *parquet.ColumnChunk) (
 		}
 		totalValuesRead += valuesInPage
 
-		// Move to next page
-		currentOffset = currentOffset + headerSize + int64(pageHeader.CompressedPageSize)
+		bodySize, err := pageBodyDiskSize(pFile, pageHeader, decryptor)
+		if err != nil {
+			return nil, fmt.Errorf("read page body size at offset %d: %w", currentOffset, err)
+		}
+		currentOffset = currentOffset + headerSize + bodySize
 		pageIndex++
+		advancePageOrdinal(decryptor, pageHeader)
 	}
 
 	return pages, nil
 }
 
-// readFirstDataPageHeader reads page headers sequentially until finding the first data page header.
-// This is more efficient than reading all page headers when you only need the first data page.
-// It skips dictionary pages and other non-data pages to find the first actual data page.
-func readFirstDataPageHeader(pFile io.ReadSeeker, columnChunk *parquet.ColumnChunk) (*PageHeaderInfo, error) {
+// readFirstDataPageHeader reads page headers sequentially until finding the
+// first data page header. When decryptor is non-nil pages are decrypted as
+// they are walked; dictionary headers occupy ordinal 0 so the data-page
+// ordinal does not need to advance before the first data page.
+func readFirstDataPageHeader(pFile io.ReadSeeker, columnChunk *parquet.ColumnChunk, decryptor *layout.PageDecryptor) (*PageHeaderInfo, error) {
 	meta := columnChunk.MetaData
 	if meta == nil {
 		return nil, fmt.Errorf("column chunk metadata is nil")
@@ -230,7 +268,7 @@ func readFirstDataPageHeader(pFile io.ReadSeeker, columnChunk *parquet.ColumnChu
 
 	// Read page headers sequentially until we find the first data page
 	for {
-		pageHeader, headerSize, err := readPageHeader(pFile, offset)
+		pageHeader, headerSize, err := readPageHeader(pFile, offset, decryptor)
 		if err != nil {
 			return nil, fmt.Errorf("read page header at offset %d: %w", offset, err)
 		}
@@ -243,8 +281,23 @@ func readFirstDataPageHeader(pFile io.ReadSeeker, columnChunk *parquet.ColumnChu
 			return &headerInfo, nil
 		}
 
-		// Not a data page, move to next page
-		offset = offset + headerSize + int64(pageHeader.CompressedPageSize)
+		bodySize, err := pageBodyDiskSize(pFile, pageHeader, decryptor)
+		if err != nil {
+			return nil, fmt.Errorf("read page body size at offset %d: %w", offset, err)
+		}
+		offset = offset + headerSize + bodySize
+	}
+}
+
+// advancePageOrdinal bumps the decryptor's per-data-page ordinal so the next
+// header's AAD matches the writer's per-page sequence. Dictionary, index, and
+// other non-data pages do not advance the ordinal.
+func advancePageOrdinal(decryptor *layout.PageDecryptor, pageHeader *parquet.PageHeader) {
+	if decryptor == nil {
+		return
+	}
+	if pageHeader.GetType() == parquet.PageType_DATA_PAGE || pageHeader.GetType() == parquet.PageType_DATA_PAGE_V2 {
+		decryptor.PageOrdinal++
 	}
 }
 
@@ -256,7 +309,7 @@ func ReadPageData(pFile io.ReadSeeker, offset int64, pageHeader *parquet.PageHea
 		opt = *opts
 	}
 	// Re-read the header to get exact header size
-	_, headerSize, err := readPageHeader(pFile, offset)
+	_, headerSize, err := readPageHeader(pFile, offset, nil)
 	if err != nil {
 		return nil, fmt.Errorf("read page header: %w", err)
 	}
@@ -339,8 +392,10 @@ func DecodeDictionaryPage(data []byte, pageHeader *parquet.PageHeader, physicalT
 	return values, nil
 }
 
-// GetAllPageHeaders returns metadata for all pages in a column chunk
-// This is useful for tools that need to inspect page structure
+// GetAllPageHeaders returns metadata for all pages in a column chunk. When the
+// column is encrypted the reader's configured keys are used to decrypt page
+// headers transparently. Missing keys surface the standard "decryption key
+// required for column" error.
 func (pr *ParquetReader) GetAllPageHeaders(rgIndex, colIndex int) ([]PageHeaderInfo, error) {
 	if rgIndex < 0 || rgIndex >= len(pr.Footer.RowGroups) {
 		return nil, fmt.Errorf("invalid row group index: %d (valid range: 0-%d)", rgIndex, len(pr.Footer.RowGroups)-1)
@@ -352,14 +407,16 @@ func (pr *ParquetReader) GetAllPageHeaders(rgIndex, colIndex int) ([]PageHeaderI
 	}
 
 	column := rg.Columns[colIndex]
-	if column != nil && column.GetCryptoMetadata() != nil {
-		return nil, fmt.Errorf("page header inspection is not supported for encrypted columns")
+	decryptor, err := pr.pageInspectionDecryptor(rg, column, int16(rgIndex), int16(colIndex))
+	if err != nil {
+		return nil, err
 	}
-	return readAllPageHeaders(pr.PFile, column)
+	return readAllPageHeaders(pr.PFile, column, decryptor)
 }
 
-// GetFirstDataPageHeader returns metadata for the first data page in a column chunk
-// This is more efficient than GetAllPageHeaders when you only need the first data page
+// GetFirstDataPageHeader returns metadata for the first data page in a column
+// chunk. When the column is encrypted the reader's configured keys are used to
+// decrypt page headers transparently.
 func (pr *ParquetReader) GetFirstDataPageHeader(rgIndex, colIndex int) (*PageHeaderInfo, error) {
 	if rgIndex < 0 || rgIndex >= len(pr.Footer.RowGroups) {
 		return nil, fmt.Errorf("invalid row group index: %d (valid range: 0-%d)", rgIndex, len(pr.Footer.RowGroups)-1)
@@ -371,21 +428,24 @@ func (pr *ParquetReader) GetFirstDataPageHeader(rgIndex, colIndex int) (*PageHea
 	}
 
 	column := rg.Columns[colIndex]
-	if column != nil && column.GetCryptoMetadata() != nil {
-		return nil, fmt.Errorf("page header inspection is not supported for encrypted columns")
+	decryptor, err := pr.pageInspectionDecryptor(rg, column, int16(rgIndex), int16(colIndex))
+	if err != nil {
+		return nil, err
 	}
-	return readFirstDataPageHeader(pr.PFile, column)
+	return readFirstDataPageHeader(pr.PFile, column, decryptor)
 }
 
-// ReadDictionaryPageValues reads and decodes dictionary page values at the given offset
-// This is a convenience function for tools that need to inspect dictionary pages directly
+// ReadDictionaryPageValues reads and decodes dictionary page values at the
+// given offset. This offset-based form is plaintext-only because the offset
+// cannot identify the column whose key would be required to decrypt the page;
+// use ReadDictionaryPageValuesInColumn for encrypted columns.
 func (pr *ParquetReader) ReadDictionaryPageValues(offset int64, codec parquet.CompressionCodec, physicalType parquet.Type) ([]interface{}, error) {
 	if pr.pageOffsetEncrypted(offset) {
-		return nil, fmt.Errorf("dictionary page inspection is not supported for encrypted columns")
+		return nil, fmt.Errorf("dictionary page inspection is not supported for encrypted columns at offset %d; use ReadDictionaryPageValuesInColumn", offset)
 	}
 
 	// Read page header at the offset
-	pageHeader, _, err := readPageHeader(pr.PFile, offset)
+	pageHeader, _, err := readPageHeader(pr.PFile, offset, nil)
 	if err != nil {
 		return nil, fmt.Errorf("read page header: %w", err)
 	}
@@ -407,6 +467,140 @@ func (pr *ParquetReader) ReadDictionaryPageValues(offset int64, codec parquet.Co
 	}
 
 	return values, nil
+}
+
+// ReadDictionaryPageValuesInColumn reads and decodes dictionary page values
+// for the dictionary page of the given column chunk. Offset, codec, and
+// physical type are derived from the column metadata, and encrypted columns
+// are decrypted transparently when the reader has the right keys.
+func (pr *ParquetReader) ReadDictionaryPageValuesInColumn(rgIndex, colIndex int) ([]interface{}, error) {
+	if rgIndex < 0 || rgIndex >= len(pr.Footer.RowGroups) {
+		return nil, fmt.Errorf("invalid row group index: %d (valid range: 0-%d)", rgIndex, len(pr.Footer.RowGroups)-1)
+	}
+	rg := pr.Footer.RowGroups[rgIndex]
+	if colIndex < 0 || colIndex >= len(rg.Columns) {
+		return nil, fmt.Errorf("invalid column index: %d (valid range: 0-%d)", colIndex, len(rg.Columns)-1)
+	}
+
+	column := rg.Columns[colIndex]
+	if column == nil || column.MetaData == nil {
+		return nil, fmt.Errorf("column %d metadata is nil", colIndex)
+	}
+	if !column.MetaData.IsSetDictionaryPageOffset() {
+		return nil, fmt.Errorf("column %d does not have a dictionary page", colIndex)
+	}
+
+	decryptor, err := pr.pageInspectionDecryptor(rg, column, int16(rgIndex), int16(colIndex))
+	if err != nil {
+		return nil, err
+	}
+
+	offset := column.MetaData.GetDictionaryPageOffset()
+	pageHeader, headerSize, err := readPageHeader(pr.PFile, offset, decryptor)
+	if err != nil {
+		return nil, fmt.Errorf("read page header: %w", err)
+	}
+	if pageHeader.Type != parquet.PageType_DICTIONARY_PAGE {
+		return nil, fmt.Errorf("expected dictionary page but got %v", pageHeader.Type)
+	}
+
+	data, err := readPageBody(pr.PFile, offset+headerSize, pageHeader, column.MetaData.GetCodec(), pr.crcMode, decryptor)
+	if err != nil {
+		return nil, fmt.Errorf("read page data: %w", err)
+	}
+
+	values, err := DecodeDictionaryPage(data, pageHeader, column.MetaData.GetType())
+	if err != nil {
+		return nil, fmt.Errorf("decode dictionary page: %w", err)
+	}
+	return values, nil
+}
+
+// pageInspectionDecryptor builds a PageDecryptor when the column is encrypted
+// and returns nil for plaintext columns. Missing keys surface the standard
+// "decryption key required for column" error. rowGroupOrdinal is the index
+// fallback used when the row group does not carry an explicit ordinal.
+func (pr *ParquetReader) pageInspectionDecryptor(rg *parquet.RowGroup, column *parquet.ColumnChunk, rowGroupOrdinal, columnOrdinal int16) (*layout.PageDecryptor, error) {
+	if column == nil || column.GetCryptoMetadata() == nil {
+		return nil, nil
+	}
+	algorithm := pr.encryptionAlgorithm()
+	if algorithm == nil {
+		return nil, fmt.Errorf("encrypted column missing file encryption algorithm")
+	}
+	aadPrefix, aadFileUnique, err := pr.footerAADParts(algorithm)
+	if err != nil {
+		return nil, fmt.Errorf("footer AAD: %w", err)
+	}
+	key, err := pr.resolveColumnKey(column)
+	if err != nil {
+		return nil, fmt.Errorf("resolve column key: %w", err)
+	}
+	pageAlgorithm := layout.PageEncryptionAESGCM
+	if algorithm.IsSetAES_GCM_CTR_V1() {
+		pageAlgorithm = layout.PageEncryptionAESGCMCTR
+	}
+	if rg != nil && rg.IsSetOrdinal() {
+		rowGroupOrdinal = rg.GetOrdinal()
+	}
+	return &layout.PageDecryptor{
+		Algorithm:       pageAlgorithm,
+		Key:             key,
+		AADPrefix:       aadPrefix,
+		AADFileUnique:   aadFileUnique,
+		RowGroupOrdinal: rowGroupOrdinal,
+		ColumnOrdinal:   columnOrdinal,
+	}, nil
+}
+
+// readPageBody reads the page body bytes (decrypting when decryptor is non-nil)
+// from dataOffset, validates CRC, and decompresses according to codec. The
+// reader is repositioned to dataOffset first.
+func readPageBody(pFile io.ReadSeeker, dataOffset int64, pageHeader *parquet.PageHeader, codec parquet.CompressionCodec, crcMode common.CRCMode, decryptor *layout.PageDecryptor) ([]byte, error) {
+	if _, err := pFile.Seek(dataOffset, io.SeekStart); err != nil {
+		return nil, fmt.Errorf("seek to page data: %w", err)
+	}
+
+	var compressedData []byte
+	if decryptor == nil {
+		compressedData = make([]byte, pageHeader.CompressedPageSize)
+		if _, err := io.ReadFull(pFile, compressedData); err != nil {
+			return nil, fmt.Errorf("read compressed page data: %w", err)
+		}
+	} else {
+		module, err := encryption.ReadModule(pFile, layout.DefaultMaxPageSize)
+		if err != nil {
+			return nil, fmt.Errorf("read encrypted page body: %w", err)
+		}
+		if decryptor.Algorithm == layout.PageEncryptionAESGCMCTR {
+			compressedData, err = encryption.DecryptCTR(decryptor.Key, module)
+		} else {
+			compressedData, err = encryption.DecryptGCM(decryptor.Key, dictionaryOrDataPageAAD(decryptor, pageHeader), module)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("decrypt page body: %w", err)
+		}
+	}
+
+	if err := common.ValidatePageCRC(pageHeader.IsSetCrc(), pageHeader.GetCrc(), crcMode, compressedData); err != nil {
+		return nil, fmt.Errorf("CRC validation failed: %w", err)
+	}
+
+	uncompressed, err := compress.UncompressWithExpectedSize(compressedData, codec, int64(pageHeader.UncompressedPageSize))
+	if err != nil {
+		return nil, fmt.Errorf("decompress page data: %w", err)
+	}
+	return uncompressed, nil
+}
+
+func dictionaryOrDataPageAAD(decryptor *layout.PageDecryptor, pageHeader *parquet.PageHeader) []byte {
+	moduleType := encryption.ModuleDataPage
+	pageOrdinal := decryptor.PageOrdinal
+	if pageHeader.GetType() == parquet.PageType_DICTIONARY_PAGE {
+		moduleType = encryption.ModuleDictionaryPage
+		pageOrdinal = 0
+	}
+	return encryption.AAD(decryptor.AADPrefix, decryptor.AADFileUnique, moduleType, decryptor.RowGroupOrdinal, decryptor.ColumnOrdinal, pageOrdinal)
 }
 
 func (pr *ParquetReader) pageOffsetEncrypted(offset int64) bool {

--- a/reader/page_test.go
+++ b/reader/page_test.go
@@ -1342,7 +1342,7 @@ func TestReadAllPageHeaders_NilMetadata(t *testing.T) {
 		MetaData: nil,
 	}
 
-	_, err := readAllPageHeaders(buf, cc)
+	_, err := readAllPageHeaders(buf, cc, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "metadata is nil")
 }


### PR DESCRIPTION
This is for https://github.com/hangxie/parquet-go/issues/287

GetAllPageHeaders and GetFirstDataPageHeader transparently decrypt page headers when the reader has the right keys; missing keys surface the standard "decryption key required for column" error. Adds new ReadDictionaryPageValuesInColumn(rgIdx, colIdx) sibling for the offset-based ReadDictionaryPageValues, which cannot identify a column key from an offset alone.

The page header reader now accepts an optional PageDecryptor, page ordinals advance per data page (not dictionary or index pages), and encrypted body lengths are consumed from the 4-byte module prefix so iteration stays aligned even when CompressedPageSize semantics differ between writers.

Resolves #287