### PR TITLE
fix(marshal): enforce UNKNOWN logical type constraint in JSON marshal path

### DIFF
--- a/marshal/json.go
+++ b/marshal/json.go
@@ -170,6 +170,12 @@ func processJSONNode(node *Node, res map[string]*layout.Table, schemaHandler *sc
 		return newStack, nil
 	}
 
+	if newStack, handled, err := HandleUnknown(node, se, res, stack); err != nil {
+		return nil, fmt.Errorf("handle UNKNOWN for %s: %w", pathStr, err)
+	} else if handled {
+		return newStack, nil
+	}
+
 	switch node.Val.Type().Kind() {
 	case reflect.Map:
 		if se.GetConvertedType() == parquet.ConvertedType_MAP {

--- a/marshal/json_test.go
+++ b/marshal/json_test.go
@@ -809,6 +809,30 @@ func TestMarshalJSON_MapIndexErrors(t *testing.T) {
 	require.NotNil(t, result)
 }
 
+func TestMarshalJSONUnknown(t *testing.T) {
+	schemaString := `{
+		"Tag": "name=parquet_go_root",
+		"Fields": [
+			{"Tag": "name=null_col, type=INT32, logicaltype=UNKNOWN, repetitiontype=OPTIONAL", "Type": "int32"}
+		]
+	}`
+
+	sch, err := schema.NewSchemaHandlerFromJSON(schemaString)
+	require.NoError(t, err)
+
+	t.Run("null_value_accepted", func(t *testing.T) {
+		_, err := MarshalJSON([]any{`{"null_col": null}`}, sch)
+		require.NoError(t, err)
+	})
+
+	t.Run("non_null_value_rejected", func(t *testing.T) {
+		_, err := MarshalJSON([]any{`{"null_col": 42}`}, sch)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "UNKNOWN column")
+		require.Contains(t, err.Error(), "nil value")
+	})
+}
+
 // Test struct field mapping with StringToVariableName conversion
 func TestMarshalJSON_StructFieldMapping(t *testing.T) {
 	schemaString := `{


### PR DESCRIPTION
## Summary

- `processJSONNode` in `marshal/json.go` was missing a `HandleUnknown` call, allowing non-null values to be written silently to `UNKNOWN`-typed columns via the JSON writer
- `processNode` (struct path) already had the guard; this aligns the JSON path with the same behaviour
- Added `TestMarshalJSONUnknown` in `json_test.go` covering both the accepted (null) and rejected (non-null) cases

## Test plan

- [ ] `TestMarshalJSONUnknown/null_value_accepted` — `{"null_col": null}` marshals without error
- [ ] `TestMarshalJSONUnknown/non_null_value_rejected` — `{"null_col": 42}` returns an error containing "UNKNOWN column" and "nil value"
- [ ] `make all` passes (format, lint, tests, examples, build)