### PR TITLE
fix(marshal): enforce UNKNOWN logical type constraint in CSV and Arrow marshal paths

### DIFF
--- a/marshal/arrow.go
+++ b/marshal/arrow.go
@@ -42,6 +42,9 @@ func MarshalArrow(records []any, schemaHandler *schema.SchemaHandler) (*map[stri
 
 		for j := range records {
 			rec := records[j].([]any)[i]
+			if lt := table.Schema.LogicalType; lt != nil && lt.UNKNOWN != nil && rec != nil {
+				return nil, fmt.Errorf("UNKNOWN column %s must have nil value, got non-nil", pathStr)
+			}
 			table.Values = append(table.Values, rec)
 
 			table.RepetitionLevels = append(table.RepetitionLevels, 0)

--- a/marshal/arrow_test.go
+++ b/marshal/arrow_test.go
@@ -9,6 +9,30 @@ import (
 	"github.com/hangxie/parquet-go/v3/schema"
 )
 
+func TestMarshalArrowUnknown(t *testing.T) {
+	schemaString := `{
+		"Tag": "name=parquet_go_root",
+		"Fields": [
+			{"Tag": "name=null_col, type=INT32, logicaltype=UNKNOWN, repetitiontype=OPTIONAL", "Type": "int32"}
+		]
+	}`
+
+	sch, err := schema.NewSchemaHandlerFromJSON(schemaString)
+	require.NoError(t, err)
+
+	t.Run("nil_value_accepted", func(t *testing.T) {
+		_, err := MarshalArrow([]any{[]any{nil}}, sch)
+		require.NoError(t, err)
+	})
+
+	t.Run("non_nil_value_rejected", func(t *testing.T) {
+		_, err := MarshalArrow([]any{[]any{int32(42)}}, sch)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "UNKNOWN column")
+		require.Contains(t, err.Error(), "nil value")
+	})
+}
+
 func TestMarshalArrow(t *testing.T) {
 	// Create a simple schema for Arrow data
 	schemaString := `{

--- a/marshal/csv.go
+++ b/marshal/csv.go
@@ -46,6 +46,9 @@ func MarshalCSV(records []any, schemaHandler *schema.SchemaHandler) (*map[string
 				return nil, fmt.Errorf("row %d has less than %d fields", j, fieldCount)
 			}
 			rec := row[i]
+			if lt := table.Schema.LogicalType; lt != nil && lt.UNKNOWN != nil && rec != nil {
+				return nil, fmt.Errorf("UNKNOWN column %s must have nil value, got non-nil", pathStr)
+			}
 			table.Values = append(table.Values, rec)
 
 			table.RepetitionLevels = append(table.RepetitionLevels, 0)

--- a/marshal/csv_test.go
+++ b/marshal/csv_test.go
@@ -9,6 +9,30 @@ import (
 	"github.com/hangxie/parquet-go/v3/schema"
 )
 
+func TestMarshalCSVUnknown(t *testing.T) {
+	schemaString := `{
+		"Tag": "name=parquet_go_root",
+		"Fields": [
+			{"Tag": "name=null_col, type=INT32, logicaltype=UNKNOWN, repetitiontype=OPTIONAL", "Type": "int32"}
+		]
+	}`
+
+	sch, err := schema.NewSchemaHandlerFromJSON(schemaString)
+	require.NoError(t, err)
+
+	t.Run("nil_value_accepted", func(t *testing.T) {
+		_, err := MarshalCSV([]any{[]any{nil}}, sch)
+		require.NoError(t, err)
+	})
+
+	t.Run("non_nil_value_rejected", func(t *testing.T) {
+		_, err := MarshalCSV([]any{[]any{int32(42)}}, sch)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "UNKNOWN column")
+		require.Contains(t, err.Error(), "nil value")
+	})
+}
+
 func TestMarshalCSV(t *testing.T) {
 	// Create a simple schema for CSV data
 	schemaString := `{


### PR DESCRIPTION
## Summary

- `MarshalCSV` and `MarshalArrow` bypassed `HandleUnknown` entirely, silently writing non-nil values into UNKNOWN logical type columns and producing invalid Parquet files
- Added a per-column nil guard in both paths matching the protection already present in the struct and JSON marshal paths
- Covered by new `TestMarshalCSVUnknown` and `TestMarshalArrowUnknown` table-driven tests (nil accepted, non-nil rejected with a descriptive error)

## Test plan

- [ ] `TestMarshalCSVUnknown/nil_value_accepted` — passes without error
- [ ] `TestMarshalCSVUnknown/non_nil_value_rejected` — returns error containing `"UNKNOWN column"` and `"nil value"`
- [ ] `TestMarshalArrowUnknown/nil_value_accepted` — passes without error
- [ ] `TestMarshalArrowUnknown/non_nil_value_rejected` — returns error containing `"UNKNOWN column"` and `"nil value"`
- [ ] `make all` passes clean