### PR TITLE
feat(source): InPlaceReopener capability for self-returning Open (HDFS)

### DIFF
--- a/reader/columnbuffer.go
+++ b/reader/columnbuffer.go
@@ -156,13 +156,17 @@ func (cbt *ColumnBufferType) NextRowGroup() error {
 	if columnChunks[i].FilePath != nil {
 		// Open into a local variable and assign only on success; a failed Open
 		// returns a nil interface, which would otherwise clobber cbt.PFile and
-		// panic when ReadStop later calls Close on it. The previous handle is
-		// released only after the new one is opened.
+		// panic when ReadStop later calls Close on it. Some backends (e.g. HDFS)
+		// reopen an internal handle and return themselves from Open; such readers
+		// declare source.InPlaceReopener, and closing the previous handle would
+		// close the very reader Open just returned, so skip the Close for them.
 		pFile, err := cbt.PFile.Open(*columnChunks[i].FilePath)
 		if err != nil {
 			return fmt.Errorf("open file %s: %w", *columnChunks[i].FilePath, err)
 		}
-		_ = cbt.PFile.Close()
+		if !source.ReopensInPlace(cbt.PFile) {
+			_ = cbt.PFile.Close()
+		}
 		cbt.PFile = pFile
 	}
 

--- a/reader/columnbuffer_test.go
+++ b/reader/columnbuffer_test.go
@@ -25,6 +25,9 @@ type mockColumnBufferFileReader struct {
 	shouldFail bool
 	cloneFails bool
 	openFails  bool
+	// openReturnsSelf mimics backends such as HDFS whose Open mutates the
+	// receiver in place and returns it, rather than a distinct reader.
+	openReturnsSelf bool
 	// clones records readers handed out by Clone, letting tests assert the
 	// cloned handle is closed on cleanup paths.
 	clones []*mockColumnBufferFileReader
@@ -92,8 +95,17 @@ func (m *mockColumnBufferFileReader) Open(name string) (source.ParquetFileReader
 	if m.shouldFail || m.openFails {
 		return nil, fmt.Errorf("mock open error")
 	}
+	if m.openReturnsSelf {
+		// Mutate in place and return the same receiver, as HDFS does.
+		m.offset = 0
+		return m, nil
+	}
 	return newMockColumnBufferFileReader(m.data), nil
 }
+
+// ReopensInPlace declares the source.InPlaceReopener capability when the mock is
+// configured to return itself from Open, matching real in-place backends.
+func (m *mockColumnBufferFileReader) ReopensInPlace() bool { return m.openReturnsSelf }
 
 func (m *mockColumnBufferFileReader) Clone() (source.ParquetFileReader, error) {
 	if m.cloneFails {
@@ -109,6 +121,7 @@ func (m *mockColumnBufferFileReader) Clone() (source.ParquetFileReader, error) {
 	newReader.shouldFail = m.shouldFail
 	newReader.cloneFails = m.cloneFails
 	newReader.openFails = m.openFails
+	newReader.openReturnsSelf = m.openReturnsSelf
 	m.clones = append(m.clones, newReader)
 	return newReader, nil
 }
@@ -809,6 +822,113 @@ func TestNextRowGroup_OpenFailurePreservesPFile(t *testing.T) {
 	require.NotNil(t, cbt.PFile)
 	require.Same(t, mockFile, cbt.PFile)
 	require.NotPanics(t, func() { _ = cbt.PFile.Close() })
+}
+
+// When a backend's Open mutates and returns the same receiver (as HDFS does)
+// and declares the source.InPlaceReopener capability, NextRowGroup must not
+// close the reader it just opened; doing so would hand a closed reader to
+// ConvertToThriftReader.
+func TestNextRowGroup_MutatingOpenKeepsReaderOpen(t *testing.T) {
+	mockFile := newMockColumnBufferFileReader([]byte{})
+	mockFile.openReturnsSelf = true
+
+	filePath := "external.parquet"
+	cbt := &ColumnBufferType{
+		PFile: mockFile,
+		Footer: &parquet.FileMetaData{
+			RowGroups: []*parquet.RowGroup{
+				{Columns: []*parquet.ColumnChunk{{
+					MetaData: &parquet.ColumnMetaData{
+						PathInSchema:   []string{"leaf"},
+						DataPageOffset: 0,
+						NumValues:      1,
+						Type:           parquet.Type_INT64,
+						Codec:          parquet.CompressionCodec_UNCOMPRESSED,
+					},
+					FilePath: &filePath,
+				}}},
+			},
+		},
+		SchemaHandler: newSchemaHandlerWithPath("leaf"),
+		PathStr:       common.PathToStr([]string{"root", "leaf"}),
+		RowGroupIndex: 0,
+	}
+
+	_ = cbt.NextRowGroup()
+	// The reader returned by Open is the same object as before; it must remain
+	// open and installed on the column buffer.
+	require.Same(t, mockFile, cbt.PFile)
+	require.False(t, mockFile.closed, "the newly opened reader must not be closed")
+}
+
+// readerState is backing state shared between copies of a valueStructReader.
+type readerState struct {
+	closed bool
+	reopen bool
+}
+
+// valueStructReader is a value-type ParquetFileReader that holds a pointer to
+// shared state and returns itself from Open — a class of reader whose ownership
+// cannot be inferred by identity. It opts into the explicit
+// source.InPlaceReopener contract via ReopensInPlace so callers know not to
+// close it across Open.
+type valueStructReader struct {
+	state *readerState
+}
+
+func (valueStructReader) Read([]byte) (int, error)                        { return 0, io.EOF }
+func (valueStructReader) Seek(int64, int) (int64, error)                  { return 0, nil }
+func (r valueStructReader) Close() error                                  { r.state.closed = true; return nil }
+func (r valueStructReader) Open(string) (source.ParquetFileReader, error) { return r, nil }
+func (r valueStructReader) Clone() (source.ParquetFileReader, error)      { return r, nil }
+func (r valueStructReader) ReopensInPlace() bool                          { return r.state.reopen }
+
+// A value-struct reader that shares state and returns itself from Open must be
+// kept open by NextRowGroup when it declares the InPlaceReopener capability —
+// the case reflection-based identity could not handle.
+func TestNextRowGroup_InPlaceReopenerKeptOpen(t *testing.T) {
+	state := &readerState{reopen: true}
+	cbt := newExternalChunkColumnBuffer(valueStructReader{state})
+
+	_ = cbt.NextRowGroup()
+	require.False(t, state.closed, "a reader declaring InPlaceReopener must not be closed")
+}
+
+// The capability is opt-in: a reader that returns itself from Open but does not
+// declare InPlaceReopener is treated as a distinct handle and closed, so backends
+// that share state across Open must declare it explicitly.
+func TestNextRowGroup_SelfReturningWithoutCapabilityClosed(t *testing.T) {
+	state := &readerState{reopen: false}
+	cbt := newExternalChunkColumnBuffer(valueStructReader{state})
+
+	_ = cbt.NextRowGroup()
+	require.True(t, state.closed, "a self-returning reader without the capability is closed")
+}
+
+// newExternalChunkColumnBuffer builds a column buffer positioned to open a
+// single external-FilePath column chunk on the next NextRowGroup call.
+func newExternalChunkColumnBuffer(pFile source.ParquetFileReader) *ColumnBufferType {
+	filePath := "external.parquet"
+	return &ColumnBufferType{
+		PFile: pFile,
+		Footer: &parquet.FileMetaData{
+			RowGroups: []*parquet.RowGroup{
+				{Columns: []*parquet.ColumnChunk{{
+					MetaData: &parquet.ColumnMetaData{
+						PathInSchema:   []string{"leaf"},
+						DataPageOffset: 0,
+						NumValues:      1,
+						Type:           parquet.Type_INT64,
+						Codec:          parquet.CompressionCodec_UNCOMPRESSED,
+					},
+					FilePath: &filePath,
+				}}},
+			},
+		},
+		SchemaHandler: newSchemaHandlerWithPath("leaf"),
+		PathStr:       common.PathToStr([]string{"root", "leaf"}),
+		RowGroupIndex: 0,
+	}
 }
 
 func TestSkipRows_ReadPageForSkipErrorReturnsZero(t *testing.T) {

--- a/source/README.md
+++ b/source/README.md
@@ -18,6 +18,29 @@ type ParquetFileWriter interface {
 }
 ```
 
+## Reader `Open` and the `InPlaceReopener` capability
+
+`Open` is used to open a sibling file referenced by a column chunk's
+`file_path`. Most backends return a brand-new, independent reader from `Open`;
+the caller owns that reader and closes the previous handle itself.
+
+A backend whose `Open` instead reopens its own internal handle and returns the
+same receiver (the HDFS source works this way, reusing a single client) must
+declare the optional `InPlaceReopener` capability so callers do not close the
+handle they just reopened:
+
+```go
+type InPlaceReopener interface {
+	ReopensInPlace() bool
+}
+```
+
+When a reader reports `ReopensInPlace() == true`, callers that swap in the
+result of `Open` skip closing the previous handle, because the previous and new
+readers are the same object. Backends whose `Open` yields an independent reader
+should not implement this interface (or should return `false`). Use the
+`source.ReopensInPlace(reader)` helper to query the capability safely.
+
 Supported sources:
 * Local
 * HDFS

--- a/source/hdfs/reader.go
+++ b/source/hdfs/reader.go
@@ -45,13 +45,24 @@ func (f *hdfsReader) Open(name string) (source.ParquetFileReader, error) {
 	if f.client == nil {
 		return nil, fmt.Errorf("client is nil")
 	}
-	var err error
-	f.fileReader, err = f.client.Open(name)
+	// Open into a local variable and swap in the new handle only on success, so
+	// a failed Open preserves the existing fileReader instead of losing it. The
+	// displaced reader is closed explicitly to avoid leaking it.
+	fileReader, err := f.client.Open(name)
 	if err != nil {
 		return nil, fmt.Errorf("open hdfs file: %w", err)
 	}
+	if f.fileReader != nil {
+		_ = f.fileReader.Close()
+	}
+	f.fileReader = fileReader
 	return f, nil
 }
+
+// ReopensInPlace declares the source.InPlaceReopener capability: Open reopens
+// the internal file handle and returns the same receiver, so callers must not
+// close the previous handle after Open.
+func (f *hdfsReader) ReopensInPlace() bool { return true }
 
 func (f hdfsReader) Clone() (source.ParquetFileReader, error) {
 	// Create a new reader without creating a new HDFS client

--- a/source/hdfs/reader_test.go
+++ b/source/hdfs/reader_test.go
@@ -17,6 +17,7 @@ type mockFileReader struct {
 	readErr  error
 	seekErr  error
 	closeErr error
+	closed   bool
 }
 
 func (m *mockFileReader) Read(b []byte) (int, error) {
@@ -39,7 +40,10 @@ func (m *mockFileReader) Seek(offset int64, _ int) (int64, error) {
 	return m.seekPos, nil
 }
 
-func (m *mockFileReader) Close() error { return m.closeErr }
+func (m *mockFileReader) Close() error {
+	m.closed = true
+	return m.closeErr
+}
 
 // mockFileWriter implements hdfsFileWriterIface for testing.
 type mockFileWriter struct {
@@ -80,6 +84,10 @@ func (m *mockHdfsClient) Close() error { return m.closeErr }
 func TestHdfsFileInterfaceCompliance(t *testing.T) {
 	var _ source.ParquetFileReader = (*hdfsReader)(nil)
 	var _ source.ParquetFileWriter = (*hdfsWriter)(nil)
+	// hdfsReader reopens its internal handle in place, so it must declare the
+	// InPlaceReopener capability for callers to keep it open across Open.
+	var r source.ParquetFileReader = &hdfsReader{}
+	require.True(t, source.ReopensInPlace(r))
 }
 
 func TestHdfsFileStructure(t *testing.T) {
@@ -239,6 +247,40 @@ func TestHdfsReader_OpenWithMockClient(t *testing.T) {
 		_, err := reader.Open("test.parquet")
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "connection refused")
+	})
+
+	t.Run("failure_preserves_existing_reader", func(t *testing.T) {
+		existing := &mockFileReader{}
+		reader := &hdfsReader{
+			hdfsFile: hdfsFile{
+				client: &mockHdfsClient{openErr: errors.New("connection refused")},
+			},
+			fileReader: existing,
+		}
+
+		_, err := reader.Open("test.parquet")
+		require.Error(t, err)
+		// The existing handle must be preserved, not overwritten or closed.
+		require.Same(t, existing, reader.fileReader)
+		require.False(t, existing.closed)
+	})
+
+	t.Run("success_closes_displaced_reader", func(t *testing.T) {
+		old := &mockFileReader{}
+		fresh := &mockFileReader{}
+		reader := &hdfsReader{
+			hdfsFile: hdfsFile{
+				client: &mockHdfsClient{openResult: fresh},
+			},
+			fileReader: old,
+		}
+
+		result, err := reader.Open("test.parquet")
+		require.NoError(t, err)
+		require.Same(t, reader, result)
+		require.Same(t, fresh, reader.fileReader)
+		// The displaced reader must be closed so it is not leaked.
+		require.True(t, old.closed)
 	})
 }
 

--- a/source/source.go
+++ b/source/source.go
@@ -15,6 +15,29 @@ type ParquetFileReader interface {
 	Clone() (ParquetFileReader, error)
 }
 
+// InPlaceReopener is an optional capability a ParquetFileReader may implement to
+// declare that its Open method returns a reader sharing the receiver's
+// underlying handle (for example, it reopens an internal handle and returns
+// itself) rather than a fully independent reader. When a caller swaps in the
+// reader returned by Open, it must not Close the previous handle if that handle
+// reports ReopensInPlace() == true, because the previous and new readers are the
+// same object; closing it would close the reader Open just returned.
+//
+// Readers whose Open yields an independent reader — the common case — should not
+// implement this interface (or should return false); the caller owns the old
+// handle and is responsible for closing it.
+type InPlaceReopener interface {
+	ReopensInPlace() bool
+}
+
+// ReopensInPlace reports whether r declares, via the InPlaceReopener capability,
+// that Open returns a reader sharing its underlying handle. It is the safe way
+// for callers to decide whether the previous handle must be closed after Open.
+func ReopensInPlace(r ParquetFileReader) bool {
+	o, ok := r.(InPlaceReopener)
+	return ok && o.ReopensInPlace()
+}
+
 type ParquetFileWriter interface {
 	io.Writer
 	io.Closer

--- a/source/source_test.go
+++ b/source/source_test.go
@@ -85,6 +85,23 @@ func (m *mockParquetFileReader) Clone() (ParquetFileReader, error) {
 	return clone, nil
 }
 
+// inPlaceReader declares the InPlaceReopener capability with a configurable result.
+type inPlaceReader struct {
+	*mockParquetFileReader
+	reopen bool
+}
+
+func (r inPlaceReader) ReopensInPlace() bool { return r.reopen }
+
+func TestReopensInPlace(t *testing.T) {
+	// A reader without the capability is not treated as reopening in place.
+	require.False(t, ReopensInPlace(newMockParquetFileReader([]byte{})))
+
+	// A reader declaring the capability is honored by its reported value.
+	require.True(t, ReopensInPlace(inPlaceReader{newMockParquetFileReader([]byte{}), true}))
+	require.False(t, ReopensInPlace(inPlaceReader{newMockParquetFileReader([]byte{}), false}))
+}
+
 // Test the buffer size constant
 
 func TestBufferSizeConstant(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds an opt-in capability so a `ParquetFileReader` whose `Open` reopens its own internal handle and returns the same receiver is not closed out from under itself when reading an external (`file_path`) column chunk. Split out of #353 for separate review.

**Stacked on #353** (base branch `hangxie/read-stop-panic`) — review/merge that first; this diff is only the incremental capability + HDFS work.

## Changes

- **`source.InPlaceReopener` capability + `ReopensInPlace` helper.** Most backends return a new, independent reader from `Open`; the caller closes the previous handle. A backend that instead reopens its internal handle and returns itself must declare this so callers skip the close. Whether to close cannot be reliably inferred from the returned value, so it is opt-in. Documented in `source/README.md`.
- **`source/hdfs`.** `hdfsReader.Open` assigned its internal `fileReader` before checking the error, leaking/losing the existing handle on failure; now it opens into a local, swaps only on success, and closes the displaced reader. Declares `InPlaceReopener` since it reopens in place and returns itself.
- **`reader.NextRowGroup`.** Skips closing the previous handle after an external `Open` when the reader declares `InPlaceReopener`, so an in-place reopen is not closed. Distinct-reader backends are unchanged.

## Notes

- The external `file_path` column-chunk path is rarely emitted and, for HDFS, was already non-functional before #353 (the old code closed the handle before reopening). This makes that path correct for a self-returning `Open` and hardens the HDFS backend, but the broader external→main transition remains tracked in #352.

## Tests

- `source.ReopensInPlace` honors declared/absent capability.
- HDFS `Open` preserves the existing handle on failure and closes the displaced reader on success; `hdfsReader` declares `InPlaceReopener`.
- `NextRowGroup` keeps a capability-declaring self-returning reader open, and still closes a self-returning reader that does not declare the capability.

`make all` passes.
