### PR TITLE
fix(schema): prevent reflect panics on empty field names in Parquet schemas

### DIFF
--- a/schema/gettype.go
+++ b/schema/gettype.go
@@ -237,7 +237,7 @@ func (sh *SchemaHandler) resolveGroupType(idx int32, elements [][]int32, element
 	switch {
 	case sh.isListSchema(idx, elements, cT):
 		cidx := elements[elements[idx][0]][0]
-		return applyRepetition(reflect.SliceOf(elementTypes[cidx]), rT)
+		return applyRepetition(reflect.SliceOf(typeOrAny(elementTypes[cidx])), rT)
 
 	case sh.isMapSchema(idx, elements, cT):
 		kIdx, vIdx := elements[elements[idx][0]][0], elements[elements[idx][0]][1]

--- a/schema/gettype.go
+++ b/schema/gettype.go
@@ -212,6 +212,11 @@ func (sh *SchemaHandler) isMapSchema(idx int32, elements [][]int32, cT *parquet.
 func (sh *SchemaHandler) resolveStructType(idx int32, elements [][]int32, elementTypes []reflect.Type, rT *parquet.FieldRepetitionType) reflect.Type {
 	fields := make([]reflect.StructField, 0, len(elements[idx]))
 	for _, ci := range elements[idx] {
+		if sh.Infos[ci].InName == "" {
+			// reflect.StructOf panics on empty field names; signal corrupt schema
+			// via nil so GetType can surface a proper error.
+			return nil
+		}
 		fields = append(fields, reflect.StructField{
 			Name: sh.Infos[ci].InName,
 			Type: typeOrAny(elementTypes[ci]),
@@ -336,5 +341,8 @@ func (sh *SchemaHandler) GetType(prefixPath string) (reflect.Type, error) {
 		toVisit = append(toVisit, children[cur]...)
 	}
 
+	if ts[idx] == nil {
+		return nil, fmt.Errorf("corrupt schema at %s: empty field name", prefixPath)
+	}
 	return ts[idx], nil
 }

--- a/schema/gettype_test.go
+++ b/schema/gettype_test.go
@@ -377,6 +377,49 @@ func TestSchemaHandler_GetType(t *testing.T) {
 			expectedError: "OPTIONAL repetition type",
 		},
 		{
+			// reflect.SliceOf(nil) panics when a LIST's Element node resolves to nil
+			// (because that Element is a struct group with an empty-named child).
+			// GetType must return a usable type without panicking, consistent with
+			// how MAP already wraps its key/value types with typeOrAny.
+			name: "list_element_with_empty_named_child_no_panic",
+			setupHandler: func() *SchemaHandler {
+				reqRep := parquet.FieldRepetitionType_REQUIRED
+				repRep := parquet.FieldRepetitionType_REPEATED
+				listCT := parquet.ConvertedType_LIST
+				int32Type := parquet.Type_INT32
+				// root → tags (LIST) → List (REPEATED) → Element (GROUP) → "" (leaf)
+				return &SchemaHandler{
+					SchemaElements: []*parquet.SchemaElement{
+						{Name: "root", NumChildren: common.ToPtr(int32(1)), RepetitionType: &reqRep},
+						{Name: "tags", NumChildren: common.ToPtr(int32(1)), ConvertedType: &listCT, RepetitionType: &reqRep},
+						{Name: "List", NumChildren: common.ToPtr(int32(1)), RepetitionType: &repRep},
+						{Name: "Element", NumChildren: common.ToPtr(int32(1)), RepetitionType: &reqRep},
+						{Name: "", Type: &int32Type, RepetitionType: &reqRep, NumChildren: common.ToPtr(int32(0))},
+					},
+					Infos: []*common.Tag{
+						{InName: "Root", ExName: "root"},
+						{InName: "Tags", ExName: "tags"},
+						{InName: "List", ExName: "list"},
+						{InName: "Element", ExName: "element"},
+						{InName: "", ExName: ""},
+					},
+					MapIndex: map[string]int32{
+						"Root": 0,
+					},
+					InPathToExPath: map[string]string{
+						"Root": "root",
+					},
+					ExPathToInPath: map[string]string{
+						"root": "Root",
+					},
+				}
+			},
+			path: "Root",
+			validateType: func(t *testing.T, resultType reflect.Type) {
+				require.NotNil(t, resultType)
+			},
+		},
+		{
 			// reflect.StructOf panics if any StructField.Name is empty. A malformed
 			// Parquet file can carry a schema element with an empty name, which
 			// StringToVariableName converts to "". GetType must return an error

--- a/schema/gettype_test.go
+++ b/schema/gettype_test.go
@@ -376,6 +376,47 @@ func TestSchemaHandler_GetType(t *testing.T) {
 			path:          "Root",
 			expectedError: "OPTIONAL repetition type",
 		},
+		{
+			// reflect.StructOf panics if any StructField.Name is empty. A malformed
+			// Parquet file can carry a schema element with an empty name, which
+			// StringToVariableName converts to "". GetType must return an error
+			// instead of propagating the panic.
+			name: "empty_child_field_name_returns_error_not_panic",
+			setupHandler: func() *SchemaHandler {
+				int32Type := parquet.Type_INT32
+				reqRep := parquet.FieldRepetitionType_REQUIRED
+				return &SchemaHandler{
+					SchemaElements: []*parquet.SchemaElement{
+						{
+							Name:           "root",
+							NumChildren:    common.ToPtr(int32(1)),
+							RepetitionType: &reqRep,
+						},
+						{
+							Name:           "",
+							Type:           &int32Type,
+							RepetitionType: &reqRep,
+							NumChildren:    common.ToPtr(int32(0)),
+						},
+					},
+					Infos: []*common.Tag{
+						{InName: "Root", ExName: "root"},
+						{InName: "", ExName: ""},
+					},
+					MapIndex: map[string]int32{
+						"Root": 0,
+					},
+					InPathToExPath: map[string]string{
+						"Root": "root",
+					},
+					ExPathToInPath: map[string]string{
+						"root": "Root",
+					},
+				}
+			},
+			path:          "Root",
+			expectedError: "empty field name",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- `reflect.StructOf` panics when any `StructField.Name` is `""`. A malformed Parquet footer can carry a schema element with an empty name, which `StringToVariableName` converts to `""`. Guard in `resolveStructType`: return `nil` when any child `InName` is empty, and detect that sentinel in `GetType` to surface a proper error instead of crashing.
- `reflect.SliceOf(nil)` panics identically. When a LIST's Element node is a struct group with an empty-named child, `resolveStructType` now returns `nil`, which was passed raw to `reflect.SliceOf`. Wrap with `typeOrAny` (matching the existing MAP case) so a nil element type degrades to `[]interface{}` rather than panicking.

Both panics were reachable through `NewParquetReader` → `NewColumnBuffer` → `schemaHandler.GetType` whenever a file's footer schema contained an element with an empty name.

## Test plan

- [ ] `TestSchemaHandler_GetType/empty_child_field_name_returns_error_not_panic` — struct group with empty-named child: was a panic from `reflect.StructOf`, now returns an error
- [ ] `TestSchemaHandler_GetType/list_element_with_empty_named_child_no_panic` — LIST whose Element is a struct group with empty-named child: was a panic from `reflect.SliceOf(nil)`, now returns a valid `[]interface{}` type
- [ ] `make all` passes (format, lint, all package tests, examples, build)