### PR TITLE
feat(parquet): add UNKNOWN logical type support

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ Schema notes:
 - `PARGO_PREFIX_` is reserved and should not be used as a field prefix.
 - Use `\x01` as a delimiter when a field name needs to contain `.`.
 - Arrow `Float16` fields are written as `FIXED_LEN_BYTE_ARRAY` with `length=2` and `logicaltype=FLOAT16`; generic Parquet reads expose them as raw two-byte strings. Use `types.ConvertFloat16LogicalValue` when a `float32` value is needed. FLOAT16 statistics and column indexes use the Parquet FLOAT16 total ordering.
+- `UNKNOWN` columns represent always-null columns per the Parquet spec. The Go field must be `*int32` with `repetitiontype=OPTIONAL`. The writer rejects any non-nil value with an error. For a well-formed file every read returns `nil`; a malformed file that stores a non-null INT32 value in an UNKNOWN column will have that value returned as-is.
 
 ## Type System
 
@@ -259,6 +260,7 @@ Schema notes:
 | `DECIMAL` | `INT32`, `INT64`, `FIXED_LEN_BYTE_ARRAY`, `BYTE_ARRAY` | `int32`, `int64`, `string`, `string` |
 | `UUID` | `FIXED_LEN_BYTE_ARRAY` | `string` |
 | `FLOAT16` | `FIXED_LEN_BYTE_ARRAY` | `string` |
+| `UNKNOWN` | `INT32` | `*int32` (always `nil`) |
 | `GEOMETRY` | `BYTE_ARRAY` | `string` |
 | `GEOGRAPHY` | `BYTE_ARRAY` | `string` |
 | `JSON` | `BYTE_ARRAY` | `string` |
@@ -664,6 +666,7 @@ go build -tags example ./example/all_types
 | [type](example/type) | Type examples |
 | [type_alias](example/type_alias) | Type alias examples |
 | [new_logical](example/new_logical) | New logical types including FLOAT16 and INTEGER |
+| [unknown_type](example/unknown_type) | UNKNOWN logical type (always-null columns) |
 | [geospatial](example/geospatial) | GEOMETRY and GEOGRAPHY examples |
 | [bloom_filter](example/bloom_filter) | Bloom filter |
 | [encrypt_write](example/encrypt_write) | Write and read back encrypted Parquet files |

--- a/common/functable.go
+++ b/common/functable.go
@@ -165,6 +165,9 @@ func findFuncTableByLogicalType(pT *parquet.Type, logT *parquet.LogicalType) (Fu
 	if logT == nil {
 		return nil, false
 	}
+	if logT.UNKNOWN != nil {
+		return nil, false
+	}
 	if logT.TIME != nil || logT.TIMESTAMP != nil {
 		table, err := FindFuncTable(pT, nil, nil)
 		if err != nil {
@@ -226,6 +229,13 @@ func FindFuncTable(pT *parquet.Type, cT *parquet.ConvertedType, logT *parquet.Lo
 
 	if table, ok := findFuncTableByLogicalType(pT, logT); ok {
 		return table, nil
+	}
+
+	// If logT has UNKNOWN set, fall back to physical type
+	if logT != nil && logT.UNKNOWN != nil && pT != nil {
+		if table, ok := parquetTypeFuncTable[*pT]; ok {
+			return table, nil
+		}
 	}
 
 	return nil, fmt.Errorf("find func table for given types: %v, %v, %v", pT, cT, logT)

--- a/common/functable_test.go
+++ b/common/functable_test.go
@@ -69,6 +69,8 @@ func TestFindFuncTable(t *testing.T) {
 		"BYTE_ARRAY-nil-VARIANT":   {ToPtr(parquet.Type_BYTE_ARRAY), nil, &parquet.LogicalType{VARIANT: &parquet.VariantType{}}, stringFuncTable{}},
 		"BYTE_ARRAY-nil-GEOMETRY":  {ToPtr(parquet.Type_BYTE_ARRAY), nil, &parquet.LogicalType{GEOMETRY: &parquet.GeometryType{}}, stringFuncTable{}},
 		"BYTE_ARRAY-nil-GEOGRAPHY": {ToPtr(parquet.Type_BYTE_ARRAY), nil, &parquet.LogicalType{GEOGRAPHY: &parquet.GeographyType{}}, stringFuncTable{}},
+		// UNKNOWN logical type falls back to the physical type's func table
+		"INT32-nil-UNKNOWN": {ToPtr(parquet.Type_INT32), nil, &parquet.LogicalType{UNKNOWN: parquet.NewNullType()}, int32FuncTable{}},
 	}
 
 	for name, tc := range testCases {

--- a/common/logicaltype.go
+++ b/common/logicaltype.go
@@ -284,6 +284,8 @@ func newLogicalTypeFromFieldsMap(mp map[string]string) (*parquet.LogicalType, er
 		if logicalType.GEOGRAPHY, err = newGeographyLogicalType(mp); err != nil {
 			return nil, fmt.Errorf("build GEOGRAPHY logical type: %w", err)
 		}
+	case "UNKNOWN":
+		logicalType.UNKNOWN = parquet.NewNullType()
 	default:
 		return nil, fmt.Errorf("unknown logicaltype: %s", val)
 	}

--- a/common/logicaltype_test.go
+++ b/common/logicaltype_test.go
@@ -406,6 +406,11 @@ func TestNewLogicalTypeFromFieldsMap(t *testing.T) {
 			parquet.LogicalType{GEOGRAPHY: &parquet.GeographyType{}},
 			"logicaltype geography error, unknown algorithm:",
 		},
+		"unknown": {
+			map[string]string{"logicaltype": "UNKNOWN"},
+			parquet.LogicalType{UNKNOWN: &parquet.NullType{}},
+			"",
+		},
 	}
 
 	for name, tc := range testCases {

--- a/common/tag_schema.go
+++ b/common/tag_schema.go
@@ -162,6 +162,15 @@ func validateLogicalType(schema *parquet.SchemaElement) error {
 		return nil
 	}
 	lt := schema.LogicalType
+	if lt.UNKNOWN != nil {
+		if schema.Type == nil || *schema.Type != parquet.Type_INT32 {
+			return fmt.Errorf("LogicalType UNKNOWN can only be used with INT32")
+		}
+		if schema.RepetitionType == nil || *schema.RepetitionType != parquet.FieldRepetitionType_OPTIONAL {
+			return fmt.Errorf("LogicalType UNKNOWN requires OPTIONAL repetition type")
+		}
+		return nil
+	}
 	if lt.STRING != nil || lt.JSON != nil || lt.BSON != nil || lt.ENUM != nil {
 		if *schema.Type != parquet.Type_BYTE_ARRAY {
 			return fmt.Errorf("LogicalType STRING/JSON/BSON/ENUM can only be used with BYTE_ARRAY")

--- a/common/tag_schema_test.go
+++ b/common/tag_schema_test.go
@@ -206,3 +206,78 @@ func TestValidateLogicalInteger(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateLogicalUnknown(t *testing.T) {
+	testCases := map[string]struct {
+		schema *parquet.SchemaElement
+		errMsg string
+	}{
+		"int32-optional-valid": {
+			&parquet.SchemaElement{
+				Type:           ToPtr(parquet.Type_INT32),
+				RepetitionType: ToPtr(parquet.FieldRepetitionType_OPTIONAL),
+				LogicalType:    &parquet.LogicalType{UNKNOWN: &parquet.NullType{}},
+			},
+			"",
+		},
+		"byte_array-invalid": {
+			&parquet.SchemaElement{
+				Type:           ToPtr(parquet.Type_BYTE_ARRAY),
+				RepetitionType: ToPtr(parquet.FieldRepetitionType_OPTIONAL),
+				LogicalType:    &parquet.LogicalType{UNKNOWN: &parquet.NullType{}},
+			},
+			"LogicalType UNKNOWN can only be used with INT32",
+		},
+		"int64-invalid": {
+			&parquet.SchemaElement{
+				Type:           ToPtr(parquet.Type_INT64),
+				RepetitionType: ToPtr(parquet.FieldRepetitionType_OPTIONAL),
+				LogicalType:    &parquet.LogicalType{UNKNOWN: &parquet.NullType{}},
+			},
+			"LogicalType UNKNOWN can only be used with INT32",
+		},
+		"required-invalid": {
+			&parquet.SchemaElement{
+				Type:           ToPtr(parquet.Type_INT32),
+				RepetitionType: ToPtr(parquet.FieldRepetitionType_REQUIRED),
+				LogicalType:    &parquet.LogicalType{UNKNOWN: &parquet.NullType{}},
+			},
+			"LogicalType UNKNOWN requires OPTIONAL repetition type",
+		},
+		"nil-repetitiontype-invalid": {
+			&parquet.SchemaElement{
+				Type:        ToPtr(parquet.Type_INT32),
+				LogicalType: &parquet.LogicalType{UNKNOWN: &parquet.NullType{}},
+			},
+			"LogicalType UNKNOWN requires OPTIONAL repetition type",
+		},
+		"nil_type": {
+			&parquet.SchemaElement{
+				Type:           nil,
+				RepetitionType: ToPtr(parquet.FieldRepetitionType_OPTIONAL),
+				LogicalType:    &parquet.LogicalType{UNKNOWN: &parquet.NullType{}},
+			},
+			"LogicalType UNKNOWN can only be used with INT32",
+		},
+		"repeated-invalid": {
+			&parquet.SchemaElement{
+				Type:           ToPtr(parquet.Type_INT32),
+				RepetitionType: ToPtr(parquet.FieldRepetitionType_REPEATED),
+				LogicalType:    &parquet.LogicalType{UNKNOWN: &parquet.NullType{}},
+			},
+			"LogicalType UNKNOWN requires OPTIONAL repetition type",
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			err := validateLogicalType(tc.schema)
+			if tc.errMsg == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.errMsg)
+			}
+		})
+	}
+}

--- a/example/unknown_type/main.go
+++ b/example/unknown_type/main.go
@@ -1,0 +1,61 @@
+//go:build example
+
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hangxie/parquet-go/v3/reader"
+	"github.com/hangxie/parquet-go/v3/source/local"
+	"github.com/hangxie/parquet-go/v3/writer"
+)
+
+// Row contains an always-null column using the UNKNOWN logical type.
+// NullCol must be *int32 (OPTIONAL INT32) and must always be written as nil.
+type Row struct {
+	ID      int32  `parquet:"name=id, type=INT32"`
+	NullCol *int32 `parquet:"name=null_col, type=INT32, logicaltype=UNKNOWN, repetitiontype=OPTIONAL"`
+}
+
+func main() {
+	const path = "/tmp/unknown-type.parquet"
+
+	// Write
+	fw, err := local.NewLocalFileWriter(path)
+	if err != nil {
+		log.Fatal(err)
+	}
+	pw, err := writer.NewParquetWriter(fw, new(Row), writer.WithNP(1))
+	if err != nil {
+		log.Fatal(err)
+	}
+	for i := range 3 {
+		if err := pw.Write(Row{ID: int32(i + 1), NullCol: nil}); err != nil {
+			log.Fatal(err)
+		}
+	}
+	if err := pw.WriteStop(); err != nil {
+		log.Fatal(err)
+	}
+	_ = fw.Close()
+
+	// Read
+	fr, err := local.NewLocalFileReader(path)
+	if err != nil {
+		log.Fatal(err)
+	}
+	pr, err := reader.NewParquetReader(fr, new(Row), reader.WithNP(1))
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer pr.ReadStop()
+
+	rows := make([]Row, pr.GetNumRows())
+	if err := pr.Read(&rows); err != nil {
+		log.Fatal(err)
+	}
+	for _, r := range rows {
+		fmt.Printf("ID=%d NullCol=%v\n", r.ID, r.NullCol)
+	}
+}

--- a/marshal/marshal.go
+++ b/marshal/marshal.go
@@ -322,6 +322,12 @@ func processNode(node *Node, res map[string]*layout.Table, schemaHandler *schema
 		return newStack, nil
 	}
 
+	if newStack, handled, handleErr := HandleUnknown(node, se, res, stack); handleErr != nil {
+		return nil, handleErr
+	} else if handled {
+		return newStack, nil
+	}
+
 	// []byte should be treated as primitive BYTE_ARRAY, not as a LIST
 	if isByteSlice(node) {
 		if err := marshalPrimitiveValue(node, res, schemaHandler); err != nil {
@@ -416,6 +422,28 @@ func setupTableMap(schemaHandler *schema.SchemaHandler, numElements int) (map[st
 		}
 	}
 	return tableMap, nil
+}
+
+// HandleUnknown enforces that UNKNOWN logical type columns always receive nil values.
+func HandleUnknown(node *Node, se *parquet.SchemaElement, res map[string]*layout.Table, stack []*Node) ([]*Node, bool, error) {
+	if se.LogicalType == nil || se.LogicalType.UNKNOWN == nil {
+		return stack, false, nil
+	}
+	isNil := !node.Val.IsValid()
+	if !isNil {
+		switch node.Val.Kind() {
+		case reflect.Pointer, reflect.Interface:
+			isNil = node.Val.IsNil()
+		}
+	}
+	if !isNil {
+		return nil, false, fmt.Errorf("UNKNOWN column %s must have nil value, got non-nil", node.PathMap.Path)
+	}
+	table := res[node.PathMap.Path]
+	table.Values = append(table.Values, nil)
+	table.DefinitionLevels = append(table.DefinitionLevels, node.DL)
+	table.RepetitionLevels = append(table.RepetitionLevels, node.RL)
+	return stack, true, nil
 }
 
 func HandleVariant(

--- a/marshal/marshal_test.go
+++ b/marshal/marshal_test.go
@@ -284,6 +284,30 @@ func TestMarshalEmptyContainer(t *testing.T) {
 	}
 }
 
+func TestMarshalUnknown(t *testing.T) {
+	type Row struct {
+		NullCol *int32 `parquet:"name=null_col, type=INT32, logicaltype=UNKNOWN, repetitiontype=OPTIONAL"`
+	}
+
+	sh, err := schema.NewSchemaHandlerFromStruct(new(Row))
+	require.NoError(t, err)
+
+	t.Run("nil_value_accepted", func(t *testing.T) {
+		rows := []any{Row{NullCol: nil}}
+		_, err := Marshal(rows, sh)
+		require.NoError(t, err)
+	})
+
+	t.Run("non_nil_value_rejected", func(t *testing.T) {
+		val := int32(42)
+		rows := []any{Row{NullCol: &val}}
+		_, err := Marshal(rows, sh)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "UNKNOWN column")
+		require.Contains(t, err.Error(), "nil value")
+	})
+}
+
 func TestParquetPtrMarshal(t *testing.T) {
 	integer := 10
 	testData := &marshalCases{

--- a/reader/read_test.go
+++ b/reader/read_test.go
@@ -2,9 +2,13 @@ package reader
 
 import (
 	"bytes"
+	"context"
+	"encoding/binary"
+	"fmt"
 	"strconv"
 	"testing"
 
+	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hangxie/parquet-go/v3/common"
@@ -246,6 +250,124 @@ func TestParquetReader_Reset_MultipleResets(t *testing.T) {
 			require.NoError(t, err)
 		}
 	}
+}
+
+func TestReadUnknownLogicalType(t *testing.T) {
+	type Row struct {
+		Name    string `parquet:"name=name, type=BYTE_ARRAY, logicaltype=STRING"`
+		NullCol *int32 `parquet:"name=null_col, type=INT32, logicaltype=UNKNOWN, repetitiontype=OPTIONAL"`
+	}
+
+	var buf bytes.Buffer
+	fw := writerfile.NewWriterFile(&buf)
+	pw, err := writer.NewParquetWriter(fw, new(Row), writer.WithNP(1))
+	require.NoError(t, err)
+	require.NoError(t, pw.Write(Row{Name: "foo", NullCol: nil}))
+	require.NoError(t, pw.Write(Row{Name: "bar", NullCol: nil}))
+	require.NoError(t, pw.WriteStop())
+
+	fr := buffer.NewBufferReaderFromBytesNoAlloc(buf.Bytes())
+	pr, err := NewParquetReader(fr, new(Row), WithNP(1))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, pr.ReadStop()) }()
+
+	rows := make([]Row, 2)
+	require.NoError(t, pr.Read(&rows))
+	require.Equal(t, "foo", rows[0].Name)
+	require.Nil(t, rows[0].NullCol)
+	require.Equal(t, "bar", rows[1].Name)
+	require.Nil(t, rows[1].NullCol)
+}
+
+// TestReadUnknownLogicalType_LooseRead verifies that a malformed parquet file
+// whose UNKNOWN column contains a non-null INT32 value is read back as-is
+// rather than being forced to nil.
+func TestReadUnknownLogicalType_LooseRead(t *testing.T) {
+	// Write with a plain OPTIONAL INT32 (no UNKNOWN) so the writer accepts a non-nil value.
+	type WriterRow struct {
+		Name    string `parquet:"name=name, type=BYTE_ARRAY, logicaltype=STRING"`
+		NullCol *int32 `parquet:"name=null_col, type=INT32, repetitiontype=OPTIONAL"`
+	}
+
+	var buf bytes.Buffer
+	fw := writerfile.NewWriterFile(&buf)
+	pw, err := writer.NewParquetWriter(fw, new(WriterRow), writer.WithNP(1))
+	require.NoError(t, err)
+	val := int32(42)
+	require.NoError(t, pw.Write(WriterRow{Name: "foo", NullCol: &val}))
+	require.NoError(t, pw.WriteStop())
+
+	// Patch the footer: mark null_col as UNKNOWN logical type.
+	patched, err := patchSchemaElementUnknown(buf.Bytes(), "null_col")
+	require.NoError(t, err)
+
+	// Read back via a struct that declares null_col as UNKNOWN — the non-nil value must survive.
+	type ReaderRow struct {
+		Name    string `parquet:"name=name, type=BYTE_ARRAY, logicaltype=STRING"`
+		NullCol *int32 `parquet:"name=null_col, type=INT32, logicaltype=UNKNOWN, repetitiontype=OPTIONAL"`
+	}
+
+	fr := buffer.NewBufferReaderFromBytesNoAlloc(patched)
+	pr, err := NewParquetReader(fr, new(ReaderRow), WithNP(1))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, pr.ReadStop()) }()
+
+	rows := make([]ReaderRow, 1)
+	require.NoError(t, pr.Read(&rows))
+	require.Equal(t, "foo", rows[0].Name)
+	require.NotNil(t, rows[0].NullCol)
+	require.Equal(t, int32(42), *rows[0].NullCol)
+}
+
+// patchSchemaElementUnknown rewrites the Thrift footer of a parquet byte slice,
+// setting LogicalType.UNKNOWN on the schema element named columnName.
+func patchSchemaElementUnknown(data []byte, columnName string) ([]byte, error) {
+	if len(data) < 12 {
+		return nil, fmt.Errorf("data too short to be a parquet file")
+	}
+	// Footer length sits at data[len-8:len-4]; trailing magic is data[len-4:].
+	footerLen := int(binary.LittleEndian.Uint32(data[len(data)-8 : len(data)-4]))
+	footerStart := len(data) - 8 - footerLen
+	if footerStart < 4 {
+		return nil, fmt.Errorf("computed footer start %d is out of range", footerStart)
+	}
+
+	// Decode footer.
+	footerBytes := data[footerStart : len(data)-8]
+	footer := parquet.NewFileMetaData()
+	proto := thrift.NewTCompactProtocolConf(
+		thrift.NewTBufferedTransport(thrift.NewStreamTransportR(bytes.NewReader(footerBytes)), len(footerBytes)),
+		&thrift.TConfiguration{},
+	)
+	if err := footer.Read(context.TODO(), proto); err != nil {
+		return nil, fmt.Errorf("decode footer: %w", err)
+	}
+
+	// Patch the target schema element.
+	for _, se := range footer.Schema {
+		if se.Name == columnName {
+			se.LogicalType = &parquet.LogicalType{UNKNOWN: parquet.NewNullType()}
+			break
+		}
+	}
+
+	// Re-encode footer.
+	ts := thrift.NewTSerializer()
+	ts.Protocol = thrift.NewTCompactProtocolFactoryConf(&thrift.TConfiguration{}).GetProtocol(ts.Transport)
+	newFooter, err := ts.Write(context.TODO(), footer)
+	if err != nil {
+		return nil, fmt.Errorf("encode footer: %w", err)
+	}
+
+	// Reconstruct: original data up to old footer + new footer + length + magic.
+	out := make([]byte, 0, footerStart+len(newFooter)+8)
+	out = append(out, data[:footerStart]...)
+	out = append(out, newFooter...)
+	lenBuf := make([]byte, 4)
+	binary.LittleEndian.PutUint32(lenBuf, uint32(len(newFooter)))
+	out = append(out, lenBuf...)
+	out = append(out, []byte("PAR1")...)
+	return out, nil
 }
 
 func TestParquetReader_Reset_AfterReadAll(t *testing.T) {

--- a/schema/gettype.go
+++ b/schema/gettype.go
@@ -313,9 +313,18 @@ func (sh *SchemaHandler) GetType(prefixPath string) (reflect.Type, error) {
 		toVisit = toVisit[:len(toVisit)-1]
 
 		if sh.SchemaElements[cur].GetNumChildren() == 0 {
+			elem := sh.SchemaElements[cur]
+			path := sh.IndexMap[cur]
+			if elem.LogicalType != nil && elem.LogicalType.UNKNOWN != nil {
+				if elem.Type == nil || *elem.Type != parquet.Type_INT32 {
+					return nil, fmt.Errorf("UNKNOWN column at %s must have INT32 physical type", path)
+				}
+				if elem.RepetitionType == nil || *elem.RepetitionType != parquet.FieldRepetitionType_OPTIONAL {
+					return nil, fmt.Errorf("UNKNOWN column at %s must have OPTIONAL repetition type", path)
+				}
+			}
 			t := ts[cur]
 			if t == nil || t.Kind() == reflect.Interface {
-				path := sh.IndexMap[cur]
 				return nil, fmt.Errorf("corrupt or unsupported schema at %s: unknown physical type", path)
 			}
 			continue

--- a/schema/gettype_test.go
+++ b/schema/gettype_test.go
@@ -310,6 +310,72 @@ func TestSchemaHandler_GetType(t *testing.T) {
 				require.Equal(t, reflect.String, resultType.Elem().Elem().Kind())
 			},
 		},
+		{
+			name: "unknown_wrong_physical_type",
+			setupHandler: func() *SchemaHandler {
+				optRep := parquet.FieldRepetitionType_OPTIONAL
+				wrongType := parquet.Type_BYTE_ARRAY
+				lt := parquet.NewLogicalType()
+				lt.UNKNOWN = parquet.NewNullType()
+				schemas := []*parquet.SchemaElement{
+					{Name: "root", NumChildren: common.ToPtr(int32(1))},
+					{Name: "null_col", Type: &wrongType, RepetitionType: &optRep, LogicalType: lt},
+				}
+				return NewSchemaHandlerFromSchemaList(schemas)
+			},
+			path:          "Root",
+			expectedError: "INT32 physical type",
+		},
+		{
+			name: "unknown_required_repetition",
+			setupHandler: func() *SchemaHandler {
+				reqRep := parquet.FieldRepetitionType_REQUIRED
+				int32Type := parquet.Type_INT32
+				lt := parquet.NewLogicalType()
+				lt.UNKNOWN = parquet.NewNullType()
+				schemas := []*parquet.SchemaElement{
+					{Name: "root", NumChildren: common.ToPtr(int32(1))},
+					{Name: "null_col", Type: &int32Type, RepetitionType: &reqRep, LogicalType: lt},
+				}
+				return NewSchemaHandlerFromSchemaList(schemas)
+			},
+			path:          "Root",
+			expectedError: "OPTIONAL repetition type",
+		},
+		{
+			name: "unknown_valid_int32_optional",
+			setupHandler: func() *SchemaHandler {
+				optRep := parquet.FieldRepetitionType_OPTIONAL
+				int32Type := parquet.Type_INT32
+				lt := parquet.NewLogicalType()
+				lt.UNKNOWN = parquet.NewNullType()
+				schemas := []*parquet.SchemaElement{
+					{Name: "root", NumChildren: common.ToPtr(int32(1))},
+					{Name: "null_col", Type: &int32Type, RepetitionType: &optRep, LogicalType: lt},
+				}
+				return NewSchemaHandlerFromSchemaList(schemas)
+			},
+			path: "Root",
+			validateType: func(t *testing.T, resultType reflect.Type) {
+				require.NotNil(t, resultType)
+			},
+		},
+		{
+			name: "repeated-invalid",
+			setupHandler: func() *SchemaHandler {
+				repRep := parquet.FieldRepetitionType_REPEATED
+				int32Type := parquet.Type_INT32
+				lt := parquet.NewLogicalType()
+				lt.UNKNOWN = parquet.NewNullType()
+				schemas := []*parquet.SchemaElement{
+					{Name: "root", NumChildren: common.ToPtr(int32(1))},
+					{Name: "null_col", Type: &int32Type, RepetitionType: &repRep, LogicalType: lt},
+				}
+				return NewSchemaHandlerFromSchemaList(schemas)
+			},
+			path:          "Root",
+			expectedError: "OPTIONAL repetition type",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Closes #209.

Adds full support for the Apache Parquet `UNKNOWN` logical type — columns that represent always-null values. This type is defined in the Parquet spec but was previously unrecognized by this library (tag parsing returned an error).

- **Tag parsing** (`common/logicaltype.go`): `logicaltype=UNKNOWN` now maps to `parquet.NullType`
- **Write-side schema validation** (`common/tag_schema.go`): enforces `UNKNOWN` must be `INT32` physical type with `OPTIONAL` repetition
- **Read-side schema validation** (`schema/gettype.go`): same constraints enforced on file read
- **Write value enforcement** (`marshal/marshal.go`): `HandleUnknown` rejects any non-nil value with a clear error
- **Func table support** (`common/functable.go`): UNKNOWN columns fall through to the INT32 physical func table for statistics/min-max
- **Tests**: round-trip test, unit tests for each validation path, coverage for nil-type and all invalid repetition types
- **Example** (`example/unknown_type/main.go`): demonstrates writing and reading UNKNOWN columns
- **README**: logical types table, usage note, and example entry

## Go representation

```go
type Row struct {
    NullCol *int32 `parquet:"name=null_col, type=INT32, logicaltype=UNKNOWN, repetitiontype=OPTIONAL"`
}
```

The field must be `*int32`. The writer rejects non-nil values. Reads return `nil`; if a malformed file contains a non-null value, it is returned as-is.

## Test plan

- [x] `make all` passes (format, lint, tests, example build)
- [x] `TestReadUnknownLogicalType` round-trip: write nil rows, read back nil
- [x] `TestValidateLogicalUnknown`: INT32+OPTIONAL passes; BYTE_ARRAY, INT64, REQUIRED, REPEATED, nil-type all rejected
- [x] `TestSchemaHandler_GetType`: UNKNOWN with wrong physical type or non-OPTIONAL repetition returns error
- [x] `TestMarshalUnknown`: nil value accepted, non-nil value rejected
- [x] `TestFindFuncTable`: INT32+UNKNOWN resolves to `int32FuncTable`