### PR TITLE
refactor(marshal): tidy variant reconstruction signatures

### DIFF
--- a/marshal/unmarshal.go
+++ b/marshal/unmarshal.go
@@ -444,7 +444,7 @@ func Unmarshal(tableMap *map[string]*layout.Table, bgn, end int, dstInterface an
 		}
 	}
 
-	if err := processVariantReconstruction(variantReconstructors, root, prefixPath, schemaHandler, tableBgn, tableEnd, state.sliceRecords); err != nil {
+	if err := processVariantReconstruction(variantReconstructors, root, prefixPath, tableBgn, tableEnd, state.sliceRecords); err != nil {
 		return fmt.Errorf("reconstruct variants: %w", err)
 	}
 

--- a/marshal/unmarshal.go
+++ b/marshal/unmarshal.go
@@ -89,8 +89,8 @@ func computeTableBounds(tableMap *map[string]*layout.Table, prefixPath string, b
 	return tableNeeds, tableBgn, tableEnd, true
 }
 
-func identifyVariants(schemaHandler *schema.SchemaHandler, prefixPath string, tableNeeds map[string]*layout.Table, tableMap *map[string]*layout.Table) (map[string]*ShreddedVariantReconstructor, map[string]string) {
-	variantReconstructors := make(map[string]*ShreddedVariantReconstructor)
+func identifyVariants(schemaHandler *schema.SchemaHandler, prefixPath string, tableNeeds map[string]*layout.Table, tableMap *map[string]*layout.Table) (map[string]*variantReconstructor, map[string]string) {
+	variantReconstructors := make(map[string]*variantReconstructor)
 	variantChildPaths := make(map[string]string)
 	if schemaHandler.VariantSchemas == nil {
 		return variantReconstructors, variantChildPaths
@@ -99,7 +99,7 @@ func identifyVariants(schemaHandler *schema.SchemaHandler, prefixPath string, ta
 		if prefixPath != "" && !common.IsChildPath(prefixPath, variantPath) {
 			continue
 		}
-		variantReconstructors[variantPath] = NewShreddedVariantReconstructor(variantPath, info, tableMap, schemaHandler)
+		variantReconstructors[variantPath] = newVariantReconstructor(variantPath, info, tableMap, schemaHandler)
 		for childPath := range tableNeeds {
 			if strings.HasPrefix(childPath, variantPath+common.ParGoPathDelimiter) {
 				variantChildPaths[childPath] = variantPath

--- a/marshal/unmarshal_variant.go
+++ b/marshal/unmarshal_variant.go
@@ -5,11 +5,10 @@ import (
 	"reflect"
 
 	"github.com/hangxie/parquet-go/v3/common"
-	"github.com/hangxie/parquet-go/v3/schema"
 	"github.com/hangxie/parquet-go/v3/types"
 )
 
-func processVariantReconstruction(variantReconstructors map[string]*variantReconstructor, root reflect.Value, prefixPath string, schemaHandler *schema.SchemaHandler, tableBgn, tableEnd map[string]int, sliceRecords map[any]*SliceRecord) error {
+func processVariantReconstruction(variantReconstructors map[string]*variantReconstructor, root reflect.Value, prefixPath string, tableBgn, tableEnd map[string]int, sliceRecords map[any]*SliceRecord) error {
 	for variantPath, reconstructor := range variantReconstructors {
 		numRows := countVariantRows(reconstructor, tableBgn, tableEnd)
 		expandRootForVariants(root, numRows, sliceRecords)
@@ -19,7 +18,7 @@ func processVariantReconstruction(variantReconstructors map[string]*variantRecon
 			if err != nil {
 				return fmt.Errorf("reconstruct variant at %s row %d: %w", variantPath, rowIdx, err)
 			}
-			if err := setVariantValue(root, variantPath, prefixPath, schemaHandler, variant, rowIdx, sliceRecords); err != nil {
+			if err := setVariantValue(root, variantPath, prefixPath, variant, rowIdx, sliceRecords); err != nil {
 				return fmt.Errorf("set variant at %s row %d: %w", variantPath, rowIdx, err)
 			}
 		}
@@ -170,7 +169,7 @@ func navigateToVariantTarget(root reflect.Value, path []string, prefixIndex int,
 }
 
 // setVariantValue navigates the struct path and sets a variant value at the specified location.
-func setVariantValue(root reflect.Value, variantPath, prefixPath string, _ *schema.SchemaHandler, variant types.Variant, rowIdx int, sliceRecords map[any]*SliceRecord) error {
+func setVariantValue(root reflect.Value, variantPath, prefixPath string, variant types.Variant, rowIdx int, sliceRecords map[any]*SliceRecord) error {
 	path := common.StrToPath(variantPath)
 	prefixIndex := common.PathStrIndex(prefixPath)
 

--- a/marshal/unmarshal_variant.go
+++ b/marshal/unmarshal_variant.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hangxie/parquet-go/v3/types"
 )
 
-func processVariantReconstruction(variantReconstructors map[string]*ShreddedVariantReconstructor, root reflect.Value, prefixPath string, schemaHandler *schema.SchemaHandler, tableBgn, tableEnd map[string]int, sliceRecords map[any]*SliceRecord) error {
+func processVariantReconstruction(variantReconstructors map[string]*variantReconstructor, root reflect.Value, prefixPath string, schemaHandler *schema.SchemaHandler, tableBgn, tableEnd map[string]int, sliceRecords map[any]*SliceRecord) error {
 	for variantPath, reconstructor := range variantReconstructors {
 		numRows := countVariantRows(reconstructor, tableBgn, tableEnd)
 		expandRootForVariants(root, numRows, sliceRecords)
@@ -27,7 +27,7 @@ func processVariantReconstruction(variantReconstructors map[string]*ShreddedVari
 	return nil
 }
 
-func countVariantRows(reconstructor *ShreddedVariantReconstructor, tableBgn, tableEnd map[string]int) int {
+func countVariantRows(reconstructor *variantReconstructor, tableBgn, tableEnd map[string]int) int {
 	if reconstructor.MetadataTable == nil {
 		return 0
 	}

--- a/marshal/unmarshal_variant_test.go
+++ b/marshal/unmarshal_variant_test.go
@@ -21,7 +21,6 @@ func TestSetVariantValue(t *testing.T) {
 			Var  types.Variant
 		}
 
-		sh := &schema.SchemaHandler{}
 		sliceRecords := make(map[any]*SliceRecord)
 
 		testStruct := SimpleStruct{Name: "test"}
@@ -32,7 +31,7 @@ func TestSetVariantValue(t *testing.T) {
 			Value:    []byte{0x00},
 		}
 
-		err := setVariantValue(root, common.ParGoRootInName+common.ParGoPathDelimiter+"Var", "", sh, variant, 0, sliceRecords)
+		err := setVariantValue(root, common.ParGoRootInName+common.ParGoPathDelimiter+"Var", "", variant, 0, sliceRecords)
 		require.NoError(t, err)
 		require.Equal(t, variant, testStruct.Var)
 	})
@@ -43,7 +42,6 @@ func TestSetVariantValue(t *testing.T) {
 			Var  *types.Variant
 		}
 
-		sh := &schema.SchemaHandler{}
 		sliceRecords := make(map[any]*SliceRecord)
 
 		testStruct := StructWithPtrVariant{Name: "test"}
@@ -54,7 +52,7 @@ func TestSetVariantValue(t *testing.T) {
 			Value:    []byte{0x00},
 		}
 
-		err := setVariantValue(root, common.ParGoRootInName+common.ParGoPathDelimiter+"Var", "", sh, variant, 0, sliceRecords)
+		err := setVariantValue(root, common.ParGoRootInName+common.ParGoPathDelimiter+"Var", "", variant, 0, sliceRecords)
 		require.NoError(t, err)
 		require.NotNil(t, testStruct.Var)
 		require.Equal(t, variant, *testStruct.Var)
@@ -68,7 +66,6 @@ func TestSetVariantValue(t *testing.T) {
 			Inner Inner
 		}
 
-		sh := &schema.SchemaHandler{}
 		sliceRecords := make(map[any]*SliceRecord)
 
 		testStruct := Outer{}
@@ -79,7 +76,7 @@ func TestSetVariantValue(t *testing.T) {
 			Value:    []byte{0x00},
 		}
 
-		err := setVariantValue(root, common.ParGoRootInName+common.ParGoPathDelimiter+"Inner"+common.ParGoPathDelimiter+"Var", "", sh, variant, 0, sliceRecords)
+		err := setVariantValue(root, common.ParGoRootInName+common.ParGoPathDelimiter+"Inner"+common.ParGoPathDelimiter+"Var", "", variant, 0, sliceRecords)
 		require.NoError(t, err)
 		require.Equal(t, variant, testStruct.Inner.Var)
 	})
@@ -89,7 +86,6 @@ func TestSetVariantValue(t *testing.T) {
 			Var types.Variant
 		}
 
-		sh := &schema.SchemaHandler{}
 		sliceRecords := make(map[any]*SliceRecord)
 
 		testSlice := []ItemWithVariant{{}, {}}
@@ -109,7 +105,7 @@ func TestSetVariantValue(t *testing.T) {
 			Value:    []byte{0x00},
 		}
 
-		err := setVariantValue(root, common.ParGoRootInName+common.ParGoPathDelimiter+"Var", "", sh, variant, 1, sliceRecords)
+		err := setVariantValue(root, common.ParGoRootInName+common.ParGoPathDelimiter+"Var", "", variant, 1, sliceRecords)
 		require.NoError(t, err)
 		require.Equal(t, variant, testSlice[1].Var)
 	})
@@ -119,7 +115,6 @@ func TestSetVariantValue(t *testing.T) {
 			Name string
 		}
 
-		sh := &schema.SchemaHandler{}
 		sliceRecords := make(map[any]*SliceRecord)
 
 		testStruct := SimpleStruct{Name: "test"}
@@ -130,7 +125,7 @@ func TestSetVariantValue(t *testing.T) {
 			Value:    []byte{0x00},
 		}
 
-		err := setVariantValue(root, common.ParGoRootInName+common.ParGoPathDelimiter+"NonExistent", "", sh, variant, 0, sliceRecords)
+		err := setVariantValue(root, common.ParGoRootInName+common.ParGoPathDelimiter+"NonExistent", "", variant, 0, sliceRecords)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "not found")
 	})
@@ -142,7 +137,6 @@ func TestSetVariantValue(t *testing.T) {
 			}
 		}
 
-		sh := &schema.SchemaHandler{}
 		sliceRecords := make(map[any]*SliceRecord)
 
 		testStruct := StructWithPtrNested{}
@@ -153,7 +147,7 @@ func TestSetVariantValue(t *testing.T) {
 			Value:    []byte{0x00},
 		}
 
-		err := setVariantValue(root, common.ParGoRootInName+common.ParGoPathDelimiter+"Inner"+common.ParGoPathDelimiter+"Var", "", sh, variant, 0, sliceRecords)
+		err := setVariantValue(root, common.ParGoRootInName+common.ParGoPathDelimiter+"Inner"+common.ParGoPathDelimiter+"Var", "", variant, 0, sliceRecords)
 		require.NoError(t, err)
 		require.NotNil(t, testStruct.Inner)
 		require.Equal(t, variant, testStruct.Inner.Var)
@@ -164,7 +158,6 @@ func TestSetVariantValue(t *testing.T) {
 			Var types.Variant
 		}
 
-		sh := &schema.SchemaHandler{}
 		sliceRecords := make(map[any]*SliceRecord)
 
 		testSlice := []ItemWithVariant{{}}
@@ -176,7 +169,7 @@ func TestSetVariantValue(t *testing.T) {
 		}
 
 		// rowIdx 5 is out of bounds for a slice with 1 element
-		err := setVariantValue(root, common.ParGoRootInName+common.ParGoPathDelimiter+"Var", "", sh, variant, 5, sliceRecords)
+		err := setVariantValue(root, common.ParGoRootInName+common.ParGoPathDelimiter+"Var", "", variant, 5, sliceRecords)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "out of bounds")
 	})
@@ -186,7 +179,6 @@ func TestSetVariantValue(t *testing.T) {
 			Data []byte
 		}
 
-		sh := &schema.SchemaHandler{}
 		sliceRecords := make(map[any]*SliceRecord)
 
 		testStruct := StructWithBytes{Data: []byte{1, 2, 3}}
@@ -197,7 +189,7 @@ func TestSetVariantValue(t *testing.T) {
 			Value:    []byte{0x00},
 		}
 
-		err := setVariantValue(root, common.ParGoRootInName+common.ParGoPathDelimiter+"Data"+common.ParGoPathDelimiter+"Var", "", sh, variant, 0, sliceRecords)
+		err := setVariantValue(root, common.ParGoRootInName+common.ParGoPathDelimiter+"Data"+common.ParGoPathDelimiter+"Var", "", variant, 0, sliceRecords)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "[]byte")
 	})
@@ -207,7 +199,6 @@ func TestSetVariantValue(t *testing.T) {
 			Value int
 		}
 
-		sh := &schema.SchemaHandler{}
 		sliceRecords := make(map[any]*SliceRecord)
 
 		testStruct := StructWithInt{Value: 42}
@@ -218,7 +209,7 @@ func TestSetVariantValue(t *testing.T) {
 			Value:    []byte{0x00},
 		}
 
-		err := setVariantValue(root, common.ParGoRootInName+common.ParGoPathDelimiter+"Value"+common.ParGoPathDelimiter+"Var", "", sh, variant, 0, sliceRecords)
+		err := setVariantValue(root, common.ParGoRootInName+common.ParGoPathDelimiter+"Value"+common.ParGoPathDelimiter+"Var", "", variant, 0, sliceRecords)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "unexpected kind")
 	})
@@ -228,7 +219,6 @@ func TestSetVariantValue(t *testing.T) {
 			Name string
 		}
 
-		sh := &schema.SchemaHandler{}
 		sliceRecords := make(map[any]*SliceRecord)
 
 		testStruct := StructWithString{Name: "test"}
@@ -239,7 +229,7 @@ func TestSetVariantValue(t *testing.T) {
 			Value:    []byte{0x00},
 		}
 
-		err := setVariantValue(root, common.ParGoRootInName+common.ParGoPathDelimiter+"Name", "", sh, variant, 0, sliceRecords)
+		err := setVariantValue(root, common.ParGoRootInName+common.ParGoPathDelimiter+"Name", "", variant, 0, sliceRecords)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "could not set variant value at path end")
 	})
@@ -249,7 +239,6 @@ func TestSetVariantValue(t *testing.T) {
 			Var types.Variant
 		}
 
-		sh := &schema.SchemaHandler{}
 		sliceRecords := make(map[any]*SliceRecord) // Empty - no SliceRecord for this slice
 
 		testSlice := []ItemWithVariant{{}, {}, {}}
@@ -261,14 +250,13 @@ func TestSetVariantValue(t *testing.T) {
 		}
 
 		// Access row 1 without SliceRecord - should use direct po.Index(rowIdx)
-		err := setVariantValue(root, common.ParGoRootInName+common.ParGoPathDelimiter+"Var", "", sh, variant, 1, sliceRecords)
+		err := setVariantValue(root, common.ParGoRootInName+common.ParGoPathDelimiter+"Var", "", variant, 1, sliceRecords)
 		require.NoError(t, err)
 		require.Equal(t, variant, testSlice[1].Var)
 	})
 
 	t.Run("path_ends_at_variant_type_directly", func(t *testing.T) {
 		// Test case where the path ends right at a types.Variant field
-		sh := &schema.SchemaHandler{}
 		sliceRecords := make(map[any]*SliceRecord)
 
 		// Create a Variant directly
@@ -281,14 +269,13 @@ func TestSetVariantValue(t *testing.T) {
 		}
 
 		// Path is just the root (empty path after prefix)
-		err := setVariantValue(root, common.ParGoRootInName, "", sh, variant, 0, sliceRecords)
+		err := setVariantValue(root, common.ParGoRootInName, "", variant, 0, sliceRecords)
 		require.NoError(t, err)
 		require.Equal(t, variant, testVariant)
 	})
 
 	t.Run("path_ends_at_pointer_to_variant_directly", func(t *testing.T) {
 		// Test case where the path ends at a *types.Variant field
-		sh := &schema.SchemaHandler{}
 		sliceRecords := make(map[any]*SliceRecord)
 
 		var testVariant *types.Variant
@@ -300,7 +287,7 @@ func TestSetVariantValue(t *testing.T) {
 		}
 
 		// Path is just the root (empty path after prefix)
-		err := setVariantValue(root, common.ParGoRootInName, "", sh, variant, 0, sliceRecords)
+		err := setVariantValue(root, common.ParGoRootInName, "", variant, 0, sliceRecords)
 		require.NoError(t, err)
 		require.NotNil(t, testVariant)
 		require.Equal(t, variant, *testVariant)

--- a/marshal/variant_reconstruct.go
+++ b/marshal/variant_reconstruct.go
@@ -11,10 +11,10 @@ import (
 	"github.com/hangxie/parquet-go/v3/types"
 )
 
-// ShreddedVariantReconstructor handles the reconstruction of shredded VARIANT columns.
+// variantReconstructor handles the reconstruction of shredded VARIANT columns.
 // It collects related tables (metadata, value, typed_value) and reconstructs full
 // Variant values row by row.
-type ShreddedVariantReconstructor struct {
+type variantReconstructor struct {
 	Path             string                    // Path of the variant group
 	Info             *schema.VariantSchemaInfo // Schema info for this variant
 	MetadataTable    *layout.Table             // metadata column (always present)
@@ -24,14 +24,14 @@ type ShreddedVariantReconstructor struct {
 	SchemaHandler    *schema.SchemaHandler     // Schema handler for path resolution
 }
 
-// NewShreddedVariantReconstructor creates a reconstructor for a shredded variant column.
-func NewShreddedVariantReconstructor(
+// newVariantReconstructor creates a reconstructor for a shredded variant column.
+func newVariantReconstructor(
 	path string,
 	info *schema.VariantSchemaInfo,
 	tableMap *map[string]*layout.Table,
 	sh *schema.SchemaHandler,
-) *ShreddedVariantReconstructor {
-	r := &ShreddedVariantReconstructor{
+) *variantReconstructor {
+	r := &variantReconstructor{
 		Path:          path,
 		Info:          info,
 		SchemaHandler: sh,
@@ -75,7 +75,7 @@ func NewShreddedVariantReconstructor(
 // It handles definition levels to return nil for missing values.
 // getValueAtRow returns the value from a table at the given row index.
 // It handles repeated fields by returning a slice of values.
-func (r *ShreddedVariantReconstructor) getValueAtRow(table *layout.Table, rowIdx int, tableBgn, tableEnd map[string]int) (any, error) {
+func (r *variantReconstructor) getValueAtRow(table *layout.Table, rowIdx int, tableBgn, tableEnd map[string]int) (any, error) {
 	if table == nil {
 		return nil, nil
 	}
@@ -132,7 +132,7 @@ func (r *ShreddedVariantReconstructor) getValueAtRow(table *layout.Table, rowIdx
 	return values[0], nil
 }
 
-func (r *ShreddedVariantReconstructor) findChildTables(pathPrefix string) map[string][]*layout.Table {
+func (r *variantReconstructor) findChildTables(pathPrefix string) map[string][]*layout.Table {
 	childTables := make(map[string][]*layout.Table)
 	for tableName, table := range *r.tableMap {
 		if strings.HasPrefix(tableName, pathPrefix+common.ParGoPathDelimiter) {
@@ -163,7 +163,7 @@ func findVariantChildNames(childTables map[string][]*layout.Table) (variantChild
 	return names, names.meta != "" || names.value != "" || names.typed != ""
 }
 
-func (r *ShreddedVariantReconstructor) reconstructChildValues(pathPrefix, childName string, rowIdx int, tableBgn, tableEnd map[string]int, metadata []byte) ([]any, bool, error) {
+func (r *variantReconstructor) reconstructChildValues(pathPrefix, childName string, rowIdx int, tableBgn, tableEnd map[string]int, metadata []byte) ([]any, bool, error) {
 	if childName == "" {
 		return nil, false, nil
 	}
@@ -180,7 +180,7 @@ func (r *ShreddedVariantReconstructor) reconstructChildValues(pathPrefix, childN
 	return nil, false, nil
 }
 
-func (r *ShreddedVariantReconstructor) isChildTablesRepeated(childTables map[string][]*layout.Table) (bool, error) {
+func (r *variantReconstructor) isChildTablesRepeated(childTables map[string][]*layout.Table) (bool, error) {
 	for _, tables := range childTables {
 		for _, table := range tables {
 			maxRL, err := r.SchemaHandler.MaxRepetitionLevel(table.Path)
@@ -195,7 +195,7 @@ func (r *ShreddedVariantReconstructor) isChildTablesRepeated(childTables map[str
 	return false, nil
 }
 
-func (r *ShreddedVariantReconstructor) reconstructVariantGroup(
+func (r *variantReconstructor) reconstructVariantGroup(
 	pathPrefix string, rowIdx int, tableBgn, tableEnd map[string]int, metadata []byte,
 	childTables map[string][]*layout.Table, names variantChildNames,
 ) (any, error) {
@@ -238,7 +238,7 @@ func (r *ShreddedVariantReconstructor) reconstructVariantGroup(
 	return variantResultsToAny(results, isRepeated)
 }
 
-func (r *ShreddedVariantReconstructor) reconstructElementChildren(
+func (r *variantReconstructor) reconstructElementChildren(
 	pathPrefix string, rowIdx int, tableBgn, tableEnd map[string]int, metadata []byte,
 	childTables map[string][]*layout.Table,
 ) (any, error) {
@@ -263,7 +263,7 @@ func (r *ShreddedVariantReconstructor) reconstructElementChildren(
 	return elements, nil
 }
 
-func (r *ShreddedVariantReconstructor) collectChildValues(
+func (r *variantReconstructor) collectChildValues(
 	pathPrefix string, rowIdx int, tableBgn, tableEnd map[string]int, metadata []byte,
 	childTables map[string][]*layout.Table,
 ) (map[string][]any, int, error) {
@@ -289,7 +289,7 @@ func (r *ShreddedVariantReconstructor) collectChildValues(
 	return tableValues, maxLen, nil
 }
 
-func (r *ShreddedVariantReconstructor) resolveExName(childName, pathPrefix string) string {
+func (r *variantReconstructor) resolveExName(childName, pathPrefix string) string {
 	childPath := pathPrefix + common.ParGoPathDelimiter + childName
 	if idx, ok := r.SchemaHandler.MapIndex[childPath]; ok {
 		return r.SchemaHandler.Infos[idx].ExName
@@ -297,7 +297,7 @@ func (r *ShreddedVariantReconstructor) resolveExName(childName, pathPrefix strin
 	return childName
 }
 
-func (r *ShreddedVariantReconstructor) reconstructMapChildren(
+func (r *variantReconstructor) reconstructMapChildren(
 	pathPrefix string, rowIdx int, tableBgn, tableEnd map[string]int, metadata []byte,
 	childTables map[string][]*layout.Table,
 ) (any, error) {
@@ -354,7 +354,7 @@ func (r *ShreddedVariantReconstructor) reconstructMapChildren(
 }
 
 // reconstructValue recursively builds a Go value from shredded columns.
-func (r *ShreddedVariantReconstructor) reconstructValue(pathPrefix string, rowIdx int, tableBgn, tableEnd map[string]int, metadata []byte) (any, error) {
+func (r *variantReconstructor) reconstructValue(pathPrefix string, rowIdx int, tableBgn, tableEnd map[string]int, metadata []byte) (any, error) {
 	if table, ok := (*r.tableMap)[pathPrefix]; ok {
 		return r.getValueAtRow(table, rowIdx, tableBgn, tableEnd)
 	}
@@ -394,7 +394,7 @@ func (r *ShreddedVariantReconstructor) reconstructValue(pathPrefix string, rowId
 }
 
 // Reconstruct reconstructs a Variant value for the given row index.
-func (r *ShreddedVariantReconstructor) Reconstruct(rowIdx int, tableBgn, tableEnd map[string]int) (types.Variant, error) {
+func (r *variantReconstructor) Reconstruct(rowIdx int, tableBgn, tableEnd map[string]int) (types.Variant, error) {
 	val, err := r.reconstructValue(r.Path, rowIdx, tableBgn, tableEnd, nil)
 	if err != nil {
 		return types.Variant{}, fmt.Errorf("reconstruct variant at %s row %d: %w", r.Path, rowIdx, err)

--- a/marshal/variant_reconstruct_test.go
+++ b/marshal/variant_reconstruct_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hangxie/parquet-go/v3/types"
 )
 
-func TestNewShreddedVariantReconstructor(t *testing.T) {
+func TestNewVariantReconstructor(t *testing.T) {
 	// Create schema with variant
 	variantInfo := &schema.VariantSchemaInfo{
 		MetadataIdx:    2,
@@ -55,7 +55,7 @@ func TestNewShreddedVariantReconstructor(t *testing.T) {
 	}
 
 	t.Run("all_tables_present", func(t *testing.T) {
-		r := NewShreddedVariantReconstructor(
+		r := newVariantReconstructor(
 			"Root"+common.ParGoPathDelimiter+"Var",
 			variantInfo,
 			tableMap,
@@ -77,7 +77,7 @@ func TestNewShreddedVariantReconstructor(t *testing.T) {
 			IsShredded:     true,
 		}
 
-		r := NewShreddedVariantReconstructor(
+		r := newVariantReconstructor(
 			"Root"+common.ParGoPathDelimiter+"Var",
 			infoNoValue,
 			tableMap,
@@ -93,7 +93,7 @@ func TestNewShreddedVariantReconstructor(t *testing.T) {
 	t.Run("missing_tables_in_map", func(t *testing.T) {
 		emptyTableMap := &map[string]*layout.Table{}
 
-		r := NewShreddedVariantReconstructor(
+		r := newVariantReconstructor(
 			"Root"+common.ParGoPathDelimiter+"Var",
 			variantInfo,
 			emptyTableMap,
@@ -107,7 +107,7 @@ func TestNewShreddedVariantReconstructor(t *testing.T) {
 	})
 }
 
-func TestShreddedVariantReconstructor_GetValueAtRow(t *testing.T) {
+func TestVariantReconstructor_GetValueAtRow(t *testing.T) {
 	sh := &schema.SchemaHandler{
 		MapIndex: map[string]int32{
 			"Root": 0,
@@ -121,7 +121,7 @@ func TestShreddedVariantReconstructor_GetValueAtRow(t *testing.T) {
 		},
 	}
 
-	r := &ShreddedVariantReconstructor{
+	r := &variantReconstructor{
 		SchemaHandler: sh,
 	}
 
@@ -216,7 +216,7 @@ func TestShreddedVariantReconstructor_GetValueAtRow(t *testing.T) {
 	})
 }
 
-func TestShreddedVariantReconstructor_Reconstruct(t *testing.T) {
+func TestVariantReconstructor_Reconstruct(t *testing.T) {
 	sh := &schema.SchemaHandler{
 		MapIndex: map[string]int32{
 			"Root": 0,
@@ -260,7 +260,7 @@ func TestShreddedVariantReconstructor_Reconstruct(t *testing.T) {
 			"Root" + common.ParGoPathDelimiter + "Var" + common.ParGoPathDelimiter + "Value":    valueTable,
 		}
 
-		r := NewShreddedVariantReconstructor(
+		r := newVariantReconstructor(
 			"Root"+common.ParGoPathDelimiter+"Var",
 			&schema.VariantSchemaInfo{
 				MetadataIdx:    2,
@@ -299,7 +299,7 @@ func TestShreddedVariantReconstructor_Reconstruct(t *testing.T) {
 			"Root" + common.ParGoPathDelimiter + "Var" + common.ParGoPathDelimiter + "Metadata": metadataTable,
 		}
 
-		r := NewShreddedVariantReconstructor(
+		r := newVariantReconstructor(
 			"Root"+common.ParGoPathDelimiter+"Var",
 			&schema.VariantSchemaInfo{
 				MetadataIdx:    2,
@@ -335,7 +335,7 @@ func TestShreddedVariantReconstructor_Reconstruct(t *testing.T) {
 			"Root" + common.ParGoPathDelimiter + "Var" + common.ParGoPathDelimiter + "Metadata": metadataTable,
 		}
 
-		r := NewShreddedVariantReconstructor(
+		r := newVariantReconstructor(
 			"Root"+common.ParGoPathDelimiter+"Var",
 			&schema.VariantSchemaInfo{
 				MetadataIdx:    2,
@@ -378,7 +378,7 @@ func TestShreddedVariantReconstructor_Reconstruct(t *testing.T) {
 			"Root" + common.ParGoPathDelimiter + "Var" + common.ParGoPathDelimiter + "Value":    valueTable,
 		}
 
-		r := NewShreddedVariantReconstructor(
+		r := newVariantReconstructor(
 			"Root"+common.ParGoPathDelimiter+"Var",
 			&schema.VariantSchemaInfo{
 				MetadataIdx:    2,
@@ -423,7 +423,7 @@ func TestShreddedVariantReconstructor_Reconstruct(t *testing.T) {
 			"Root" + common.ParGoPathDelimiter + "Var" + common.ParGoPathDelimiter + "Typed_value": typedValueTable,
 		}
 
-		r := NewShreddedVariantReconstructor(
+		r := newVariantReconstructor(
 			"Root"+common.ParGoPathDelimiter+"Var",
 			&schema.VariantSchemaInfo{
 				MetadataIdx:    2,
@@ -450,7 +450,7 @@ func TestShreddedVariantReconstructor_Reconstruct(t *testing.T) {
 	})
 }
 
-func TestShreddedVariantReconstructor_Recursive(t *testing.T) {
+func TestVariantReconstructor_Recursive(t *testing.T) {
 	// Root.Var (VARIANT) shredded into:
 	// Root.Var.Metadata
 	// Root.Var.Typed_value.a.Metadata
@@ -522,7 +522,7 @@ func TestShreddedVariantReconstructor_Recursive(t *testing.T) {
 		break
 	}
 
-	r := NewShreddedVariantReconstructor(path, info, &tableMap, sh)
+	r := newVariantReconstructor(path, info, &tableMap, sh)
 
 	tableBgn := map[string]int{mKey: 0, vKey: 0, imKey: 0, ivKey: 0}
 	tableEnd := map[string]int{mKey: 1, vKey: 1, imKey: 1, ivKey: 1}
@@ -537,7 +537,7 @@ func TestShreddedVariantReconstructor_Recursive(t *testing.T) {
 	require.Equal(t, expected, decoded)
 }
 
-func TestShreddedVariantReconstructor_Reconstruct_Coverage(t *testing.T) {
+func TestVariantReconstructor_Reconstruct_Coverage(t *testing.T) {
 	t.Run("reconstruct_value_error_propagation", func(t *testing.T) {
 		metadata := types.EncodeVariantMetadata([]string{"a"})
 		metadataTable := &layout.Table{
@@ -572,7 +572,7 @@ func TestShreddedVariantReconstructor_Reconstruct_Coverage(t *testing.T) {
 			break
 		}
 
-		r := NewShreddedVariantReconstructor(path, info, &tableMap, sh)
+		r := newVariantReconstructor(path, info, &tableMap, sh)
 
 		mKey := common.ParGoRootInName + common.ParGoPathDelimiter + "Var" + common.ParGoPathDelimiter + "Metadata"
 		vKey := common.ParGoRootInName + common.ParGoPathDelimiter + "Var" + common.ParGoPathDelimiter + "Value"
@@ -625,7 +625,7 @@ func TestShreddedVariantReconstructor_Reconstruct_Coverage(t *testing.T) {
 			break
 		}
 
-		r := NewShreddedVariantReconstructor(path, info, &tableMap, sh)
+		r := newVariantReconstructor(path, info, &tableMap, sh)
 
 		mKey := common.ParGoRootInName + common.ParGoPathDelimiter + "Var" + common.ParGoPathDelimiter + "Metadata"
 		vKey := common.ParGoRootInName + common.ParGoPathDelimiter + "Var" + common.ParGoPathDelimiter + "Value"
@@ -639,7 +639,7 @@ func TestShreddedVariantReconstructor_Reconstruct_Coverage(t *testing.T) {
 	})
 }
 
-func TestShreddedVariantReconstructor_reconstructValue_Coverage(t *testing.T) {
+func TestVariantReconstructor_reconstructValue_Coverage(t *testing.T) {
 	t.Run("nested_list_reconstruction", func(t *testing.T) {
 		// Mock a LIST of Variants
 		// Root.Var (LIST)
@@ -688,7 +688,7 @@ func TestShreddedVariantReconstructor_reconstructValue_Coverage(t *testing.T) {
 		// reconstructValue handles LIST by going to List/Element.
 
 		// Manually create reconstructor since it's not a top-level Variant group
-		r := &ShreddedVariantReconstructor{
+		r := &variantReconstructor{
 			Path:          common.ParGoRootInName + common.ParGoPathDelimiter + "Var",
 			tableMap:      &tableMap,
 			SchemaHandler: sh,
@@ -735,7 +735,7 @@ func TestShreddedVariantReconstructor_reconstructValue_Coverage(t *testing.T) {
 			},
 		}
 
-		r := &ShreddedVariantReconstructor{
+		r := &variantReconstructor{
 			Path:          common.ParGoRootInName + common.ParGoPathDelimiter + "Obj",
 			tableMap:      &tableMap,
 			SchemaHandler: sh,
@@ -778,7 +778,7 @@ func TestShreddedVariantReconstructor_reconstructValue_Coverage(t *testing.T) {
 			},
 		}
 
-		r1 := &ShreddedVariantReconstructor{
+		r1 := &variantReconstructor{
 			Path:          common.ParGoRootInName + common.ParGoPathDelimiter + "Var",
 			tableMap:      &tableMap1,
 			SchemaHandler: sh1,
@@ -816,7 +816,7 @@ func TestShreddedVariantReconstructor_reconstructValue_Coverage(t *testing.T) {
 				DefinitionLevels: []int32{1},
 			},
 		}
-		r2 := &ShreddedVariantReconstructor{
+		r2 := &variantReconstructor{
 			Path:          common.ParGoRootInName + common.ParGoPathDelimiter + "Var",
 			tableMap:      &tableMap2,
 			SchemaHandler: sh2,
@@ -848,7 +848,7 @@ func TestShreddedVariantReconstructor_reconstructValue_Coverage(t *testing.T) {
 		}
 		tableBgn2[tKey3], tableEnd2[tKey3] = 0, 1
 
-		r3 := &ShreddedVariantReconstructor{
+		r3 := &variantReconstructor{
 			Path:          common.ParGoRootInName + common.ParGoPathDelimiter + "Var",
 			tableMap:      &tableMap2,
 			SchemaHandler: sh3,
@@ -863,7 +863,7 @@ func TestShreddedVariantReconstructor_reconstructValue_Coverage(t *testing.T) {
 		sh, _ := schema.NewSchemaHandlerFromStruct(new(struct {
 			Var int32 `parquet:"name=Var, type=VARIANT"`
 		}))
-		r := &ShreddedVariantReconstructor{
+		r := &variantReconstructor{
 			Path:          common.ParGoRootInName + common.ParGoPathDelimiter + "Var",
 			tableMap:      &map[string]*layout.Table{},
 			SchemaHandler: sh,
@@ -911,7 +911,7 @@ func TestShreddedVariantReconstructor_reconstructValue_Coverage(t *testing.T) {
 				DefinitionLevels: []int32{1},
 			},
 		}
-		r := &ShreddedVariantReconstructor{
+		r := &variantReconstructor{
 			Path:          common.ParGoRootInName + common.ParGoPathDelimiter + "Var",
 			tableMap:      &tableMap,
 			SchemaHandler: sh,
@@ -923,10 +923,10 @@ func TestShreddedVariantReconstructor_reconstructValue_Coverage(t *testing.T) {
 	})
 }
 
-// TestShreddedVariantReconstructor_reconstructElementChildren covers the code path where
+// TestVariantReconstructor_reconstructElementChildren covers the code path where
 // a LIST element contains non-variant struct children (not Metadata/Value/Typed_value),
 // which routes through reconstructElementChildren and collectChildValues.
-func TestShreddedVariantReconstructor_reconstructElementChildren(t *testing.T) {
+func TestVariantReconstructor_reconstructElementChildren(t *testing.T) {
 	t.Run("list_of_struct_elements", func(t *testing.T) {
 		// Schema:  Root.Var (LIST)
 		//            List (REPEATED)
@@ -966,7 +966,7 @@ func TestShreddedVariantReconstructor_reconstructElementChildren(t *testing.T) {
 			} `parquet:"name=Var, type=LIST"`
 		}))
 
-		r := &ShreddedVariantReconstructor{
+		r := &variantReconstructor{
 			Path:          common.ParGoRootInName + common.ParGoPathDelimiter + "Var",
 			tableMap:      &tableMap,
 			SchemaHandler: sh,
@@ -1018,7 +1018,7 @@ func TestShreddedVariantReconstructor_reconstructElementChildren(t *testing.T) {
 			} `parquet:"name=Var, type=LIST"`
 		}))
 
-		r := &ShreddedVariantReconstructor{
+		r := &variantReconstructor{
 			Path:          common.ParGoRootInName + common.ParGoPathDelimiter + "Var",
 			tableMap:      &tableMap,
 			SchemaHandler: sh,


### PR DESCRIPTION
## Summary

Two small, behavior-preserving cleanups in the variant reconstruction code,
split out from #345 to keep that PR focused on record identity.

### 1. Shorten and unexport `variantReconstructor`

`ShreddedVariantReconstructor` / `NewShreddedVariantReconstructor` were exported
but used nowhere outside the `marshal` package. Renamed to `variantReconstructor`
/ `newVariantReconstructor`: shorter, and no longer leaks an internal
reconstruction detail into the public API surface.

### 2. Drop the dead `schemaHandler` parameter

`processVariantReconstruction` threaded a `*schema.SchemaHandler` solely to hand
it to `setVariantValue`, which ignored it (an unnamed `_` parameter). Removed it
from both signatures, along with the now-unused `schema` import in the variant
files.

## Notes

- The rename unexports a previously-exported type. It is used only within
  `marshal/`, so no external caller is affected; flagging it since it technically
  narrows the public API.

## Testing

- `make all` passes (format, lint, test, example, build)
- `marshal` package coverage unchanged at 92.5%
