### PR TITLE
refactor(marshal): key unmarshal records by storage identity

### DIFF
--- a/marshal/unmarshal.go
+++ b/marshal/unmarshal.go
@@ -29,15 +29,24 @@ type SliceRecord struct {
 
 type unmarshalState struct {
 	schemaHandler     *schema.SchemaHandler
-	mapRecords        map[reflect.Value]*MapRecord
+	mapRecords        map[any]*MapRecord
 	mapRecordsStack   []reflect.Value
-	sliceRecords      map[reflect.Value]*SliceRecord
+	sliceRecords      map[any]*SliceRecord
 	sliceRecordsStack []reflect.Value
 	prevType          reflect.Type
 	prevFieldName     string
 	prevFieldIndex    []int
-	prevSlicePo       reflect.Value
+	prevSlicePo       any
 	prevSliceRecord   *SliceRecord
+}
+
+// valueIdentity keys a reflect.Value by its underlying storage, used by the
+// record maps in place of the reflect.Value itself, whose equality the Go spec
+// does not define for identity use. The typed *T pointer (not a bare uintptr)
+// keeps the storage GC-visible and distinguishes values by type as well as
+// address. Every value tracked here is addressable.
+func valueIdentity(v reflect.Value) any {
+	return v.Addr().Interface()
 }
 
 type tableContext struct {
@@ -174,14 +183,15 @@ func handleOldListLeaf(po reflect.Value, val any) {
 }
 
 func (s *unmarshalState) getSliceRecord(po reflect.Value) *SliceRecord {
-	if s.prevSlicePo == po {
+	key := valueIdentity(po)
+	if s.prevSlicePo != nil && s.prevSlicePo == key {
 		return s.prevSliceRecord
 	}
-	s.prevSlicePo = po
-	sliceRec, ok := s.sliceRecords[po]
+	s.prevSlicePo = key
+	sliceRec, ok := s.sliceRecords[key]
 	if !ok {
 		sliceRec = &SliceRecord{Values: []reflect.Value{}, Index: -1}
-		s.sliceRecords[po] = sliceRec
+		s.sliceRecords[key] = sliceRec
 		s.sliceRecordsStack = append(s.sliceRecordsStack, po)
 	}
 	s.prevSliceRecord = sliceRec
@@ -240,10 +250,11 @@ func (s *unmarshalState) handleMap(po reflect.Value, tc *tableContext, index int
 		po.Set(reflect.MakeMap(poType))
 	}
 
-	mapRec, ok := s.mapRecords[po]
+	key := valueIdentity(po)
+	mapRec, ok := s.mapRecords[key]
 	if !ok {
 		mapRec = &MapRecord{KeyValues: []KeyValue{}, Index: -1}
-		s.mapRecords[po] = mapRec
+		s.mapRecords[key] = mapRec
 		s.mapRecordsStack = append(s.mapRecordsStack, po)
 	}
 
@@ -391,7 +402,7 @@ func (s *unmarshalState) processTable(root reflect.Value, prefixIndex int, table
 	s.prevType = nil
 	s.prevFieldName = ""
 	s.prevFieldIndex = nil
-	s.prevSlicePo = reflect.Value{}
+	s.prevSlicePo = nil
 	s.prevSliceRecord = nil
 
 	for i := bgn; i < end; i++ {
@@ -420,8 +431,8 @@ func Unmarshal(tableMap *map[string]*layout.Table, bgn, end int, dstInterface an
 
 	state := &unmarshalState{
 		schemaHandler: schemaHandler,
-		mapRecords:    make(map[reflect.Value]*MapRecord),
-		sliceRecords:  make(map[reflect.Value]*SliceRecord),
+		mapRecords:    make(map[any]*MapRecord),
+		sliceRecords:  make(map[any]*SliceRecord),
 	}
 
 	for name, table := range tableNeeds {
@@ -439,12 +450,12 @@ func Unmarshal(tableMap *map[string]*layout.Table, bgn, end int, dstInterface an
 
 	for i := len(state.sliceRecordsStack) - 1; i >= 0; i-- {
 		po := state.sliceRecordsStack[i]
-		vs := state.sliceRecords[po]
+		vs := state.sliceRecords[valueIdentity(po)]
 		po.Set(reflect.Append(po, vs.Values...))
 	}
 	for i := len(state.mapRecordsStack) - 1; i >= 0; i-- {
 		po := state.mapRecordsStack[i]
-		for _, kv := range state.mapRecords[po].KeyValues {
+		for _, kv := range state.mapRecords[valueIdentity(po)].KeyValues {
 			po.SetMapIndex(kv.Key, kv.Value)
 		}
 	}

--- a/marshal/unmarshal_test.go
+++ b/marshal/unmarshal_test.go
@@ -405,6 +405,34 @@ func TestUnmarshal_MapAndList_MultipleEntries(t *testing.T) {
 	require.Equal(t, src, dst)
 }
 
+// TestValueIdentity checks the record-tracking invariant: two reflect.Values
+// map to the same key iff they share storage of the same type.
+func TestValueIdentity(t *testing.T) {
+	type inner struct{ V int32 }
+	type outer struct {
+		A inner
+		B inner
+	}
+
+	t.Run("same storage and type compares equal", func(t *testing.T) {
+		v := reflect.ValueOf(&outer{}).Elem()
+		require.True(t, valueIdentity(v.Field(0)) == valueIdentity(v.FieldByName("A")))
+	})
+
+	t.Run("distinct storage compares unequal", func(t *testing.T) {
+		v := reflect.ValueOf(&outer{}).Elem()
+		require.False(t, valueIdentity(v.Field(0)) == valueIdentity(v.Field(1)))
+	})
+
+	t.Run("same address but different type compares unequal", func(t *testing.T) {
+		// A struct and its offset-zero field share an address; the typed pointer
+		// identity keeps them distinct, where a bare uintptr key would collide.
+		v := reflect.ValueOf(&outer{}).Elem()
+		require.Equal(t, v.Addr().Pointer(), v.Field(0).Addr().Pointer())
+		require.False(t, valueIdentity(v) == valueIdentity(v.Field(0)))
+	})
+}
+
 // Test helper types and functions for old list format testing
 type TestTarget [][]int32
 

--- a/marshal/unmarshal_variant.go
+++ b/marshal/unmarshal_variant.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hangxie/parquet-go/v3/types"
 )
 
-func processVariantReconstruction(variantReconstructors map[string]*ShreddedVariantReconstructor, root reflect.Value, prefixPath string, schemaHandler *schema.SchemaHandler, tableBgn, tableEnd map[string]int, sliceRecords map[reflect.Value]*SliceRecord) error {
+func processVariantReconstruction(variantReconstructors map[string]*ShreddedVariantReconstructor, root reflect.Value, prefixPath string, schemaHandler *schema.SchemaHandler, tableBgn, tableEnd map[string]int, sliceRecords map[any]*SliceRecord) error {
 	for variantPath, reconstructor := range variantReconstructors {
 		numRows := countVariantRows(reconstructor, tableBgn, tableEnd)
 		expandRootForVariants(root, numRows, sliceRecords)
@@ -45,8 +45,8 @@ func countVariantRows(reconstructor *ShreddedVariantReconstructor, tableBgn, tab
 	return numRows
 }
 
-func expandRootForVariants(root reflect.Value, numRows int, sliceRecords map[reflect.Value]*SliceRecord) {
-	if sliceRec, ok := sliceRecords[root]; ok && len(sliceRec.Values) >= numRows {
+func expandRootForVariants(root reflect.Value, numRows int, sliceRecords map[any]*SliceRecord) {
+	if sliceRec, ok := sliceRecords[valueIdentity(root)]; ok && len(sliceRec.Values) >= numRows {
 		return
 	}
 	if root.Kind() == reflect.Slice && root.Len() < numRows {
@@ -112,7 +112,7 @@ func assignVariantToTarget(po reflect.Value, variant types.Variant) error {
 	return fmt.Errorf("could not set variant value at path end")
 }
 
-func navigateToVariantTarget(root reflect.Value, path []string, prefixIndex int, variant types.Variant, rowIdx int, sliceRecords map[reflect.Value]*SliceRecord) (reflect.Value, error) {
+func navigateToVariantTarget(root reflect.Value, path []string, prefixIndex int, variant types.Variant, rowIdx int, sliceRecords map[any]*SliceRecord) (reflect.Value, error) {
 	po := root
 	for i := prefixIndex; i < len(path); i++ {
 		if !po.IsValid() {
@@ -132,7 +132,7 @@ func navigateToVariantTarget(root reflect.Value, path []string, prefixIndex int,
 			if po.Type().Elem().Kind() == reflect.Uint8 {
 				return po, fmt.Errorf("unexpected []byte at path index %d", i)
 			}
-			sliceRec, ok := sliceRecords[po]
+			sliceRec, ok := sliceRecords[valueIdentity(po)]
 			if ok && rowIdx < len(sliceRec.Values) {
 				po = sliceRec.Values[rowIdx]
 			} else if rowIdx < po.Len() {
@@ -170,7 +170,7 @@ func navigateToVariantTarget(root reflect.Value, path []string, prefixIndex int,
 }
 
 // setVariantValue navigates the struct path and sets a variant value at the specified location.
-func setVariantValue(root reflect.Value, variantPath, prefixPath string, _ *schema.SchemaHandler, variant types.Variant, rowIdx int, sliceRecords map[reflect.Value]*SliceRecord) error {
+func setVariantValue(root reflect.Value, variantPath, prefixPath string, _ *schema.SchemaHandler, variant types.Variant, rowIdx int, sliceRecords map[any]*SliceRecord) error {
 	path := common.StrToPath(variantPath)
 	prefixIndex := common.PathStrIndex(prefixPath)
 

--- a/marshal/unmarshal_variant_test.go
+++ b/marshal/unmarshal_variant_test.go
@@ -22,7 +22,7 @@ func TestSetVariantValue(t *testing.T) {
 		}
 
 		sh := &schema.SchemaHandler{}
-		sliceRecords := make(map[reflect.Value]*SliceRecord)
+		sliceRecords := make(map[any]*SliceRecord)
 
 		testStruct := SimpleStruct{Name: "test"}
 		root := reflect.ValueOf(&testStruct).Elem()
@@ -44,7 +44,7 @@ func TestSetVariantValue(t *testing.T) {
 		}
 
 		sh := &schema.SchemaHandler{}
-		sliceRecords := make(map[reflect.Value]*SliceRecord)
+		sliceRecords := make(map[any]*SliceRecord)
 
 		testStruct := StructWithPtrVariant{Name: "test"}
 		root := reflect.ValueOf(&testStruct).Elem()
@@ -69,7 +69,7 @@ func TestSetVariantValue(t *testing.T) {
 		}
 
 		sh := &schema.SchemaHandler{}
-		sliceRecords := make(map[reflect.Value]*SliceRecord)
+		sliceRecords := make(map[any]*SliceRecord)
 
 		testStruct := Outer{}
 		root := reflect.ValueOf(&testStruct).Elem()
@@ -90,13 +90,13 @@ func TestSetVariantValue(t *testing.T) {
 		}
 
 		sh := &schema.SchemaHandler{}
-		sliceRecords := make(map[reflect.Value]*SliceRecord)
+		sliceRecords := make(map[any]*SliceRecord)
 
 		testSlice := []ItemWithVariant{{}, {}}
 		root := reflect.ValueOf(&testSlice).Elem()
 
 		// Create slice record to track slice values
-		sliceRecords[root] = &SliceRecord{
+		sliceRecords[valueIdentity(root)] = &SliceRecord{
 			Values: []reflect.Value{
 				reflect.ValueOf(&testSlice[0]).Elem(),
 				reflect.ValueOf(&testSlice[1]).Elem(),
@@ -120,7 +120,7 @@ func TestSetVariantValue(t *testing.T) {
 		}
 
 		sh := &schema.SchemaHandler{}
-		sliceRecords := make(map[reflect.Value]*SliceRecord)
+		sliceRecords := make(map[any]*SliceRecord)
 
 		testStruct := SimpleStruct{Name: "test"}
 		root := reflect.ValueOf(&testStruct).Elem()
@@ -143,7 +143,7 @@ func TestSetVariantValue(t *testing.T) {
 		}
 
 		sh := &schema.SchemaHandler{}
-		sliceRecords := make(map[reflect.Value]*SliceRecord)
+		sliceRecords := make(map[any]*SliceRecord)
 
 		testStruct := StructWithPtrNested{}
 		root := reflect.ValueOf(&testStruct).Elem()
@@ -165,7 +165,7 @@ func TestSetVariantValue(t *testing.T) {
 		}
 
 		sh := &schema.SchemaHandler{}
-		sliceRecords := make(map[reflect.Value]*SliceRecord)
+		sliceRecords := make(map[any]*SliceRecord)
 
 		testSlice := []ItemWithVariant{{}}
 		root := reflect.ValueOf(&testSlice).Elem()
@@ -187,7 +187,7 @@ func TestSetVariantValue(t *testing.T) {
 		}
 
 		sh := &schema.SchemaHandler{}
-		sliceRecords := make(map[reflect.Value]*SliceRecord)
+		sliceRecords := make(map[any]*SliceRecord)
 
 		testStruct := StructWithBytes{Data: []byte{1, 2, 3}}
 		root := reflect.ValueOf(&testStruct).Elem()
@@ -208,7 +208,7 @@ func TestSetVariantValue(t *testing.T) {
 		}
 
 		sh := &schema.SchemaHandler{}
-		sliceRecords := make(map[reflect.Value]*SliceRecord)
+		sliceRecords := make(map[any]*SliceRecord)
 
 		testStruct := StructWithInt{Value: 42}
 		root := reflect.ValueOf(&testStruct).Elem()
@@ -229,7 +229,7 @@ func TestSetVariantValue(t *testing.T) {
 		}
 
 		sh := &schema.SchemaHandler{}
-		sliceRecords := make(map[reflect.Value]*SliceRecord)
+		sliceRecords := make(map[any]*SliceRecord)
 
 		testStruct := StructWithString{Name: "test"}
 		root := reflect.ValueOf(&testStruct).Elem()
@@ -250,7 +250,7 @@ func TestSetVariantValue(t *testing.T) {
 		}
 
 		sh := &schema.SchemaHandler{}
-		sliceRecords := make(map[reflect.Value]*SliceRecord) // Empty - no SliceRecord for this slice
+		sliceRecords := make(map[any]*SliceRecord) // Empty - no SliceRecord for this slice
 
 		testSlice := []ItemWithVariant{{}, {}, {}}
 		root := reflect.ValueOf(&testSlice).Elem()
@@ -269,7 +269,7 @@ func TestSetVariantValue(t *testing.T) {
 	t.Run("path_ends_at_variant_type_directly", func(t *testing.T) {
 		// Test case where the path ends right at a types.Variant field
 		sh := &schema.SchemaHandler{}
-		sliceRecords := make(map[reflect.Value]*SliceRecord)
+		sliceRecords := make(map[any]*SliceRecord)
 
 		// Create a Variant directly
 		testVariant := types.Variant{}
@@ -289,7 +289,7 @@ func TestSetVariantValue(t *testing.T) {
 	t.Run("path_ends_at_pointer_to_variant_directly", func(t *testing.T) {
 		// Test case where the path ends at a *types.Variant field
 		sh := &schema.SchemaHandler{}
-		sliceRecords := make(map[reflect.Value]*SliceRecord)
+		sliceRecords := make(map[any]*SliceRecord)
 
 		var testVariant *types.Variant
 		root := reflect.ValueOf(&testVariant).Elem()
@@ -399,14 +399,14 @@ func TestExpandRootForVariants_Coverage(t *testing.T) {
 	// Test slice expansion
 	testSlice := []int32{1}
 	root := reflect.ValueOf(&testSlice).Elem()
-	sliceRecords := make(map[reflect.Value]*SliceRecord)
+	sliceRecords := make(map[any]*SliceRecord)
 
 	expandRootForVariants(root, 5, sliceRecords)
 	require.Equal(t, 5, root.Len())
 	require.Equal(t, int32(1), testSlice[0])
 
 	// Test with sliceRecord already having enough values
-	sliceRecords[root] = &SliceRecord{Values: make([]reflect.Value, 10)}
+	sliceRecords[valueIdentity(root)] = &SliceRecord{Values: make([]reflect.Value, 10)}
 	expandRootForVariants(root, 5, sliceRecords)
 	require.Equal(t, 5, root.Len()) // No further expansion
 }


### PR DESCRIPTION
## Summary

The unmarshal record maps keyed on `reflect.Value`. The Go spec does not define
`reflect.Value` equality for identity purposes (comparison is over its internal
`typ`/`ptr`/`flag` fields), so using it to dedup records depends on unspecified
behavior. This re-keys the map and slice record maps on the underlying storage
identity.

`Value.Addr().Interface()` (the typed `*T` pointer) is used rather than a bare
`uintptr`: it keeps the storage GC-visible, and its equality matches on both
type and address, so distinct values that happen to share an address (e.g. a
struct and its offset-zero field) do not collide. The record stacks still retain
the `reflect.Value` for final write-back.

## Behavior

This is spec-conformance hardening. Every value tracked here is addressable and
settable, and for that regime the current runtime's `reflect.Value` equality
already tracks storage identity — so there is **no observable behavior change**.
`TestValueIdentity` documents the invariant (same storage + type → equal;
distinct storage → unequal; same address + different type → unequal).

Closes #338

## Testing

- `make all` passes (format, lint, test, example, build)
- `marshal` package coverage unchanged at 92.5%
