### PR TITLE
fix(schema): enforce logical type physical constraints

### DIFF
--- a/common/tag_schema.go
+++ b/common/tag_schema.go
@@ -157,6 +157,47 @@ func validateLogicalInteger(lt *parquet.LogicalType, pT *parquet.Type) error {
 	return nil
 }
 
+func isDecimalPhysicalType(pT parquet.Type) bool {
+	switch pT {
+	case parquet.Type_INT32, parquet.Type_INT64, parquet.Type_BYTE_ARRAY, parquet.Type_FIXED_LEN_BYTE_ARRAY:
+		return true
+	}
+	return false
+}
+
+func validateLogicalBinaryTypes(lt *parquet.LogicalType, pT *parquet.Type) error {
+	if (lt.STRING != nil || lt.JSON != nil || lt.BSON != nil || lt.ENUM != nil) && *pT != parquet.Type_BYTE_ARRAY {
+		return fmt.Errorf("LogicalType STRING/JSON/BSON/ENUM can only be used with BYTE_ARRAY")
+	}
+	if lt.UUID != nil && *pT != parquet.Type_FIXED_LEN_BYTE_ARRAY {
+		return fmt.Errorf("LogicalType UUID can only be used with FIXED_LEN_BYTE_ARRAY")
+	}
+	if lt.FLOAT16 != nil && *pT != parquet.Type_FIXED_LEN_BYTE_ARRAY {
+		return fmt.Errorf("LogicalType FLOAT16 can only be used with FIXED_LEN_BYTE_ARRAY")
+	}
+	if (lt.GEOMETRY != nil || lt.GEOGRAPHY != nil) && *pT != parquet.Type_BYTE_ARRAY {
+		return fmt.Errorf("LogicalType GEOMETRY/GEOGRAPHY can only be used with BYTE_ARRAY")
+	}
+	return nil
+}
+
+func validateLogicalDecimal(lt *parquet.LogicalType, pT *parquet.Type) error {
+	if lt.DECIMAL != nil && !isDecimalPhysicalType(*pT) {
+		return fmt.Errorf("LogicalType DECIMAL can only be used with INT32, INT64, BYTE_ARRAY, or FIXED_LEN_BYTE_ARRAY")
+	}
+	return nil
+}
+
+func validateLogicalDateTimestamp(lt *parquet.LogicalType, pT *parquet.Type) error {
+	if lt.DATE != nil && *pT != parquet.Type_INT32 {
+		return fmt.Errorf("LogicalType DATE can only be used with INT32")
+	}
+	if lt.TIMESTAMP != nil && *pT != parquet.Type_INT64 {
+		return fmt.Errorf("LogicalType TIMESTAMP can only be used with INT64")
+	}
+	return nil
+}
+
 func validateLogicalType(schema *parquet.SchemaElement) error {
 	if schema.LogicalType == nil {
 		return nil
@@ -171,28 +212,17 @@ func validateLogicalType(schema *parquet.SchemaElement) error {
 		}
 		return nil
 	}
-	if lt.STRING != nil || lt.JSON != nil || lt.BSON != nil || lt.ENUM != nil {
-		if *schema.Type != parquet.Type_BYTE_ARRAY {
-			return fmt.Errorf("LogicalType STRING/JSON/BSON/ENUM can only be used with BYTE_ARRAY")
-		}
+	if err := validateLogicalBinaryTypes(lt, schema.Type); err != nil {
+		return err
 	}
-	if lt.UUID != nil {
-		if *schema.Type != parquet.Type_FIXED_LEN_BYTE_ARRAY {
-			return fmt.Errorf("LogicalType UUID can only be used with FIXED_LEN_BYTE_ARRAY")
-		}
+	if err := validateLogicalDecimal(lt, schema.Type); err != nil {
+		return err
 	}
-	if lt.DATE != nil {
-		if *schema.Type != parquet.Type_INT32 {
-			return fmt.Errorf("LogicalType DATE can only be used with INT32")
-		}
+	if err := validateLogicalDateTimestamp(lt, schema.Type); err != nil {
+		return err
 	}
 	if err := validateLogicalTime(lt, schema.Type); err != nil {
 		return fmt.Errorf("validate logical TIME: %w", err)
-	}
-	if lt.TIMESTAMP != nil {
-		if *schema.Type != parquet.Type_INT64 {
-			return fmt.Errorf("LogicalType TIMESTAMP can only be used with INT64")
-		}
 	}
 	return validateLogicalInteger(lt, schema.Type)
 }
@@ -217,6 +247,10 @@ func validateConvertedType(schema *parquet.SchemaElement) error {
 		parquet.ConvertedType_TIME_MICROS, parquet.ConvertedType_TIMESTAMP_MILLIS, parquet.ConvertedType_TIMESTAMP_MICROS:
 		if *schema.Type != parquet.Type_INT64 {
 			return fmt.Errorf("ConvertedType %s can only be used with INT64", ct)
+		}
+	case parquet.ConvertedType_DECIMAL:
+		if !isDecimalPhysicalType(*schema.Type) {
+			return fmt.Errorf("ConvertedType DECIMAL can only be used with INT32, INT64, BYTE_ARRAY, or FIXED_LEN_BYTE_ARRAY")
 		}
 	case parquet.ConvertedType_INTERVAL:
 		if *schema.Type != parquet.Type_FIXED_LEN_BYTE_ARRAY {

--- a/common/tag_schema.go
+++ b/common/tag_schema.go
@@ -157,14 +157,6 @@ func validateLogicalInteger(lt *parquet.LogicalType, pT *parquet.Type) error {
 	return nil
 }
 
-func isDecimalPhysicalType(pT parquet.Type) bool {
-	switch pT {
-	case parquet.Type_INT32, parquet.Type_INT64, parquet.Type_BYTE_ARRAY, parquet.Type_FIXED_LEN_BYTE_ARRAY:
-		return true
-	}
-	return false
-}
-
 func validateLogicalBinaryTypes(lt *parquet.LogicalType, pT *parquet.Type) error {
 	if (lt.STRING != nil || lt.JSON != nil || lt.BSON != nil || lt.ENUM != nil) && *pT != parquet.Type_BYTE_ARRAY {
 		return fmt.Errorf("LogicalType STRING/JSON/BSON/ENUM can only be used with BYTE_ARRAY")
@@ -182,10 +174,15 @@ func validateLogicalBinaryTypes(lt *parquet.LogicalType, pT *parquet.Type) error
 }
 
 func validateLogicalDecimal(lt *parquet.LogicalType, pT *parquet.Type) error {
-	if lt.DECIMAL != nil && !isDecimalPhysicalType(*pT) {
+	if lt.DECIMAL == nil {
+		return nil
+	}
+	switch *pT {
+	case parquet.Type_INT32, parquet.Type_INT64, parquet.Type_BYTE_ARRAY, parquet.Type_FIXED_LEN_BYTE_ARRAY:
+		return nil
+	default:
 		return fmt.Errorf("LogicalType DECIMAL can only be used with INT32, INT64, BYTE_ARRAY, or FIXED_LEN_BYTE_ARRAY")
 	}
-	return nil
 }
 
 func validateLogicalDateTimestamp(lt *parquet.LogicalType, pT *parquet.Type) error {
@@ -249,7 +246,9 @@ func validateConvertedType(schema *parquet.SchemaElement) error {
 			return fmt.Errorf("ConvertedType %s can only be used with INT64", ct)
 		}
 	case parquet.ConvertedType_DECIMAL:
-		if !isDecimalPhysicalType(*schema.Type) {
+		switch *schema.Type {
+		case parquet.Type_INT32, parquet.Type_INT64, parquet.Type_BYTE_ARRAY, parquet.Type_FIXED_LEN_BYTE_ARRAY:
+		default:
 			return fmt.Errorf("ConvertedType DECIMAL can only be used with INT32, INT64, BYTE_ARRAY, or FIXED_LEN_BYTE_ARRAY")
 		}
 	case parquet.ConvertedType_INTERVAL:

--- a/common/tag_schema_test.go
+++ b/common/tag_schema_test.go
@@ -77,6 +77,43 @@ func TestValidateConvertedType(t *testing.T) {
 			"ConvertedType TIMESTAMP_MICROS can only be used with INT64",
 		},
 
+		// DECIMAL requires INT32, INT64, BYTE_ARRAY, or FIXED_LEN_BYTE_ARRAY
+		"decimal-int32-valid": {
+			parquet.SchemaElement{
+				Type:          ToPtr(parquet.Type_INT32),
+				ConvertedType: ToPtr(parquet.ConvertedType_DECIMAL),
+			},
+			"",
+		},
+		"decimal-int64-valid": {
+			parquet.SchemaElement{
+				Type:          ToPtr(parquet.Type_INT64),
+				ConvertedType: ToPtr(parquet.ConvertedType_DECIMAL),
+			},
+			"",
+		},
+		"decimal-byte-array-valid": {
+			parquet.SchemaElement{
+				Type:          ToPtr(parquet.Type_BYTE_ARRAY),
+				ConvertedType: ToPtr(parquet.ConvertedType_DECIMAL),
+			},
+			"",
+		},
+		"decimal-fixed-len-byte-array-valid": {
+			parquet.SchemaElement{
+				Type:          ToPtr(parquet.Type_FIXED_LEN_BYTE_ARRAY),
+				ConvertedType: ToPtr(parquet.ConvertedType_DECIMAL),
+			},
+			"",
+		},
+		"decimal-float-invalid": {
+			parquet.SchemaElement{
+				Type:          ToPtr(parquet.Type_FLOAT),
+				ConvertedType: ToPtr(parquet.ConvertedType_DECIMAL),
+			},
+			"ConvertedType DECIMAL can only be used with INT32, INT64, BYTE_ARRAY, or FIXED_LEN_BYTE_ARRAY",
+		},
+
 		// nil ConvertedType is a no-op
 		"nil-converted-type": {
 			parquet.SchemaElement{
@@ -90,6 +127,108 @@ func TestValidateConvertedType(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			err := validateConvertedType(&tc.schema)
+			if tc.errMsg == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.errMsg)
+			}
+		})
+	}
+}
+
+func TestValidateLogicalTypePhysicalConstraints(t *testing.T) {
+	testCases := map[string]struct {
+		schema parquet.SchemaElement
+		errMsg string
+	}{
+		// FLOAT16 requires FIXED_LEN_BYTE_ARRAY
+		"float16-fixed-len-byte-array-valid": {
+			parquet.SchemaElement{
+				Type:        ToPtr(parquet.Type_FIXED_LEN_BYTE_ARRAY),
+				LogicalType: &parquet.LogicalType{FLOAT16: &parquet.Float16Type{}},
+			},
+			"",
+		},
+		"float16-byte-array-invalid": {
+			parquet.SchemaElement{
+				Type:        ToPtr(parquet.Type_BYTE_ARRAY),
+				LogicalType: &parquet.LogicalType{FLOAT16: &parquet.Float16Type{}},
+			},
+			"LogicalType FLOAT16 can only be used with FIXED_LEN_BYTE_ARRAY",
+		},
+
+		// DECIMAL requires INT32, INT64, BYTE_ARRAY, or FIXED_LEN_BYTE_ARRAY
+		"decimal-int32-valid": {
+			parquet.SchemaElement{
+				Type:        ToPtr(parquet.Type_INT32),
+				LogicalType: &parquet.LogicalType{DECIMAL: &parquet.DecimalType{}},
+			},
+			"",
+		},
+		"decimal-int64-valid": {
+			parquet.SchemaElement{
+				Type:        ToPtr(parquet.Type_INT64),
+				LogicalType: &parquet.LogicalType{DECIMAL: &parquet.DecimalType{}},
+			},
+			"",
+		},
+		"decimal-byte-array-valid": {
+			parquet.SchemaElement{
+				Type:        ToPtr(parquet.Type_BYTE_ARRAY),
+				LogicalType: &parquet.LogicalType{DECIMAL: &parquet.DecimalType{}},
+			},
+			"",
+		},
+		"decimal-fixed-len-byte-array-valid": {
+			parquet.SchemaElement{
+				Type:        ToPtr(parquet.Type_FIXED_LEN_BYTE_ARRAY),
+				LogicalType: &parquet.LogicalType{DECIMAL: &parquet.DecimalType{}},
+			},
+			"",
+		},
+		"decimal-float-invalid": {
+			parquet.SchemaElement{
+				Type:        ToPtr(parquet.Type_FLOAT),
+				LogicalType: &parquet.LogicalType{DECIMAL: &parquet.DecimalType{}},
+			},
+			"LogicalType DECIMAL can only be used with INT32, INT64, BYTE_ARRAY, or FIXED_LEN_BYTE_ARRAY",
+		},
+
+		// GEOMETRY and GEOGRAPHY require BYTE_ARRAY
+		"geometry-byte-array-valid": {
+			parquet.SchemaElement{
+				Type:        ToPtr(parquet.Type_BYTE_ARRAY),
+				LogicalType: &parquet.LogicalType{GEOMETRY: &parquet.GeometryType{}},
+			},
+			"",
+		},
+		"geometry-int32-invalid": {
+			parquet.SchemaElement{
+				Type:        ToPtr(parquet.Type_INT32),
+				LogicalType: &parquet.LogicalType{GEOMETRY: &parquet.GeometryType{}},
+			},
+			"LogicalType GEOMETRY/GEOGRAPHY can only be used with BYTE_ARRAY",
+		},
+		"geography-byte-array-valid": {
+			parquet.SchemaElement{
+				Type:        ToPtr(parquet.Type_BYTE_ARRAY),
+				LogicalType: &parquet.LogicalType{GEOGRAPHY: &parquet.GeographyType{}},
+			},
+			"",
+		},
+		"geography-fixed-len-byte-array-invalid": {
+			parquet.SchemaElement{
+				Type:        ToPtr(parquet.Type_FIXED_LEN_BYTE_ARRAY),
+				LogicalType: &parquet.LogicalType{GEOGRAPHY: &parquet.GeographyType{}},
+			},
+			"LogicalType GEOMETRY/GEOGRAPHY can only be used with BYTE_ARRAY",
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			err := validateLogicalType(&tc.schema)
 			if tc.errMsg == "" {
 				require.NoError(t, err)
 			} else {


### PR DESCRIPTION
## Summary
- enforce physical type constraints for FLOAT16, DECIMAL, GEOMETRY, and GEOGRAPHY logical annotations
- enforce physical type constraints for converted DECIMAL annotations
- add table-driven regression coverage for the rejected invalid schemas

## Tests
- go test ./common
- make all

Closes #307