### PR TITLE
fix(layout): sort chunk metadata encodings for deterministic output

### DIFF
--- a/internal/layout/chunk.go
+++ b/internal/layout/chunk.go
@@ -2,6 +2,7 @@ package layout
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/hangxie/parquet-go/v3/common"
 	"github.com/hangxie/parquet-go/v3/internal/encoding"
@@ -78,6 +79,10 @@ func aggregatePageMetrics(pages []*Page, statsStartIdx int, funcTable common.Fun
 	for encoding := range encodingsMap {
 		encodings = append(encodings, encoding)
 	}
+	// Sort for deterministic output: map iteration order is randomized, which
+	// would otherwise make ColumnMetaData.Encodings order vary between runs and
+	// produce byte-different files for identical input.
+	slices.Sort(encodings)
 	return numValues, totalUncompressed, totalCompressed, minVal, maxVal, nullCount, encodings
 }
 

--- a/internal/layout/chunk_test.go
+++ b/internal/layout/chunk_test.go
@@ -219,6 +219,44 @@ func TestPagesToChunk(t *testing.T) {
 	}
 }
 
+// TestAggregatePageMetrics_EncodingsSorted verifies that the aggregated
+// Encodings slice is deterministically sorted. The encodings are collected via
+// a map, whose iteration order Go randomizes, so without an explicit sort the
+// order would vary between runs and produce byte-different files for identical
+// input. Repeating the aggregation exercises the randomized iteration.
+func TestAggregatePageMetrics_EncodingsSorted(t *testing.T) {
+	makePages := func() []*Page {
+		dictPage := NewDictPage()
+		dictPage.Header.DictionaryPageHeader = &parquet.DictionaryPageHeader{
+			Encoding: parquet.Encoding_PLAIN,
+		}
+
+		dataPage := NewDataPage()
+		dataPage.Header.DataPageHeader = &parquet.DataPageHeader{
+			NumValues:               1,
+			Encoding:                parquet.Encoding_RLE_DICTIONARY,
+			DefinitionLevelEncoding: parquet.Encoding_RLE,
+			RepetitionLevelEncoding: parquet.Encoding_BIT_PACKED,
+		}
+
+		return []*Page{dictPage, dataPage}
+	}
+
+	want := []parquet.Encoding{
+		parquet.Encoding_PLAIN,
+		parquet.Encoding_RLE,
+		parquet.Encoding_BIT_PACKED,
+		parquet.Encoding_RLE_DICTIONARY,
+	}
+
+	// Run repeatedly so randomized map iteration order is exercised; the result
+	// must be identical and sorted every time.
+	for range 100 {
+		_, _, _, _, _, _, encodings := aggregatePageMetrics(makePages(), 0, nil, true)
+		require.Equal(t, want, encodings)
+	}
+}
+
 func TestPagesToDictChunk(t *testing.T) {
 	// Create dictionary page
 	dictPage := NewDictPage()


### PR DESCRIPTION
## Summary

Fixes #333.

`ColumnMetaData.Encodings` was populated by iterating over a Go map (`encodingsMap`) in `aggregatePageMetrics`. Because Go randomizes map iteration order, the encodings appeared in a different sequence on each run, so identical input data produced **byte-different** output files. This breaks reproducible builds, complicates test comparisons, and defeats deduplication in content-addressed storage.

This is an ordering issue only — the set of encodings written was always correct.

## Change

Sort the aggregated encodings slice (`slices.Sort`) before assigning it to the metadata. Encodings are integer-valued Thrift enums, so natural ordering is well-defined and deterministic.

## Performance

Negligible. The slice holds at most a handful of *distinct* encoding enums per column chunk (data encoding + definition/repetition-level encodings + dictionary/RLE), and `aggregatePageMetrics` runs once per column chunk during metadata finalization — not on any per-row or per-value hot path. The sort cost is dwarfed by the map operations that already precede it.

## Testing

- Added `TestAggregatePageMetrics_EncodingsSorted`, which repeats the aggregation to exercise randomized map iteration and asserts the result is identical and sorted every time.
- `make all` passes (format, lint, test, example, build); `internal/layout` coverage 95.1%.