### PR TITLE
fix(layout): omit deprecated Statistics min/max for unsigned sort orders

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,7 @@ Encoding notes:
 - For maximum compatibility, use `PLAIN` and `PLAIN_DICTIONARY`.
 - Avoid dictionary encoding for high-cardinality fields because dictionaries can consume significant memory.
 - Use `omitstats=true` in a field tag to skip statistics for large array fields.
+- Whenever min/max statistics are available, the current `min_value`/`max_value` fields are written. The deprecated `min`/`max` fields (PARQUET-251) are limited to signed sort orders; for unsigned-ordered columns (e.g. `BYTE_ARRAY`/UTF8 and unsigned integer logical types) they are omitted so legacy readers do not misinterpret them.
 
 ## Compression Support
 

--- a/common/sortorder.go
+++ b/common/sortorder.go
@@ -1,0 +1,57 @@
+package common
+
+import "github.com/hangxie/parquet-go/v3/parquet"
+
+// IsSignedSortOrder reports whether a column's sort order is SIGNED, gating the
+// deprecated signed Statistics.Min/Max fields (PARQUET-251). It follows the
+// parquet-mr/Arrow classification and FindFuncTable's type precedence.
+func IsSignedSortOrder(pT *parquet.Type, cT *parquet.ConvertedType, logT *parquet.LogicalType) bool {
+	if cT != nil {
+		switch *cT {
+		case parquet.ConvertedType_UTF8, parquet.ConvertedType_ENUM,
+			parquet.ConvertedType_JSON, parquet.ConvertedType_BSON,
+			parquet.ConvertedType_INTERVAL,
+			parquet.ConvertedType_UINT_8, parquet.ConvertedType_UINT_16,
+			parquet.ConvertedType_UINT_32, parquet.ConvertedType_UINT_64:
+			return false // unsigned
+		case parquet.ConvertedType_INT_8, parquet.ConvertedType_INT_16,
+			parquet.ConvertedType_INT_32, parquet.ConvertedType_INT_64,
+			parquet.ConvertedType_DECIMAL, parquet.ConvertedType_DATE,
+			parquet.ConvertedType_TIME_MILLIS, parquet.ConvertedType_TIME_MICROS,
+			parquet.ConvertedType_TIMESTAMP_MILLIS, parquet.ConvertedType_TIMESTAMP_MICROS:
+			return true // signed
+		}
+	}
+
+	if logT != nil {
+		switch {
+		case logT.STRING != nil, logT.ENUM != nil, logT.JSON != nil,
+			logT.BSON != nil, logT.UUID != nil:
+			return false // unsigned
+		case logT.INTEGER != nil:
+			return logT.INTEGER.IsSigned
+		case logT.DECIMAL != nil, logT.DATE != nil, logT.TIME != nil,
+			logT.TIMESTAMP != nil, logT.FLOAT16 != nil:
+			// FLOAT16 has a numeric total order like FLOAT/DOUBLE.
+			return true // signed
+		case logT.UNKNOWN != nil, logT.VARIANT != nil,
+			logT.GEOMETRY != nil, logT.GEOGRAPHY != nil:
+			return false // unknown order
+		}
+	}
+
+	if pT != nil {
+		switch *pT {
+		case parquet.Type_BOOLEAN, parquet.Type_INT32, parquet.Type_INT64,
+			parquet.Type_FLOAT, parquet.Type_DOUBLE:
+			// BOOLEAN follows parquet-mr's defaultSortOrder (SIGNED); harmless
+			// as its single 0x00/0x01 byte orders identically either way.
+			return true // signed
+		case parquet.Type_BYTE_ARRAY, parquet.Type_FIXED_LEN_BYTE_ARRAY,
+			parquet.Type_INT96:
+			return false // unsigned (BYTE_ARRAY/FIXED) or unknown (INT96)
+		}
+	}
+
+	return false
+}

--- a/common/sortorder_test.go
+++ b/common/sortorder_test.go
@@ -1,0 +1,76 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hangxie/parquet-go/v3/parquet"
+)
+
+func Test_IsSignedSortOrder(t *testing.T) {
+	tests := []struct {
+		name string
+		pT   *parquet.Type
+		cT   *parquet.ConvertedType
+		logT *parquet.LogicalType
+		want bool
+	}{
+		{name: "all nil", want: false},
+		{name: "boolean", pT: ToPtr(parquet.Type_BOOLEAN), want: true},
+		{name: "int32", pT: ToPtr(parquet.Type_INT32), want: true},
+		{name: "int64", pT: ToPtr(parquet.Type_INT64), want: true},
+		{name: "float", pT: ToPtr(parquet.Type_FLOAT), want: true},
+		{name: "double", pT: ToPtr(parquet.Type_DOUBLE), want: true},
+		{name: "byte_array", pT: ToPtr(parquet.Type_BYTE_ARRAY), want: false},
+		{name: "fixed_len_byte_array", pT: ToPtr(parquet.Type_FIXED_LEN_BYTE_ARRAY), want: false},
+		{name: "int96", pT: ToPtr(parquet.Type_INT96), want: false},
+
+		// Converted types.
+		{name: "utf8", pT: ToPtr(parquet.Type_BYTE_ARRAY), cT: ToPtr(parquet.ConvertedType_UTF8), want: false},
+		{name: "enum", pT: ToPtr(parquet.Type_BYTE_ARRAY), cT: ToPtr(parquet.ConvertedType_ENUM), want: false},
+		{name: "json", pT: ToPtr(parquet.Type_BYTE_ARRAY), cT: ToPtr(parquet.ConvertedType_JSON), want: false},
+		{name: "bson", pT: ToPtr(parquet.Type_BYTE_ARRAY), cT: ToPtr(parquet.ConvertedType_BSON), want: false},
+		{name: "interval", pT: ToPtr(parquet.Type_FIXED_LEN_BYTE_ARRAY), cT: ToPtr(parquet.ConvertedType_INTERVAL), want: false},
+		{name: "uint_8", pT: ToPtr(parquet.Type_INT32), cT: ToPtr(parquet.ConvertedType_UINT_8), want: false},
+		{name: "uint_16", pT: ToPtr(parquet.Type_INT32), cT: ToPtr(parquet.ConvertedType_UINT_16), want: false},
+		{name: "uint_32", pT: ToPtr(parquet.Type_INT32), cT: ToPtr(parquet.ConvertedType_UINT_32), want: false},
+		{name: "uint_64", pT: ToPtr(parquet.Type_INT64), cT: ToPtr(parquet.ConvertedType_UINT_64), want: false},
+		{name: "int_8", pT: ToPtr(parquet.Type_INT32), cT: ToPtr(parquet.ConvertedType_INT_8), want: true},
+		{name: "int_64", pT: ToPtr(parquet.Type_INT64), cT: ToPtr(parquet.ConvertedType_INT_64), want: true},
+		{name: "decimal converted", pT: ToPtr(parquet.Type_INT32), cT: ToPtr(parquet.ConvertedType_DECIMAL), want: true},
+		{name: "date converted", pT: ToPtr(parquet.Type_INT32), cT: ToPtr(parquet.ConvertedType_DATE), want: true},
+		{name: "time_millis", pT: ToPtr(parquet.Type_INT32), cT: ToPtr(parquet.ConvertedType_TIME_MILLIS), want: true},
+		{name: "timestamp_micros", pT: ToPtr(parquet.Type_INT64), cT: ToPtr(parquet.ConvertedType_TIMESTAMP_MICROS), want: true},
+
+		// Logical types.
+		{name: "string logical", pT: ToPtr(parquet.Type_BYTE_ARRAY), logT: &parquet.LogicalType{STRING: parquet.NewStringType()}, want: false},
+		{name: "uuid logical", pT: ToPtr(parquet.Type_FIXED_LEN_BYTE_ARRAY), logT: &parquet.LogicalType{UUID: parquet.NewUUIDType()}, want: false},
+		{name: "unsigned integer logical", pT: ToPtr(parquet.Type_INT32), logT: &parquet.LogicalType{INTEGER: &parquet.IntType{BitWidth: 32, IsSigned: false}}, want: false},
+		{name: "signed integer logical", pT: ToPtr(parquet.Type_INT32), logT: &parquet.LogicalType{INTEGER: &parquet.IntType{BitWidth: 32, IsSigned: true}}, want: true},
+		{name: "decimal logical", pT: ToPtr(parquet.Type_INT32), logT: &parquet.LogicalType{DECIMAL: &parquet.DecimalType{Scale: 2, Precision: 9}}, want: true},
+		{name: "date logical", pT: ToPtr(parquet.Type_INT32), logT: &parquet.LogicalType{DATE: parquet.NewDateType()}, want: true},
+		{name: "timestamp logical", pT: ToPtr(parquet.Type_INT64), logT: &parquet.LogicalType{TIMESTAMP: &parquet.TimestampType{}}, want: true},
+		{name: "float16 logical", pT: ToPtr(parquet.Type_FIXED_LEN_BYTE_ARRAY), logT: &parquet.LogicalType{FLOAT16: parquet.NewFloat16Type()}, want: true},
+		{name: "unknown logical", pT: ToPtr(parquet.Type_INT32), logT: &parquet.LogicalType{UNKNOWN: parquet.NewNullType()}, want: false},
+		{name: "variant logical", pT: ToPtr(parquet.Type_BYTE_ARRAY), logT: &parquet.LogicalType{VARIANT: &parquet.VariantType{}}, want: false},
+		{name: "geometry logical", pT: ToPtr(parquet.Type_BYTE_ARRAY), logT: &parquet.LogicalType{GEOMETRY: parquet.NewGeometryType()}, want: false},
+		{name: "geography logical", pT: ToPtr(parquet.Type_BYTE_ARRAY), logT: &parquet.LogicalType{GEOGRAPHY: parquet.NewGeographyType()}, want: false},
+
+		// Converted type takes precedence over logical type, mirroring
+		// FindFuncTable, when the two disagree on signedness.
+		{
+			name: "converted unsigned wins over logical signed",
+			pT:   ToPtr(parquet.Type_INT64),
+			cT:   ToPtr(parquet.ConvertedType_UINT_64),
+			logT: &parquet.LogicalType{INTEGER: &parquet.IntType{BitWidth: 64, IsSigned: true}},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, IsSignedSortOrder(tt.pT, tt.cT, tt.logT))
+		})
+	}
+}

--- a/internal/layout/chunk.go
+++ b/internal/layout/chunk.go
@@ -86,11 +86,12 @@ func aggregatePageMetrics(pages []*Page, statsStartIdx int, funcTable common.Fun
 	return numValues, totalUncompressed, totalCompressed, minVal, maxVal, nullCount, encodings
 }
 
-func populateStatistics(metaData *parquet.ColumnMetaData, pT *parquet.Type, minVal, maxVal any, nullCount int64, omitStats bool) error {
+func populateStatistics(metaData *parquet.ColumnMetaData, schema *parquet.SchemaElement, minVal, maxVal any, nullCount int64, omitStats bool) error {
 	metaData.Statistics = parquet.NewStatistics()
 	if omitStats {
 		return nil
 	}
+	pT := schema.Type
 	metaData.Statistics.NullCount = &nullCount
 	if maxVal == nil || minVal == nil {
 		return nil
@@ -107,10 +108,13 @@ func populateStatistics(metaData *parquet.ColumnMetaData, pT *parquet.Type, minV
 		tmpBufMax = tmpBufMax[4:]
 		tmpBufMin = tmpBufMin[4:]
 	}
-	metaData.Statistics.Max = tmpBufMax
-	metaData.Statistics.Min = tmpBufMin
 	metaData.Statistics.MaxValue = tmpBufMax
 	metaData.Statistics.MinValue = tmpBufMin
+	// Deprecated Min/Max (PARQUET-251) only for signed sort orders.
+	if common.IsSignedSortOrder(pT, schema.ConvertedType, schema.LogicalType) {
+		metaData.Statistics.Max = tmpBufMax
+		metaData.Statistics.Min = tmpBufMin
+	}
 
 	return nil
 }
@@ -144,7 +148,7 @@ func pagesToChunk(pages []*Page, hasDictPage bool) (*Chunk, error) {
 	metaData.TotalUncompressedSize = totalUncompressed
 	metaData.PathInSchema = pages[metadataPageIdx].Path
 
-	if err := populateStatistics(metaData, pT, minVal, maxVal, nullCount, omitStats); err != nil {
+	if err := populateStatistics(metaData, pages[metadataPageIdx].Schema, minVal, maxVal, nullCount, omitStats); err != nil {
 		return nil, fmt.Errorf("populate chunk statistics: %w", err)
 	}
 

--- a/internal/layout/chunk_test.go
+++ b/internal/layout/chunk_test.go
@@ -13,12 +13,12 @@ import (
 // max- and min-value encoding when the value type does not match the parquet
 // type (WritePlain returns a type-assertion error).
 func TestPopulateStatistics_EncodeErrors(t *testing.T) {
-	pT := common.ToPtr(parquet.Type_INT32)
+	schema := &parquet.SchemaElement{Type: common.ToPtr(parquet.Type_INT32)}
 
 	t.Run("max_encode_error", func(t *testing.T) {
 		meta := parquet.NewColumnMetaData()
 		// maxVal is a string but the type is INT32, so WritePlain fails.
-		err := populateStatistics(meta, pT, int32(1), "not-an-int", 0, false)
+		err := populateStatistics(meta, schema, int32(1), "not-an-int", 0, false)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "encode chunk max statistic")
 	})
@@ -26,7 +26,7 @@ func TestPopulateStatistics_EncodeErrors(t *testing.T) {
 	t.Run("min_encode_error", func(t *testing.T) {
 		meta := parquet.NewColumnMetaData()
 		// maxVal is valid INT32, but minVal is a string, so the min encode fails.
-		err := populateStatistics(meta, pT, "not-an-int", int32(1), 0, false)
+		err := populateStatistics(meta, schema, "not-an-int", int32(1), 0, false)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "encode chunk min statistic")
 	})
@@ -1250,16 +1250,17 @@ func TestChunkLevel_SkipMinMaxStatistics_ForGeospatialTypes(t *testing.T) {
 
 				// Check min/max statistics based on expectation
 				if tt.expectMinMaxStats {
-					require.NotNil(t, chunk.ChunkHeader.MetaData.Statistics.Max)
-					require.NotNil(t, chunk.ChunkHeader.MetaData.Statistics.Min)
 					require.NotNil(t, chunk.ChunkHeader.MetaData.Statistics.MaxValue)
 					require.NotNil(t, chunk.ChunkHeader.MetaData.Statistics.MinValue)
 				} else {
-					require.Nil(t, chunk.ChunkHeader.MetaData.Statistics.Max)
-					require.Nil(t, chunk.ChunkHeader.MetaData.Statistics.Min)
 					require.Nil(t, chunk.ChunkHeader.MetaData.Statistics.MaxValue)
 					require.Nil(t, chunk.ChunkHeader.MetaData.Statistics.MinValue)
 				}
+				// These columns are UNSIGNED (BYTE_ARRAY) or UNKNOWN-ordered
+				// (GEOMETRY/GEOGRAPHY/INTERVAL), so the deprecated signed Min/Max
+				// are never written (PARQUET-251).
+				require.Nil(t, chunk.ChunkHeader.MetaData.Statistics.Max)
+				require.Nil(t, chunk.ChunkHeader.MetaData.Statistics.Min)
 
 				// Null count should always be present
 				require.NotNil(t, chunk.ChunkHeader.MetaData.Statistics.NullCount)
@@ -1333,16 +1334,17 @@ func TestChunkLevel_SkipMinMaxStatistics_ForGeospatialTypes(t *testing.T) {
 
 				// Check min/max statistics based on expectation
 				if tt.expectMinMaxStats {
-					require.NotNil(t, chunk.ChunkHeader.MetaData.Statistics.Max)
-					require.NotNil(t, chunk.ChunkHeader.MetaData.Statistics.Min)
 					require.NotNil(t, chunk.ChunkHeader.MetaData.Statistics.MaxValue)
 					require.NotNil(t, chunk.ChunkHeader.MetaData.Statistics.MinValue)
 				} else {
-					require.Nil(t, chunk.ChunkHeader.MetaData.Statistics.Max)
-					require.Nil(t, chunk.ChunkHeader.MetaData.Statistics.Min)
 					require.Nil(t, chunk.ChunkHeader.MetaData.Statistics.MaxValue)
 					require.Nil(t, chunk.ChunkHeader.MetaData.Statistics.MinValue)
 				}
+				// These columns are UNSIGNED (BYTE_ARRAY) or UNKNOWN-ordered
+				// (GEOMETRY/GEOGRAPHY/INTERVAL), so the deprecated signed Min/Max
+				// are never written (PARQUET-251).
+				require.Nil(t, chunk.ChunkHeader.MetaData.Statistics.Max)
+				require.Nil(t, chunk.ChunkHeader.MetaData.Statistics.Min)
 
 				// Null count should always be present
 				require.NotNil(t, chunk.ChunkHeader.MetaData.Statistics.NullCount)

--- a/internal/layout/dictpage.go
+++ b/internal/layout/dictpage.go
@@ -263,30 +263,9 @@ func (page *Page) dictDataPageCompress(compressType parquet.CompressionCodec, bi
 	page.Header.DataPageHeader.Encoding = parquet.Encoding_RLE_DICTIONARY
 
 	page.Header.DataPageHeader.Statistics = parquet.NewStatistics()
-	if page.MaxVal != nil {
-		tmpBuf, err := encoding.WritePlain([]any{page.MaxVal}, *page.Schema.Type)
-		if err != nil {
-			return nil, fmt.Errorf("encode dict page max statistic: %w", err)
-		}
-		if *page.Schema.Type == parquet.Type_BYTE_ARRAY {
-			tmpBuf = tmpBuf[4:]
-		}
-		page.Header.DataPageHeader.Statistics.Max = tmpBuf
-		page.Header.DataPageHeader.Statistics.MaxValue = tmpBuf
+	if err := page.setPageStatistics(page.Header.DataPageHeader.Statistics); err != nil {
+		return nil, fmt.Errorf("set dict page statistics: %w", err)
 	}
-	if page.MinVal != nil {
-		tmpBuf, err := encoding.WritePlain([]any{page.MinVal}, *page.Schema.Type)
-		if err != nil {
-			return nil, fmt.Errorf("encode dict page min statistic: %w", err)
-		}
-		if *page.Schema.Type == parquet.Type_BYTE_ARRAY {
-			tmpBuf = tmpBuf[4:]
-		}
-		page.Header.DataPageHeader.Statistics.Min = tmpBuf
-		page.Header.DataPageHeader.Statistics.MinValue = tmpBuf
-	}
-
-	page.Header.DataPageHeader.Statistics.NullCount = page.NullCount
 
 	return dataEncodeBuf, nil
 }

--- a/internal/layout/dictpage_test.go
+++ b/internal/layout/dictpage_test.go
@@ -256,9 +256,13 @@ func TestDictDataPageCompress_ByteArrayStats(t *testing.T) {
 	compressedData, err := page.dictDataPageCompress(parquet.CompressionCodec_UNCOMPRESSED, 1, []int32{0, 1}, nil)
 	require.NoError(t, err)
 	require.NotEmpty(t, compressedData)
-	// BYTE_ARRAY stats strip the 4-byte length prefix.
-	require.Equal(t, []byte("zzz"), page.Header.DataPageHeader.Statistics.Max)
-	require.Equal(t, []byte("aaa"), page.Header.DataPageHeader.Statistics.Min)
+	// BYTE_ARRAY stats strip the 4-byte length prefix. Its sort order is
+	// UNSIGNED, so only MinValue/MaxValue are written; the deprecated (signed)
+	// Min/Max fields are omitted (PARQUET-251).
+	require.Equal(t, []byte("zzz"), page.Header.DataPageHeader.Statistics.MaxValue)
+	require.Equal(t, []byte("aaa"), page.Header.DataPageHeader.Statistics.MinValue)
+	require.Nil(t, page.Header.DataPageHeader.Statistics.Max)
+	require.Nil(t, page.Header.DataPageHeader.Statistics.Min)
 }
 
 func TestDictDataPageCompress_CompressError(t *testing.T) {

--- a/internal/layout/page_write_encode.go
+++ b/internal/layout/page_write_encode.go
@@ -5,6 +5,7 @@ import (
 	"math/bits"
 	"slices"
 
+	"github.com/hangxie/parquet-go/v3/common"
 	"github.com/hangxie/parquet-go/v3/internal/compress"
 	"github.com/hangxie/parquet-go/v3/internal/encoding"
 	"github.com/hangxie/parquet-go/v3/parquet"
@@ -120,8 +121,11 @@ func (page *Page) computeLevelHistograms() {
 	}
 }
 
-// setPageStatistics sets the min/max/null statistics on a Statistics object
+// setPageStatistics sets the min/max/null statistics on a Statistics object.
+// MinValue/MaxValue are always written; the deprecated Min/Max (PARQUET-251,
+// signed byte-wise) only for signed sort orders.
 func (page *Page) setPageStatistics(stats *parquet.Statistics) error {
+	signed := common.IsSignedSortOrder(page.Schema.Type, page.Schema.ConvertedType, page.Schema.LogicalType)
 	if page.MaxVal != nil {
 		tmpBuf, err := encoding.WritePlain([]any{page.MaxVal}, *page.Schema.Type)
 		if err != nil {
@@ -130,8 +134,10 @@ func (page *Page) setPageStatistics(stats *parquet.Statistics) error {
 		if *page.Schema.Type == parquet.Type_BYTE_ARRAY {
 			tmpBuf = tmpBuf[4:]
 		}
-		stats.Max = tmpBuf
 		stats.MaxValue = tmpBuf
+		if signed {
+			stats.Max = tmpBuf
+		}
 	}
 	if page.MinVal != nil {
 		tmpBuf, err := encoding.WritePlain([]any{page.MinVal}, *page.Schema.Type)
@@ -141,8 +147,10 @@ func (page *Page) setPageStatistics(stats *parquet.Statistics) error {
 		if *page.Schema.Type == parquet.Type_BYTE_ARRAY {
 			tmpBuf = tmpBuf[4:]
 		}
-		stats.Min = tmpBuf
 		stats.MinValue = tmpBuf
+		if signed {
+			stats.Min = tmpBuf
+		}
 	}
 	stats.NullCount = page.NullCount
 	return nil

--- a/internal/layout/page_write_test.go
+++ b/internal/layout/page_write_test.go
@@ -38,10 +38,14 @@ func TestDataPageCompressWithStatistics(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, data)
 
-	// Verify that statistics were set
+	// Verify that statistics were set. BYTE_ARRAY has UNSIGNED sort order, so
+	// MinValue/MaxValue are populated but the deprecated (signed) Min/Max are
+	// omitted (PARQUET-251).
 	require.NotNil(t, page.Header.DataPageHeader.Statistics)
-	require.NotNil(t, page.Header.DataPageHeader.Statistics.Max)
-	require.NotNil(t, page.Header.DataPageHeader.Statistics.Min)
+	require.NotNil(t, page.Header.DataPageHeader.Statistics.MaxValue)
+	require.NotNil(t, page.Header.DataPageHeader.Statistics.MinValue)
+	require.Nil(t, page.Header.DataPageHeader.Statistics.Max)
+	require.Nil(t, page.Header.DataPageHeader.Statistics.Min)
 	require.NotNil(t, page.Header.DataPageHeader.Statistics.NullCount)
 }
 
@@ -58,13 +62,17 @@ func TestGeospatialFields_SkipMinMaxStatistics(t *testing.T) {
 		logicalType         *parquet.LogicalType
 		convertedType       *parquet.ConvertedType
 		expectMinMaxStats   bool
+		expectDeprecatedMin bool
 		expectNullCountStat bool
 	}{
 		{
+			// BYTE_ARRAY has UNSIGNED sort order, so MinValue/MaxValue are
+			// written but the deprecated (signed) Min/Max fields are omitted.
 			name:                "regular_byte_array_field",
 			logicalType:         nil,
 			convertedType:       nil,
 			expectMinMaxStats:   true,
+			expectDeprecatedMin: false,
 			expectNullCountStat: true,
 		},
 		{
@@ -74,6 +82,7 @@ func TestGeospatialFields_SkipMinMaxStatistics(t *testing.T) {
 			},
 			convertedType:       nil,
 			expectMinMaxStats:   false,
+			expectDeprecatedMin: false,
 			expectNullCountStat: true,
 		},
 		{
@@ -83,6 +92,7 @@ func TestGeospatialFields_SkipMinMaxStatistics(t *testing.T) {
 			},
 			convertedType:       nil,
 			expectMinMaxStats:   false,
+			expectDeprecatedMin: false,
 			expectNullCountStat: true,
 		},
 		{
@@ -90,6 +100,7 @@ func TestGeospatialFields_SkipMinMaxStatistics(t *testing.T) {
 			logicalType:         nil,
 			convertedType:       common.ToPtr(parquet.ConvertedType_INTERVAL),
 			expectMinMaxStats:   false,
+			expectDeprecatedMin: false,
 			expectNullCountStat: true,
 		},
 	}
@@ -146,15 +157,18 @@ func TestGeospatialFields_SkipMinMaxStatistics(t *testing.T) {
 
 				// Check min/max statistics based on expectation
 				if tt.expectMinMaxStats {
-					require.NotNil(t, page.Header.DataPageHeader.Statistics.Max)
-					require.NotNil(t, page.Header.DataPageHeader.Statistics.Min)
 					require.NotNil(t, page.Header.DataPageHeader.Statistics.MaxValue)
 					require.NotNil(t, page.Header.DataPageHeader.Statistics.MinValue)
 				} else {
-					require.Nil(t, page.Header.DataPageHeader.Statistics.Max)
-					require.Nil(t, page.Header.DataPageHeader.Statistics.Min)
 					require.Nil(t, page.Header.DataPageHeader.Statistics.MaxValue)
 					require.Nil(t, page.Header.DataPageHeader.Statistics.MinValue)
+				}
+				if tt.expectDeprecatedMin {
+					require.NotNil(t, page.Header.DataPageHeader.Statistics.Max)
+					require.NotNil(t, page.Header.DataPageHeader.Statistics.Min)
+				} else {
+					require.Nil(t, page.Header.DataPageHeader.Statistics.Max)
+					require.Nil(t, page.Header.DataPageHeader.Statistics.Min)
 				}
 
 				// Null count should always be present (not skipped)
@@ -219,15 +233,18 @@ func TestGeospatialFields_SkipMinMaxStatistics(t *testing.T) {
 
 				// Check min/max statistics based on expectation
 				if tt.expectMinMaxStats {
-					require.NotNil(t, page.Header.DataPageHeaderV2.Statistics.Max)
-					require.NotNil(t, page.Header.DataPageHeaderV2.Statistics.Min)
 					require.NotNil(t, page.Header.DataPageHeaderV2.Statistics.MaxValue)
 					require.NotNil(t, page.Header.DataPageHeaderV2.Statistics.MinValue)
 				} else {
-					require.Nil(t, page.Header.DataPageHeaderV2.Statistics.Max)
-					require.Nil(t, page.Header.DataPageHeaderV2.Statistics.Min)
 					require.Nil(t, page.Header.DataPageHeaderV2.Statistics.MaxValue)
 					require.Nil(t, page.Header.DataPageHeaderV2.Statistics.MinValue)
+				}
+				if tt.expectDeprecatedMin {
+					require.NotNil(t, page.Header.DataPageHeaderV2.Statistics.Max)
+					require.NotNil(t, page.Header.DataPageHeaderV2.Statistics.Min)
+				} else {
+					require.Nil(t, page.Header.DataPageHeaderV2.Statistics.Max)
+					require.Nil(t, page.Header.DataPageHeaderV2.Statistics.Min)
 				}
 
 				// Null count should always be present (not skipped)

--- a/writer/pages.go
+++ b/writer/pages.go
@@ -157,13 +157,15 @@ type pageStats struct {
 }
 
 func extractPageStats(page *layout.Page) pageStats {
+	// Use MinValue/MaxValue: always populated, whereas the deprecated Min/Max
+	// are omitted for unsigned/unknown-ordered columns (PARQUET-251).
 	if page.Header.DataPageHeader != nil && page.Header.DataPageHeader.Statistics != nil {
 		s := page.Header.DataPageHeader.Statistics
-		return pageStats{minVal: s.Min, maxVal: s.Max, nullCount: s.NullCount}
+		return pageStats{minVal: s.MinValue, maxVal: s.MaxValue, nullCount: s.NullCount}
 	}
 	if page.Header.DataPageHeaderV2 != nil && page.Header.DataPageHeaderV2.Statistics != nil {
 		s := page.Header.DataPageHeaderV2.Statistics
-		return pageStats{minVal: s.Min, maxVal: s.Max, nullCount: s.NullCount}
+		return pageStats{minVal: s.MinValue, maxVal: s.MaxValue, nullCount: s.NullCount}
 	}
 	return pageStats{}
 }

--- a/writer/pages_test.go
+++ b/writer/pages_test.go
@@ -29,8 +29,8 @@ func TestExtractPageStats(t *testing.T) {
 				Header: &parquet.PageHeader{
 					DataPageHeader: &parquet.DataPageHeader{
 						Statistics: &parquet.Statistics{
-							Min:       []byte("a"),
-							Max:       []byte("z"),
+							MinValue:  []byte("a"),
+							MaxValue:  []byte("z"),
 							NullCount: &nullCount,
 						},
 					},
@@ -44,8 +44,8 @@ func TestExtractPageStats(t *testing.T) {
 				Header: &parquet.PageHeader{
 					DataPageHeaderV2: &parquet.DataPageHeaderV2{
 						Statistics: &parquet.Statistics{
-							Min:       []byte("b"),
-							Max:       []byte("y"),
+							MinValue:  []byte("b"),
+							MaxValue:  []byte("y"),
 							NullCount: &nullCount,
 						},
 					},

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -559,3 +559,66 @@ func TestParquetWriter_UnknownLogicalType(t *testing.T) {
 		require.Nil(t, row.NullCol)
 	}
 }
+
+// TestDeprecatedMinMaxBySortOrder verifies that the deprecated Statistics
+// Min/Max fields (PARQUET-251) are only written for columns whose sort order is
+// signed. The current MinValue/MaxValue fields are written for every column.
+func TestDeprecatedMinMaxBySortOrder(t *testing.T) {
+	type Row struct {
+		Signed   int64  `parquet:"name=signed, type=INT64"`
+		Unsigned uint64 `parquet:"name=unsigned, type=INT64, convertedtype=UINT_64"`
+		Str      string `parquet:"name=str, type=BYTE_ARRAY, convertedtype=UTF8"`
+	}
+
+	pw, buf, err := createTestParquetWriter(new(Row), WithNP(1))
+	require.NoError(t, err)
+	for i := range 3 {
+		require.NoError(t, pw.Write(Row{
+			Signed:   int64(i) - 1, // includes a negative value
+			Unsigned: uint64(i),
+			Str:      fmt.Sprintf("v%d", i),
+		}))
+	}
+	require.NoError(t, pw.WriteStop())
+
+	pr, pf, err := createTestParquetReader(buf.Bytes(), new(Row), reader.WithNP(1))
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, pf.Close())
+	}()
+
+	require.Len(t, pr.Footer.RowGroups, 1)
+	columns := pr.Footer.RowGroups[0].Columns
+
+	byName := func(name string) *parquet.Statistics {
+		for _, c := range columns {
+			if c.MetaData != nil && len(c.MetaData.PathInSchema) > 0 &&
+				c.MetaData.PathInSchema[len(c.MetaData.PathInSchema)-1] == name {
+				return c.MetaData.Statistics
+			}
+		}
+		t.Fatalf("column %q not found", name)
+		return nil
+	}
+
+	// Signed column: both current and deprecated fields are populated.
+	signed := byName("signed")
+	require.NotNil(t, signed)
+	require.NotNil(t, signed.MinValue)
+	require.NotNil(t, signed.MaxValue)
+	require.NotNil(t, signed.Min)
+	require.NotNil(t, signed.Max)
+	require.Equal(t, signed.MinValue, signed.Min)
+	require.Equal(t, signed.MaxValue, signed.Max)
+
+	// Unsigned integer and UTF8 columns: only the current fields are populated;
+	// the deprecated signed Min/Max are omitted.
+	for _, name := range []string{"unsigned", "str"} {
+		stats := byName(name)
+		require.NotNil(t, stats, name)
+		require.NotNil(t, stats.MinValue, name)
+		require.NotNil(t, stats.MaxValue, name)
+		require.Nil(t, stats.Min, name)
+		require.Nil(t, stats.Max, name)
+	}
+}


### PR DESCRIPTION
Fixes #337.

## Problem

Page- and chunk-level statistics populated both the current `min_value`/`max_value` fields and the deprecated `min`/`max` fields (PARQUET-251) with identical bytes. The deprecated fields are defined with **signed byte-wise** comparison semantics, so for columns whose real sort order is unsigned (`BYTE_ARRAY`/UTF8, unsigned integer logical types) or unknown (INT96, GEOMETRY/GEOGRAPHY, VARIANT), writing those bytes publishes statistics that legacy readers interpret incorrectly. parquet-mr and Arrow only write the deprecated fields when the column's sort order is signed.

## Fix

- **`common/sortorder.go`** — new `IsSignedSortOrder(pT, cT, logT)` classifying a column's sort order (SIGNED vs UNSIGNED/UNKNOWN) using the same converted-type-before-logical-type-before-physical-type precedence as `FindFuncTable`, mirroring parquet-mr/Arrow. FLOAT16 stays signed to preserve its existing total-order behavior; BOOLEAN is treated as signed to match parquet-mr's `defaultSortOrder` (harmless — a single `0x00`/`0x01` byte compares identically either way).
- **`internal/layout/chunk.go`** (`populateStatistics`) and **`page_write_encode.go`** (`setPageStatistics`) — always write `MinValue`/`MaxValue`; emit the deprecated `Min`/`Max` only when the order is signed.
- **`internal/layout/dictpage.go`** — the dictionary-page path duplicated the stat-encoding logic verbatim; it now delegates to `setPageStatistics`, inheriting the same gate (net −18 LOC).
- **`writer/pages.go`** (`extractPageStats`) — the ColumnIndex builder read the deprecated `Min`/`Max`; switched it to the always-populated `MinValue`/`MaxValue` so unsigned columns keep their ColumnIndex.
- **`README.md`** — documented the behavior.

## Tests

- `common/sortorder_test.go` — table-driven coverage across physical/converted/logical types, including a case where converted and logical types disagree (verifies converted-type precedence).
- Updated existing layout/writer tests that conflated the current vs deprecated field pairs.
- Added `TestDeprecatedMinMaxBySortOrder` — an end-to-end round trip proving a signed `INT64` column keeps `Min`/`Max`, while `UINT_64` and UTF8 columns omit them but keep `MinValue`/`MaxValue`.

`make all` (format, lint, test, example, build) passes.
