### PR TITLE
fix(writer): base OffsetIndex first_row_index on row count

### DIFF
--- a/internal/layout/dictpage.go
+++ b/internal/layout/dictpage.go
@@ -92,7 +92,18 @@ func scanDictPageValues(table *Table, dictRec *DictRecType, startIdx int, pageSi
 		maxVal: table.Values[startIdx],
 	}
 
-	for r.endIdx < totalLn && r.size < pageSize {
+	for r.endIdx < totalLn {
+		// A data page may only end on a row boundary — a repetition-level-0
+		// entry. A repeated column contributes a run of values per row (until
+		// the next rep-0 entry); splitting that run across pages would leave a
+		// page starting mid-row, which the offset index cannot address (its
+		// first_row_index must name a row start and increase strictly). Once
+		// the size budget is met, keep scanning to the next rep-0 entry before
+		// ending the page. Flat columns have a rep-0 entry at every value, so
+		// this never extends a page.
+		if r.endIdx > startIdx && r.size >= pageSize && table.RepetitionLevels[r.endIdx] == 0 {
+			break
+		}
 		if table.Values[r.endIdx] == nil {
 			if err := checkRequiredNil(table, r.endIdx); err != nil {
 				return r, fmt.Errorf("dictionary scan index %d: %w", r.endIdx, err)

--- a/internal/layout/page.go
+++ b/internal/layout/page.go
@@ -53,6 +53,14 @@ type Page struct {
 	DefinitionLevelHistogram []int64
 	RepetitionLevelHistogram []int64
 
+	// NumRows is the number of rows (records, i.e. repetition-level-0 entries)
+	// contained in the page. It is the unit used for OffsetIndex
+	// first_row_index and differs from the leaf value count for repeated
+	// fields. Computed during page creation so it survives DataTable being
+	// nilled out later. Pages are built row-aligned, so this is always >= 1
+	// for a non-empty page and first_row_index values are strictly increasing.
+	NumRows int64
+
 	// UnencodedByteArrayDataBytes tracks the total byte size of BYTE_ARRAY
 	// data values (excluding 4-byte length prefixes) for SizeStatistics.
 	// Only set for BYTE_ARRAY physical type columns; nil otherwise.

--- a/internal/layout/page_write.go
+++ b/internal/layout/page_write.go
@@ -65,7 +65,18 @@ func scanPageValues(table *Table, startIdx int, pageSize int32, omitStats bool, 
 		maxVal: table.Values[startIdx],
 	}
 
-	for r.endIdx < totalLn && r.size < pageSize {
+	for r.endIdx < totalLn {
+		// A data page may only end on a row boundary — a repetition-level-0
+		// entry. A repeated column contributes a run of values per row (until
+		// the next rep-0 entry); splitting that run across pages would leave a
+		// page starting mid-row, which the offset index cannot address (its
+		// first_row_index must name a row start and increase strictly). Once
+		// the size budget is met, keep scanning to the next rep-0 entry before
+		// ending the page. Flat columns have a rep-0 entry at every value, so
+		// this never extends a page.
+		if r.endIdx > startIdx && r.size >= pageSize && table.RepetitionLevels[r.endIdx] == 0 {
+			break
+		}
 		if table.Values[r.endIdx] == nil {
 			if err := checkRequiredNil(table, r.endIdx); err != nil {
 				return r, fmt.Errorf("page scan index %d: %w", r.endIdx, err)

--- a/internal/layout/page_write_encode.go
+++ b/internal/layout/page_write_encode.go
@@ -77,6 +77,19 @@ func (page *Page) computeLevelHistograms() {
 	if page.DataTable == nil {
 		return
 	}
+	// A row starts at every repetition-level-0 entry. When the column is not
+	// repeated every entry is its own row, so the entry count is the row count.
+	if page.DataTable.MaxRepetitionLevel == 0 {
+		page.NumRows = int64(len(page.DataTable.DefinitionLevels))
+	} else {
+		var rows int64
+		for _, rl := range page.DataTable.RepetitionLevels {
+			if rl == 0 {
+				rows++
+			}
+		}
+		page.NumRows = rows
+	}
 	if page.DataTable.MaxDefinitionLevel > 0 {
 		page.DefinitionLevelHistogram = make([]int64, page.DataTable.MaxDefinitionLevel+1)
 		for _, dl := range page.DataTable.DefinitionLevels {

--- a/internal/layout/page_write_test.go
+++ b/internal/layout/page_write_test.go
@@ -2,6 +2,7 @@ package layout
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -524,6 +525,95 @@ func TestTableToDataPages(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, pages)
 	require.Positive(t, totalSize)
+}
+
+func TestTableToDataPagesRowAligned(t *testing.T) {
+	// Three rows of a repeated INT32 column, each row holding four values.
+	// A tiny page size would split a row mid-way if pages were sized purely by
+	// byte budget; row-aligned splitting must instead end every page on a row
+	// boundary (repetition level 0).
+	const rowCount, valuesPerRow = 3, 4
+	values := make([]any, 0, rowCount*valuesPerRow)
+	defLevels := make([]int32, 0, rowCount*valuesPerRow)
+	repLevels := make([]int32, 0, rowCount*valuesPerRow)
+	for row := range rowCount {
+		for v := range valuesPerRow {
+			values = append(values, int32(row*valuesPerRow+v))
+			defLevels = append(defLevels, 1)
+			if v == 0 {
+				repLevels = append(repLevels, 0)
+			} else {
+				repLevels = append(repLevels, 1)
+			}
+		}
+	}
+
+	for _, version := range []int32{1, 2} {
+		t.Run(fmt.Sprintf("v%d", version), func(t *testing.T) {
+			table := &Table{
+				Schema: &parquet.SchemaElement{
+					Type:           common.ToPtr(parquet.Type_INT32),
+					Name:           "vals",
+					RepetitionType: common.ToPtr(parquet.FieldRepetitionType_OPTIONAL),
+				},
+				Values:             values,
+				DefinitionLevels:   defLevels,
+				RepetitionLevels:   repLevels,
+				MaxDefinitionLevel: 1,
+				MaxRepetitionLevel: 1,
+				Info:               &common.Tag{},
+			}
+
+			// Page size of 6 bytes forces a break partway through each 4-value row.
+			pages, _, err := TableToDataPagesWithOption(table, PageWriteOption{
+				PageSize:        6,
+				CompressType:    parquet.CompressionCodec_UNCOMPRESSED,
+				DataPageVersion: version,
+			})
+			require.NoError(t, err)
+			require.Greater(t, len(pages), 1)
+
+			assertRowAligned(t, pages, rowCount)
+		})
+	}
+
+	t.Run("dict", func(t *testing.T) {
+		table := &Table{
+			Schema: &parquet.SchemaElement{
+				Type:           common.ToPtr(parquet.Type_INT32),
+				Name:           "vals",
+				RepetitionType: common.ToPtr(parquet.FieldRepetitionType_OPTIONAL),
+			},
+			Values:             values,
+			DefinitionLevels:   defLevels,
+			RepetitionLevels:   repLevels,
+			MaxDefinitionLevel: 1,
+			MaxRepetitionLevel: 1,
+			Info:               &common.Tag{},
+		}
+
+		pages, _, err := TableToDictDataPagesWithOption(NewDictRec(parquet.Type_INT32), table, 32, PageWriteOption{
+			PageSize:     6,
+			CompressType: parquet.CompressionCodec_UNCOMPRESSED,
+		})
+		require.NoError(t, err)
+		require.Greater(t, len(pages), 1)
+		assertRowAligned(t, pages, rowCount)
+	})
+}
+
+// assertRowAligned checks that every page begins on a row boundary, holds at
+// least one whole row, and that the page rows sum to the expected total.
+func assertRowAligned(t *testing.T, pages []*Page, wantRows int) {
+	t.Helper()
+	var totalRows int64
+	for _, page := range pages {
+		require.NotEmpty(t, page.DataTable.RepetitionLevels)
+		require.Zero(t, page.DataTable.RepetitionLevels[0])
+		require.GreaterOrEqual(t, page.NumRows, int64(1))
+		totalRows += page.NumRows
+	}
+	require.Equal(t, int64(wantRows), totalRows)
 }
 
 func TestTableToDataPagesComplexScenarios(t *testing.T) {
@@ -1232,6 +1322,7 @@ func TestComputeLevelHistograms(t *testing.T) {
 		wantDefHist    []int64
 		wantRepHist    []int64
 		wantByteArrayN *int64
+		wantNumRows    int64
 	}{
 		"nil_data_table": {
 			page: &Page{
@@ -1240,6 +1331,7 @@ func TestComputeLevelHistograms(t *testing.T) {
 			wantDefHist:    nil,
 			wantRepHist:    nil,
 			wantByteArrayN: nil,
+			wantNumRows:    0,
 		},
 		"definition_level_histogram_only": {
 			page: &Page{
@@ -1257,6 +1349,7 @@ func TestComputeLevelHistograms(t *testing.T) {
 			wantDefHist:    []int64{1, 2},
 			wantRepHist:    nil,
 			wantByteArrayN: nil,
+			wantNumRows:    3,
 		},
 		"repetition_level_histogram_only": {
 			page: &Page{
@@ -1274,6 +1367,7 @@ func TestComputeLevelHistograms(t *testing.T) {
 			wantDefHist:    nil,
 			wantRepHist:    []int64{2, 2},
 			wantByteArrayN: nil,
+			wantNumRows:    2,
 		},
 		"both_def_and_rep_histograms": {
 			page: &Page{
@@ -1291,6 +1385,25 @@ func TestComputeLevelHistograms(t *testing.T) {
 			wantDefHist:    []int64{1, 3},
 			wantRepHist:    []int64{3, 1},
 			wantByteArrayN: nil,
+			wantNumRows:    3,
+		},
+		"repeated_multiple_rows": {
+			page: &Page{
+				Schema: &parquet.SchemaElement{
+					Type: common.ToPtr(parquet.Type_INT32),
+				},
+				DataTable: &Table{
+					Values:             []any{int32(1), int32(2), int32(3)},
+					DefinitionLevels:   []int32{1, 1, 1},
+					RepetitionLevels:   []int32{0, 1, 0},
+					MaxDefinitionLevel: 1,
+					MaxRepetitionLevel: 1,
+				},
+			},
+			wantDefHist:    []int64{0, 3},
+			wantRepHist:    []int64{2, 1},
+			wantByteArrayN: nil,
+			wantNumRows:    2,
 		},
 		"byte_array_string_values": {
 			page: &Page{
@@ -1308,6 +1421,7 @@ func TestComputeLevelHistograms(t *testing.T) {
 			wantDefHist:    []int64{1, 2},
 			wantRepHist:    nil,
 			wantByteArrayN: common.ToPtr(int64(10)), // "hello"(5) + "world"(5)
+			wantNumRows:    3,
 		},
 		"byte_array_byte_slice_values": {
 			page: &Page{
@@ -1325,6 +1439,7 @@ func TestComputeLevelHistograms(t *testing.T) {
 			wantDefHist:    []int64{1, 2},
 			wantRepHist:    nil,
 			wantByteArrayN: common.ToPtr(int64(5)), // 3 + 2
+			wantNumRows:    3,
 		},
 		"required_field_no_histograms": {
 			page: &Page{
@@ -1342,6 +1457,7 @@ func TestComputeLevelHistograms(t *testing.T) {
 			wantDefHist:    nil,
 			wantRepHist:    nil,
 			wantByteArrayN: nil,
+			wantNumRows:    2,
 		},
 	}
 
@@ -1350,6 +1466,7 @@ func TestComputeLevelHistograms(t *testing.T) {
 			tt.page.computeLevelHistograms()
 			require.Equal(t, tt.wantDefHist, tt.page.DefinitionLevelHistogram)
 			require.Equal(t, tt.wantRepHist, tt.page.RepetitionLevelHistogram)
+			require.Equal(t, tt.wantNumRows, tt.page.NumRows)
 			if tt.wantByteArrayN == nil {
 				require.Nil(t, tt.page.UnencodedByteArrayDataBytes)
 			} else {

--- a/writer/pages.go
+++ b/writer/pages.go
@@ -168,16 +168,6 @@ func extractPageStats(page *layout.Page) pageStats {
 	return pageStats{}
 }
 
-func dataPageNumValues(page *layout.Page) int64 {
-	if page.Header.DataPageHeader != nil {
-		return int64(page.Header.DataPageHeader.NumValues)
-	}
-	if page.Header.DataPageHeaderV2 != nil {
-		return int64(page.Header.DataPageHeaderV2.NumValues)
-	}
-	return 0
-}
-
 func (pw *ParquetWriter) recordDataPage(page *layout.Page, columnIndex *parquet.ColumnIndex, offsetIndex *parquet.OffsetIndex, dataPageIdx, dataPageCount int, firstRowIndex *int64) error {
 	if page.Header.DataPageHeader == nil && page.Header.DataPageHeaderV2 == nil {
 		return fmt.Errorf("unsupported data page: %s", page.Header.String())
@@ -202,11 +192,17 @@ func (pw *ParquetWriter) recordDataPage(page *layout.Page, columnIndex *parquet.
 
 	pageLocation := parquet.NewPageLocation()
 	pageLocation.Offset = pw.offset
+	// first_row_index is the row-group-relative index of the first row in the
+	// page. Pages are built row-aligned, so *firstRowIndex is exactly the index
+	// of this page's first row.
 	pageLocation.FirstRowIndex = *firstRowIndex
 	pageLocation.CompressedPageSize = int32(len(page.RawData))
 	offsetIndex.PageLocations = append(offsetIndex.PageLocations, pageLocation)
 
-	*firstRowIndex += dataPageNumValues(page)
+	// Advance by the row (record) count, not the leaf value count: per the
+	// Parquet spec first_row_index counts repetition-level-0 entries, which
+	// differs from NumValues for columns under repeated (LIST/MAP) fields.
+	*firstRowIndex += page.NumRows
 	return nil
 }
 

--- a/writer/pages_test.go
+++ b/writer/pages_test.go
@@ -75,38 +75,72 @@ func TestExtractPageStats(t *testing.T) {
 	}
 }
 
-func TestDataPageNumValues(t *testing.T) {
-	tests := []struct {
-		name string
-		page *layout.Page
-		want int64
-	}{
-		{
-			name: "data_page_v1",
-			page: &layout.Page{Header: &parquet.PageHeader{
-				DataPageHeader: &parquet.DataPageHeader{NumValues: 7},
-			}},
-			want: 7,
-		},
-		{
-			name: "data_page_v2",
-			page: &layout.Page{Header: &parquet.PageHeader{
-				DataPageHeaderV2: &parquet.DataPageHeaderV2{NumValues: 11},
-			}},
-			want: 11,
-		},
-		{
-			name: "not_data_page",
-			page: &layout.Page{Header: &parquet.PageHeader{}},
-			want: 0,
-		},
+// TestOffsetIndexFirstRowIndex verifies that PageLocation.first_row_index
+// advances by the number of rows (repetition-level-0 entries) in each page,
+// not by the leaf value count. For a repeated column values > rows, so the
+// value-based math would push first_row_index past the row-group row count.
+// Pages are row-aligned, so first_row_index must be strictly increasing and
+// every indexed page must begin at a row boundary.
+func TestOffsetIndexFirstRowIndex(t *testing.T) {
+	type ListStruct struct {
+		ID     int32   `parquet:"name=id, type=INT32"`
+		Values []int32 `parquet:"name=values, type=INT32, repetitiontype=REPEATED"`
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.want, dataPageNumValues(tt.page))
-		})
+	const numRows = 8
+	const valuesPerRow = 50
+
+	assertOffsetIndex := func(t *testing.T, pw *ParquetWriter, buf *bytes.Buffer) {
+		for i := range numRows {
+			values := make([]int32, valuesPerRow)
+			for j := range values {
+				values[j] = int32(i*valuesPerRow + j)
+			}
+			require.NoError(t, pw.Write(ListStruct{ID: int32(i), Values: values}))
+		}
+		require.NoError(t, pw.WriteStop())
+
+		pr, pf, err := createTestParquetReader(buf.Bytes(), new(ListStruct), reader.WithNP(1))
+		require.NoError(t, err)
+		defer func() { _ = pf.Close() }()
+		defer func() { _ = pr.ReadStop() }()
+
+		require.Equal(t, int64(numRows), pr.GetNumRows())
+
+		// The leaf column "values" carries repeated data; find it and check
+		// every page location advertises a row-based first_row_index.
+		var checkedMultiPage bool
+		for col := range pr.Footer.RowGroups[0].Columns {
+			oi, err := pr.ReadOffsetIndex(0, col)
+			require.NoError(t, err)
+			if oi == nil {
+				continue
+			}
+			prev := int64(-1)
+			for _, loc := range oi.PageLocations {
+				require.Greater(t, loc.FirstRowIndex, prev)
+				require.Less(t, loc.FirstRowIndex, int64(numRows))
+				prev = loc.FirstRowIndex
+			}
+			require.Equal(t, int64(0), oi.PageLocations[0].FirstRowIndex)
+			if len(oi.PageLocations) > 1 {
+				checkedMultiPage = true
+			}
+		}
+		require.True(t, checkedMultiPage)
 	}
+
+	t.Run("v1", func(t *testing.T) {
+		pw, buf, err := createTestParquetWriter(new(ListStruct), WithNP(1), WithPageSize(64))
+		require.NoError(t, err)
+		assertOffsetIndex(t, pw, buf)
+	})
+
+	t.Run("v2", func(t *testing.T) {
+		pw, buf, err := createTestParquetWriter(new(ListStruct), WithNP(1), WithPageSize(64), WithDataPageVersion(2))
+		require.NoError(t, err)
+		assertOffsetIndex(t, pw, buf)
+	})
 }
 
 func TestColumnIndex(t *testing.T) {


### PR DESCRIPTION
## Problem

Fixes #326.

`recordDataPage` advanced `PageLocation.first_row_index` by the leaf **value** count (`DataPageHeader.NumValues` / `DataPageHeaderV2.NumValues`). Per the Parquet spec, `first_row_index` is the index of the first **row** (record — a repetition-level-0 entry) of the page within the row group.

For flat schemas values == rows, so output happened to be correct. For any column under a repeated (LIST/MAP) field, values > rows, so every page after the first advertised a `first_row_index` that was too large — a query engine using the offset index for page-level row skipping would read the wrong row ranges.

## Fix

- **Row count instead of value count.** Carry the row count (rep-level-0 entries) on `layout.Page` (`NumRows`), computed during page creation so it survives `DataTable` being released, and use it in `recordDataPage`.
- **Row-aligned page construction.** A data page must contain whole rows so the offset index can address them and `first_row_index` stays strictly increasing. Once a page meets its size budget, scanning now continues to the next row boundary (repetition level 0) before ending the page. Applies to both plain (`scanPageValues`) and dictionary (`scanDictPageValues`) paths. Flat columns are unaffected — every entry is a row boundary.

## Tests

- `TestOffsetIndexFirstRowIndex` (writer): round-trips a repeated `[]int32` column across multiple pages for v1 and v2, asserting `first_row_index` is 0-based, **strictly increasing**, and within the row-group row count.
- `TestTableToDataPagesRowAligned` (layout): forces a mid-row byte-budget break and asserts every page begins on a row boundary, holds at least one whole row, and page rows sum to the total — covering v1, v2, and dictionary paths.
- Extended `TestComputeLevelHistograms` with `NumRows` expectations; removed the obsolete `TestDataPageNumValues`.

`make all` passes (format, lint, test, example, build). Coverage: writer 94.5%, internal/layout 95.0%.
