### PR TITLE
fix(writer): correct ColumnIndex for all-null and stats-less pages

### DIFF
--- a/writer/index.go
+++ b/writer/index.go
@@ -17,7 +17,14 @@ func (pw *ParquetWriter) writeColumnIndexes(ts *thrift.TSerializer) error {
 	idx := 0
 	for rowGroupIndex, rowGroup := range pw.Footer.RowGroups {
 		for columnOrdinal, columnChunk := range rowGroup.Columns {
-			columnIndexBuf, err := ts.Write(context.TODO(), pw.columnIndexes[idx])
+			columnIndex := pw.columnIndexes[idx]
+			idx++
+			// A nil slot means the chunk has no valid ColumnIndex (its non-null
+			// pages lack min/max bounds); leave ColumnIndexOffset unset.
+			if columnIndex == nil {
+				continue
+			}
+			columnIndexBuf, err := ts.Write(context.TODO(), columnIndex)
 			if err != nil {
 				return fmt.Errorf("serialize column index: %w", err)
 			}
@@ -39,8 +46,6 @@ func (pw *ParquetWriter) writeColumnIndexes(ts *thrift.TSerializer) error {
 			if _, err = pw.PFile.Write(columnIndexBuf); err != nil {
 				return fmt.Errorf("write column index: %w", err)
 			}
-
-			idx++
 
 			pos := pw.offset
 			columnChunk.ColumnIndexOffset = &pos

--- a/writer/pages.go
+++ b/writer/pages.go
@@ -168,14 +168,40 @@ func extractPageStats(page *layout.Page) pageStats {
 	return pageStats{}
 }
 
+// pageIsAllNull reports whether a data page contains no non-null leaf values.
+// The definition-level histogram's top bucket (max definition level) counts the
+// fully-defined, non-null leaf values in the page; it is computed for every page
+// of a nullable column (max definition level > 0). A required, non-nested column
+// has no histogram (nil) and can never be all-null. Relying on the histogram
+// keeps detection correct even when statistics are omitted or the column type
+// (GEOMETRY/GEOGRAPHY, INTERVAL) intentionally carries no min/max.
+func pageIsAllNull(page *layout.Page) bool {
+	hist := page.DefinitionLevelHistogram
+	if len(hist) == 0 {
+		return false
+	}
+	return hist[len(hist)-1] == 0
+}
+
 func (pw *ParquetWriter) recordDataPage(page *layout.Page, columnIndex *parquet.ColumnIndex, offsetIndex *parquet.OffsetIndex, dataPageIdx, dataPageCount int, firstRowIndex *int64) error {
 	if page.Header.DataPageHeader == nil && page.Header.DataPageHeaderV2 == nil {
 		return fmt.Errorf("unsupported data page: %s", page.Header.String())
 	}
 
 	stats := extractPageStats(page)
-	columnIndex.MinValues[dataPageIdx] = stats.minVal
-	columnIndex.MaxValues[dataPageIdx] = stats.maxVal
+	if pageIsAllNull(page) {
+		// A page holding only null values carries no real min/max. Per the
+		// Parquet spec such a page must set null_pages[i]=true, and only then
+		// may min_values[i]/max_values[i] be empty byte arrays. Leaving
+		// null_pages false with empty min/max would advertise a bogus bound
+		// (e.g. "" for BYTE_ARRAY) that a predicate-pushdown engine trusts.
+		columnIndex.NullPages[dataPageIdx] = true
+		columnIndex.MinValues[dataPageIdx] = []byte{}
+		columnIndex.MaxValues[dataPageIdx] = []byte{}
+	} else {
+		columnIndex.MinValues[dataPageIdx] = stats.minVal
+		columnIndex.MaxValues[dataPageIdx] = stats.maxVal
+	}
 	if stats.nullCount != nil {
 		if columnIndex.NullCounts == nil {
 			columnIndex.NullCounts = make([]int64, dataPageCount)

--- a/writer/pages.go
+++ b/writer/pages.go
@@ -183,12 +183,20 @@ func pageIsAllNull(page *layout.Page) bool {
 	return hist[len(hist)-1] == 0
 }
 
-func (pw *ParquetWriter) recordDataPage(page *layout.Page, columnIndex *parquet.ColumnIndex, offsetIndex *parquet.OffsetIndex, dataPageIdx, dataPageCount int, firstRowIndex *int64) error {
+// recordDataPage fills the ColumnIndex/OffsetIndex entries for one data page.
+// It returns hasValidBounds=false when the page is a non-null page that carries
+// no min/max (statistics omitted, or a type such as GEOMETRY/GEOGRAPHY/INTERVAL
+// that intentionally has none). The caller must not emit a ColumnIndex whose
+// non-null pages lack bounds: the Parquet spec requires min_values[i]/
+// max_values[i] to be valid whenever null_pages[i] is false, so an index with
+// empty bounds there would make predicate-pushdown readers skip matching rows.
+func (pw *ParquetWriter) recordDataPage(page *layout.Page, columnIndex *parquet.ColumnIndex, offsetIndex *parquet.OffsetIndex, dataPageIdx, dataPageCount int, firstRowIndex *int64) (hasValidBounds bool, err error) {
 	if page.Header.DataPageHeader == nil && page.Header.DataPageHeaderV2 == nil {
-		return fmt.Errorf("unsupported data page: %s", page.Header.String())
+		return false, fmt.Errorf("unsupported data page: %s", page.Header.String())
 	}
 
 	stats := extractPageStats(page)
+	hasValidBounds = true
 	if pageIsAllNull(page) {
 		// A page holding only null values carries no real min/max. Per the
 		// Parquet spec such a page must set null_pages[i]=true, and only then
@@ -199,6 +207,12 @@ func (pw *ParquetWriter) recordDataPage(page *layout.Page, columnIndex *parquet.
 		columnIndex.MinValues[dataPageIdx] = []byte{}
 		columnIndex.MaxValues[dataPageIdx] = []byte{}
 	} else {
+		// nil (as opposed to an empty-but-non-nil slice, which is the valid
+		// encoding of e.g. an empty BYTE_ARRAY value) means no statistic was
+		// computed for this non-null page, so the whole ColumnIndex is invalid.
+		if stats.minVal == nil || stats.maxVal == nil {
+			hasValidBounds = false
+		}
 		columnIndex.MinValues[dataPageIdx] = stats.minVal
 		columnIndex.MaxValues[dataPageIdx] = stats.maxVal
 	}
@@ -229,7 +243,7 @@ func (pw *ParquetWriter) recordDataPage(page *layout.Page, columnIndex *parquet.
 	// Parquet spec first_row_index counts repetition-level-0 entries, which
 	// differs from NumValues for columns under repeated (LIST/MAP) fields.
 	*firstRowIndex += page.NumRows
-	return nil
+	return hasValidBounds, nil
 }
 
 func (pw *ParquetWriter) writeChunkPages(chunk *layout.Chunk, rowGroupOrdinal, columnOrdinal int16) error {
@@ -255,6 +269,7 @@ func (pw *ParquetWriter) writeChunkPages(chunk *layout.Chunk, rowGroupOrdinal, c
 	columnIndex.MinValues = make([][]byte, dataPageCount)
 	columnIndex.MaxValues = make([][]byte, dataPageCount)
 	columnIndex.BoundaryOrder = parquet.BoundaryOrder_UNORDERED
+	columnIndexSlot := len(pw.columnIndexes)
 	pw.columnIndexes = append(pw.columnIndexes, columnIndex)
 
 	offsetIndex := parquet.NewOffsetIndex()
@@ -263,6 +278,7 @@ func (pw *ParquetWriter) writeChunkPages(chunk *layout.Chunk, rowGroupOrdinal, c
 
 	firstRowIndex := int64(0)
 	dataPageIdx := 0
+	columnIndexValid := true
 
 	for _, page := range pages {
 		pageOrdinal := int16(dataPageIdx)
@@ -282,8 +298,12 @@ func (pw *ParquetWriter) writeChunkPages(chunk *layout.Chunk, rowGroupOrdinal, c
 			chunk.ChunkHeader.MetaData.TotalCompressedSize += int64(len(page.RawData) - plainRawLen)
 		}
 		if isDataPage {
-			if err := pw.recordDataPage(page, columnIndex, offsetIndex, dataPageIdx, dataPageCount, &firstRowIndex); err != nil {
+			hasValidBounds, err := pw.recordDataPage(page, columnIndex, offsetIndex, dataPageIdx, dataPageCount, &firstRowIndex)
+			if err != nil {
 				return fmt.Errorf("record data page %d: %w", dataPageIdx, err)
+			}
+			if !hasValidBounds {
+				columnIndexValid = false
 			}
 			dataPageIdx++
 		}
@@ -291,6 +311,14 @@ func (pw *ParquetWriter) writeChunkPages(chunk *layout.Chunk, rowGroupOrdinal, c
 			return fmt.Errorf("write page data: %w", err)
 		}
 		pw.offset += int64(len(page.RawData))
+	}
+
+	// Drop a ColumnIndex whose non-null pages lack valid min/max bounds (e.g. a
+	// column written with omitstats, or a type that carries no min/max). A nil
+	// slot signals writeColumnIndexes to leave this chunk's ColumnIndexOffset
+	// unset, which is spec-valid and keeps the per-chunk slot alignment intact.
+	if !columnIndexValid {
+		pw.columnIndexes[columnIndexSlot] = nil
 	}
 	return nil
 }

--- a/writer/pages_test.go
+++ b/writer/pages_test.go
@@ -248,6 +248,7 @@ func TestColumnIndex(t *testing.T) {
 		}
 
 		type Expect struct {
+			HasColumnIndex  bool
 			IsSetNullCounts bool
 			NullCounts      []int64
 			NullPages       []bool
@@ -281,17 +282,23 @@ func TestColumnIndex(t *testing.T) {
 		chunks := pr.Footer.RowGroups[0].GetColumns()
 		require.Equal(t, 5, len(chunks))
 
-		// Every column here has at least one real value per page, so none is a
-		// null page even where statistics are omitted (histogram-based detection
-		// stays correct without min/max).
+		// Columns z and v use omitstats: their non-null pages have no min/max,
+		// so no ColumnIndex may be written for them (empty bounds with
+		// null_pages=false would violate the spec). The stats-bearing columns
+		// each have a real value per page and so are never null pages.
 		expects := []Expect{
-			{true, []int64{2}, []bool{false}},
-			{true, []int64{1}, []bool{false}},
-			{false, nil, []bool{false}},
-			{true, []int64{0}, []bool{false}},
-			{false, nil, []bool{false}},
+			{true, true, []int64{2}, []bool{false}},
+			{true, true, []int64{1}, []bool{false}},
+			{false, false, nil, nil},
+			{true, true, []int64{0}, []bool{false}},
+			{false, false, nil, nil},
 		}
 		for i, chunk := range chunks {
+			if !expects[i].HasColumnIndex {
+				require.False(t, chunk.IsSetColumnIndexOffset())
+				continue
+			}
+			require.True(t, chunk.IsSetColumnIndexOffset())
 			colIdx, err := readColumnIndex(pr.PFile, *chunk.ColumnIndexOffset)
 			require.NoError(t, err)
 			require.Equal(t, expects[i].IsSetNullCounts, colIdx.IsSetNullCounts())

--- a/writer/pages_test.go
+++ b/writer/pages_test.go
@@ -181,15 +181,61 @@ func TestColumnIndex(t *testing.T) {
 		columns := pr.Footer.RowGroups[0].GetColumns()
 		require.Equal(t, 2, len(columns))
 
+		// Column x has real values: not a null page, with genuine min/max.
 		colIdx, err := readColumnIndex(pr.PFile, *columns[0].ColumnIndexOffset)
 		require.NoError(t, err)
 		require.Equal(t, true, colIdx.IsSetNullCounts())
 		require.Equal(t, []int64{0}, colIdx.GetNullCounts())
+		require.Equal(t, []bool{false}, colIdx.GetNullPages())
 
+		// Column z is entirely null: the single page must be flagged as a null
+		// page with empty (not bogus) min/max bounds.
 		colIdx, err = readColumnIndex(pr.PFile, *columns[1].ColumnIndexOffset)
 		require.NoError(t, err)
 		require.Equal(t, true, colIdx.IsSetNullCounts())
 		require.Equal(t, []int64{6}, colIdx.GetNullCounts())
+		require.Equal(t, []bool{true}, colIdx.GetNullPages())
+		require.Equal(t, [][]byte{{}}, colIdx.GetMinValues())
+		require.Equal(t, [][]byte{{}}, colIdx.GetMaxValues())
+	})
+
+	t.Run("all_null_byte_array_page", func(t *testing.T) {
+		// Regression for the spec-violating case in issue #327: an all-null
+		// BYTE_ARRAY page must set null_pages=true with empty min/max. Otherwise
+		// the empty byte-array bound reads as a real min of "", and a
+		// predicate-pushdown engine evaluating `col <= ""` would wrongly match
+		// this page.
+		type Entry struct {
+			S *string `parquet:"name=s, type=BYTE_ARRAY, convertedtype=UTF8"`
+		}
+
+		var buf bytes.Buffer
+		fw := writerfile.NewWriterFile(&buf)
+		pw, err := NewParquetWriter(fw, new(Entry), WithNP(1))
+		require.NoError(t, err)
+
+		for range 4 {
+			require.NoError(t, pw.Write(Entry{S: nil}))
+		}
+		require.NoError(t, pw.WriteStop())
+
+		pf := buffer.NewBufferReaderFromBytesNoAlloc(buf.Bytes())
+		defer func() {
+			require.NoError(t, pf.Close())
+		}()
+		pr, err := reader.NewParquetReader(pf, nil, reader.WithNP(1))
+		require.NoError(t, err)
+		require.NoError(t, pr.ReadFooter())
+
+		columns := pr.Footer.RowGroups[0].GetColumns()
+		require.Equal(t, 1, len(columns))
+
+		colIdx, err := readColumnIndex(pr.PFile, *columns[0].ColumnIndexOffset)
+		require.NoError(t, err)
+		require.Equal(t, []bool{true}, colIdx.GetNullPages())
+		require.Equal(t, []int64{4}, colIdx.GetNullCounts())
+		require.Equal(t, [][]byte{{}}, colIdx.GetMinValues())
+		require.Equal(t, [][]byte{{}}, colIdx.GetMaxValues())
 	})
 
 	t.Run("null_counts", func(t *testing.T) {
@@ -204,6 +250,7 @@ func TestColumnIndex(t *testing.T) {
 		type Expect struct {
 			IsSetNullCounts bool
 			NullCounts      []int64
+			NullPages       []bool
 		}
 
 		var buf bytes.Buffer
@@ -234,18 +281,22 @@ func TestColumnIndex(t *testing.T) {
 		chunks := pr.Footer.RowGroups[0].GetColumns()
 		require.Equal(t, 5, len(chunks))
 
+		// Every column here has at least one real value per page, so none is a
+		// null page even where statistics are omitted (histogram-based detection
+		// stays correct without min/max).
 		expects := []Expect{
-			{true, []int64{2}},
-			{true, []int64{1}},
-			{false, nil},
-			{true, []int64{0}},
-			{false, nil},
+			{true, []int64{2}, []bool{false}},
+			{true, []int64{1}, []bool{false}},
+			{false, nil, []bool{false}},
+			{true, []int64{0}, []bool{false}},
+			{false, nil, []bool{false}},
 		}
 		for i, chunk := range chunks {
 			colIdx, err := readColumnIndex(pr.PFile, *chunk.ColumnIndexOffset)
 			require.NoError(t, err)
 			require.Equal(t, expects[i].IsSetNullCounts, colIdx.IsSetNullCounts())
 			require.Equal(t, expects[i].NullCounts, colIdx.GetNullCounts())
+			require.Equal(t, expects[i].NullPages, colIdx.GetNullPages())
 		}
 	})
 


### PR DESCRIPTION
Fixes #327.

## Problem

`writeChunkPages` allocated `columnIndex.NullPages` but never set any entry to `true`. For an all-null page, `recordDataPage` stored `nil` min/max, which thrift serializes as empty byte arrays — advertising a bogus real bound (e.g. `""` for a BYTE_ARRAY column) with `null_pages=false`. A query engine trusting the page index for predicate pushdown (e.g. `col <= ""`) could silently produce wrong results.

A related spec violation surfaced in review: a non-null page written with `omitstats=true` (or a GEOMETRY/GEOGRAPHY/INTERVAL type that carries no min/max) also got empty bounds with `null_pages=false`. The spec requires `min_values[i]`/`max_values[i]` to be valid whenever `null_pages[i]` is false, so predicate-pushdown readers could skip pages containing matching rows.

## Fix

**All-null pages** — detect via the definition-level histogram's top bucket (the count of non-null leaf values), which is computed for every nullable page regardless of omitted statistics or geospatial/interval types. Such pages now set `null_pages[i]=true` with empty `min/max`.

**Non-null pages lacking bounds** — `recordDataPage` reports whether real bounds were recorded, distinguishing an absent statistic (`nil`) from a valid empty BYTE_ARRAY value (empty-but-non-nil slice). When any non-null page in a chunk lacks bounds, the chunk's ColumnIndex is dropped (its `ColumnIndexOffset` left unset), which is spec-valid. The OffsetIndex, needing no bounds, is still written. This also removes the previously-bogus empty ColumnIndex that geospatial/interval columns emitted (their geo statistics live in the column-chunk metadata, so nothing is lost).

## Tests

- All-null INT64 and BYTE_ARRAY pages assert `null_pages=true` with empty bounds (the `col <= ""` regression).
- `omitstats` columns assert their `ColumnIndexOffset` is unset, while stats-bearing columns keep valid indexes.
- Mixed null/value columns assert `null_pages=false`, guarding against false positives.

`make all` passes; writer coverage held at 94.6%.