### PR TITLE
feat: add cancellable parquet I/O APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -636,6 +636,14 @@ func NewCSVWriter(md []string, pfile source.ParquetFileWriter, opts ...WriterOpt
 func NewArrowWriter(arrowSchema *arrow.Schema, pfile source.ParquetFileWriter, opts ...WriterOption) (*ArrowWriter, error)
 ```
 
+### Cancellation
+
+Context-aware constructors and operations are additive, and all existing APIs retain their signatures for backward compatibility. Context-free entry points that have a direct `WithContext` replacement are deprecated. Legacy constructors use `context.Background()`; plain methods use the context supplied to their constructor, so their behavior is unchanged when constructed through a legacy API. Use `reader.NewParquetReaderWithContext`, `ReadWithContext`, `writer.NewParquetWriterWithContext`, `WriteWithContext`, `FlushWithContext`, and `WriteStopWithContext` when reads or writes need cancellation or deadlines. Column reads, index and bloom-filter inspection, dictionary-page inspection, and the CSV, JSON, and Arrow writer constructors also provide `WithContext` variants. Cleanup and finalization still release resources and produce a valid footer after cancellation, then report the cancellation error.
+
+> **Note:** `CloseWithContext`, `ReadStopWithContext`, `ResetWithContext`, and `WriteStopWithContext` always detach cancellation from the underlying close operations. This ensures resources are released and the file is never left in a corrupt or partially-written state, but it also means an application-level timeout or deadline that expires during cleanup will not abort it. If your backend I/O can hang indefinitely on close, consider adding a separate transport-level timeout on the file source rather than relying on the context given to these methods.
+
+Source compatibility is unchanged. A source may implement the optional context capabilities in the `source` package to cancel in-flight operations; otherwise parquet-go checks the context before calling the legacy method.
+
 ## Examples
 
 Build examples with the `example` build tag.

--- a/internal/bloomfilter/read.go
+++ b/internal/bloomfilter/read.go
@@ -14,6 +14,7 @@ import (
 
 // ReadOptions configures encrypted bloom filter reads.
 type ReadOptions struct {
+	Context         context.Context
 	Key             []byte
 	AADPrefix       []byte
 	AADFileUnique   []byte
@@ -23,7 +24,14 @@ type ReadOptions struct {
 
 // ReadBloomFilter reads a bloom filter from the given ReadSeeker at the specified offset.
 // It reads the Thrift-encoded BloomFilterHeader followed by the raw bitset bytes.
+//
+// Deprecated: use ReadBloomFilterWithContext.
 func ReadBloomFilter(r io.ReadSeeker, offset int64) (*Filter, error) {
+	return ReadBloomFilterWithContext(context.Background(), r, offset)
+}
+
+// ReadBloomFilterWithContext reads a bloom filter using ctx.
+func ReadBloomFilterWithContext(ctx context.Context, r io.ReadSeeker, offset int64) (*Filter, error) {
 	if _, err := r.Seek(offset, io.SeekStart); err != nil {
 		return nil, fmt.Errorf("seek to bloom filter offset %d: %w", offset, err)
 	}
@@ -34,7 +42,7 @@ func ReadBloomFilter(r io.ReadSeeker, offset int64) (*Filter, error) {
 	thriftReader := thrift.NewStreamTransportR(r)
 	bufferReader := thrift.NewTBufferedTransport(thriftReader, 1024)
 	protocol := tpf.GetProtocol(bufferReader)
-	if err := header.Read(context.TODO(), protocol); err != nil {
+	if err := header.Read(ctx, protocol); err != nil {
 		return nil, fmt.Errorf("read bloom filter header: %w", err)
 	}
 
@@ -46,7 +54,7 @@ func ReadBloomFilter(r io.ReadSeeker, offset int64) (*Filter, error) {
 	// then seek to the bitset position (offset + headerSize).
 	ts := thrift.NewTSerializer()
 	ts.Protocol = thrift.NewTCompactProtocolFactoryConf(&thrift.TConfiguration{}).GetProtocol(ts.Transport)
-	headerBuf, err := ts.Write(context.TODO(), header)
+	headerBuf, err := ts.Write(ctx, header)
 	if err != nil {
 		return nil, fmt.Errorf("serialize bloom filter header to determine size: %w", err)
 	}
@@ -67,6 +75,10 @@ func ReadBloomFilter(r io.ReadSeeker, offset int64) (*Filter, error) {
 // ReadEncryptedBloomFilter reads an encrypted bloom filter header and bitset
 // from the given ReadSeeker at the specified offset.
 func ReadEncryptedBloomFilter(r io.ReadSeeker, offset int64, opt ReadOptions) (*Filter, error) {
+	ctx := opt.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if _, err := r.Seek(offset, io.SeekStart); err != nil {
 		return nil, fmt.Errorf("seek to bloom filter offset %d: %w", offset, err)
 	}
@@ -79,7 +91,7 @@ func ReadEncryptedBloomFilter(r io.ReadSeeker, offset int64, opt ReadOptions) (*
 	if err != nil {
 		return nil, fmt.Errorf("decrypt bloom filter header: %w", err)
 	}
-	header, err := readBloomFilterHeader(bytes.NewReader(headerBytes))
+	header, err := readBloomFilterHeader(ctx, bytes.NewReader(headerBytes))
 	if err != nil {
 		return nil, fmt.Errorf("decode decrypted bloom filter header: %w", err)
 	}
@@ -101,13 +113,13 @@ func ReadEncryptedBloomFilter(r io.ReadSeeker, offset int64, opt ReadOptions) (*
 	return FromBitset(bitset)
 }
 
-func readBloomFilterHeader(r io.Reader) (*parquet.BloomFilterHeader, error) {
+func readBloomFilterHeader(ctx context.Context, r io.Reader) (*parquet.BloomFilterHeader, error) {
 	header := parquet.NewBloomFilterHeader()
 	tpf := thrift.NewTCompactProtocolFactoryConf(nil)
 	thriftReader := thrift.NewStreamTransportR(r)
 	bufferReader := thrift.NewTBufferedTransport(thriftReader, 1024)
 	protocol := tpf.GetProtocol(bufferReader)
-	if err := header.Read(context.TODO(), protocol); err != nil {
+	if err := header.Read(ctx, protocol); err != nil {
 		return nil, fmt.Errorf("read bloom filter header: %w", err)
 	}
 	return header, nil

--- a/internal/layout/page_read.go
+++ b/internal/layout/page_read.go
@@ -18,6 +18,7 @@ import (
 
 // PageReadOptions controls optional behavior when reading pages.
 type PageReadOptions struct {
+	Context     context.Context
 	CRCMode     common.CRCMode
 	Compressor  *compress.Compressor
 	MaxPageSize int64
@@ -217,10 +218,17 @@ func (p *Page) processDataPage(schemaHandler *schema.SchemaHandler, encodingType
 }
 
 // Read page header
+//
+// Deprecated: use ReadPageHeaderWithContext.
 func ReadPageHeader(thriftReader *thrift.TBufferedTransport) (*parquet.PageHeader, error) {
+	return ReadPageHeaderWithContext(context.Background(), thriftReader)
+}
+
+// ReadPageHeaderWithContext reads a page header using ctx.
+func ReadPageHeaderWithContext(ctx context.Context, thriftReader *thrift.TBufferedTransport) (*parquet.PageHeader, error) {
 	protocol := thrift.NewTCompactProtocolConf(thriftReader, &thrift.TConfiguration{})
 	pageHeader := parquet.NewPageHeader()
-	if err := pageHeader.Read(context.TODO(), protocol); err != nil {
+	if err := pageHeader.Read(ctx, protocol); err != nil {
 		return pageHeader, fmt.Errorf("decode page header: %w", err)
 	}
 	return pageHeader, nil
@@ -228,17 +236,24 @@ func ReadPageHeader(thriftReader *thrift.TBufferedTransport) (*parquet.PageHeade
 
 func readPageHeader(thriftReader *thrift.TBufferedTransport, opt PageReadOptions) (*parquet.PageHeader, error) {
 	if opt.Decryptor == nil {
-		return ReadPageHeader(thriftReader)
+		return ReadPageHeaderWithContext(pageContext(opt), thriftReader)
 	}
 	module, err := encryption.ReadModule(thriftReader, opt.MaxPageSize)
 	if err != nil {
 		return nil, fmt.Errorf("read encrypted page header module: %w", err)
 	}
-	pageHeader, err := decryptPageHeader(module, opt.Decryptor)
+	pageHeader, err := decryptPageHeader(pageContext(opt), module, opt.Decryptor)
 	if err != nil {
 		return nil, fmt.Errorf("decrypt page header: %w", err)
 	}
 	return pageHeader, nil
+}
+
+func pageContext(opt PageReadOptions) context.Context {
+	if opt.Context == nil {
+		return context.Background()
+	}
+	return opt.Context
 }
 
 // Read page from parquet file

--- a/internal/layout/page_read_encryption.go
+++ b/internal/layout/page_read_encryption.go
@@ -34,11 +34,18 @@ type PageDecryptor struct {
 // parsed page header. The decryptor must have its ordinal state set as if the
 // caller were reading pages sequentially: for data-page headers the data-page
 // AAD is tried first, and for dictionary headers a 0 page ordinal is used.
+//
+// Deprecated: use DecryptPageHeaderWithContext.
 func DecryptPageHeader(module []byte, decryptor *PageDecryptor) (*parquet.PageHeader, error) {
-	return decryptPageHeader(module, decryptor)
+	return decryptPageHeader(context.Background(), module, decryptor)
 }
 
-func decryptPageHeader(module []byte, decryptor *PageDecryptor) (*parquet.PageHeader, error) {
+// DecryptPageHeaderWithContext decrypts and parses a page header using ctx.
+func DecryptPageHeaderWithContext(ctx context.Context, module []byte, decryptor *PageDecryptor) (*parquet.PageHeader, error) {
+	return decryptPageHeader(ctx, module, decryptor)
+}
+
+func decryptPageHeader(ctx context.Context, module []byte, decryptor *PageDecryptor) (*parquet.PageHeader, error) {
 	tries := []encryption.ModuleType{encryption.ModuleDataPageHeader, encryption.ModuleDictionaryPageHeader}
 	var lastErr error
 	for _, moduleType := range tries {
@@ -48,7 +55,7 @@ func decryptPageHeader(module []byte, decryptor *PageDecryptor) (*parquet.PageHe
 			lastErr = err
 			continue
 		}
-		pageHeader, err := readPageHeaderFromBytes(plain)
+		pageHeader, err := readPageHeaderFromBytes(ctx, plain)
 		if err != nil {
 			return nil, fmt.Errorf("decode decrypted page header: %w", err)
 		}
@@ -63,10 +70,10 @@ func decryptPageHeader(module []byte, decryptor *PageDecryptor) (*parquet.PageHe
 	return nil, fmt.Errorf("decrypt page header: %w", lastErr)
 }
 
-func readPageHeaderFromBytes(buf []byte) (*parquet.PageHeader, error) {
+func readPageHeaderFromBytes(ctx context.Context, buf []byte) (*parquet.PageHeader, error) {
 	protocol := thrift.NewTCompactProtocolConf(thrift.NewStreamTransportR(bytes.NewReader(buf)), &thrift.TConfiguration{})
 	pageHeader := parquet.NewPageHeader()
-	if err := pageHeader.Read(context.TODO(), protocol); err != nil {
+	if err := pageHeader.Read(ctx, protocol); err != nil {
 		return nil, fmt.Errorf("decode page header: %w", err)
 	}
 	return pageHeader, nil

--- a/internal/layout/page_read_encryption_test.go
+++ b/internal/layout/page_read_encryption_test.go
@@ -94,6 +94,14 @@ func TestReadPageRawDataEncryptedDictionaryHeader(t *testing.T) {
 
 	headerModule := encryptPageGCMModule(t, key, pageTestAAD(aadPrefix, fileUnique, encryption.ModuleDictionaryPageHeader), serializePageHeader(t, header))
 	bodyModule := encryptPageGCMModule(t, key, pageTestAAD(aadPrefix, fileUnique, encryption.ModuleDictionaryPage), body)
+	decryptedHeader, err := DecryptPageHeaderWithContext(context.Background(), headerModule[4:], &PageDecryptor{
+		Algorithm:     PageEncryptionAESGCM,
+		Key:           key,
+		AADPrefix:     aadPrefix,
+		AADFileUnique: fileUnique,
+	})
+	require.NoError(t, err)
+	require.Equal(t, parquet.PageType_DICTIONARY_PAGE, decryptedHeader.GetType())
 	page, err := ReadPageRawData(encryptedPageReader(headerModule, bodyModule), testSchemaHandler(), testColumnMetaData(), &PageReadOptions{
 		MaxPageSize: 100,
 		Decryptor: &PageDecryptor{
@@ -142,7 +150,7 @@ func TestEncryptedPageErrors(t *testing.T) {
 	headerModule := encryptPageGCMModule(t, key, pageTestAAD(aadPrefix, fileUnique, encryption.ModuleDataPageHeader), serializePageHeader(t, dataHeader))
 	badDecryptor := *decryptor
 	badDecryptor.AADPrefix = []byte("wrong")
-	_, err = decryptPageHeader(headerModule[4:], &badDecryptor)
+	_, err = decryptPageHeader(context.Background(), headerModule[4:], &badDecryptor)
 	require.ErrorContains(t, err, "decrypt page header")
 
 	indexHeader := &parquet.PageHeader{
@@ -151,7 +159,7 @@ func TestEncryptedPageErrors(t *testing.T) {
 		UncompressedPageSize: 0,
 	}
 	indexHeaderModule := encryptPageGCMModule(t, key, pageTestAAD(aadPrefix, fileUnique, encryption.ModuleDataPageHeader), serializePageHeader(t, indexHeader))
-	_, err = decryptPageHeader(indexHeaderModule[4:], decryptor)
+	_, err = decryptPageHeader(context.Background(), indexHeaderModule[4:], decryptor)
 	require.ErrorContains(t, err, "unsupported encrypted page type")
 
 	_, err = readEncryptedPageBody(encryptedPageReader([]byte{1, 2}), dataHeader, PageReadOptions{

--- a/internal/layout/page_write.go
+++ b/internal/layout/page_write.go
@@ -15,6 +15,7 @@ import (
 // PageWriteOption consolidates page-level write parameters.
 // This struct is extensible for future features (e.g., encryption).
 type PageWriteOption struct {
+	Context         context.Context
 	PageSize        int32
 	CompressType    parquet.CompressionCodec
 	DataPageVersion int32
@@ -33,7 +34,11 @@ func serializePage(page *Page, opt PageWriteOption, compressedData ...[]byte) er
 
 	ts := thrift.NewTSerializer()
 	ts.Protocol = thrift.NewTCompactProtocolFactoryConf(&thrift.TConfiguration{}).GetProtocol(ts.Transport)
-	pageHeaderBuf, err := ts.Write(context.TODO(), page.Header)
+	ctx := opt.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	pageHeaderBuf, err := ts.Write(ctx, page.Header)
 	if err != nil {
 		return fmt.Errorf("serialize page header: %w", err)
 	}

--- a/reader/bloom.go
+++ b/reader/bloom.go
@@ -1,6 +1,7 @@
 package reader
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/hangxie/parquet-go/v3/common"
@@ -35,7 +36,7 @@ func (pr *ParquetReader) detectBloomFilters() {
 			if pr.PFile == nil {
 				continue
 			}
-			pf, err := pr.PFile.Clone()
+			pf, err := source.CloneWithContext(pr.context(), pr.PFile)
 			if err != nil {
 				continue
 			}
@@ -44,7 +45,7 @@ func (pr *ParquetReader) detectBloomFilters() {
 			if err == nil {
 				pr.SchemaHandler.Infos[index].BloomFilterSize = filter.NumBytes()
 			}
-			_ = pf.Close()
+			_ = source.CloseWithContext(pr.context(), pf)
 		}
 	}
 }
@@ -55,7 +56,17 @@ func (pr *ParquetReader) detectBloomFilters() {
 // its components must be separated by common.ParGoPathDelimiter (build it with common.PathToStr,
 // e.g. common.PathToStr([]string{"address", "city"})). "." is treated as an ordinary character,
 // so a column whose name itself contains a dot is a single path component.
+//
+// Deprecated: use BloomFilterCheckWithContext.
 func (pr *ParquetReader) BloomFilterCheck(columnPath string, rowGroupIndex int, value any) (bool, error) {
+	return pr.BloomFilterCheckWithContext(pr.defaultContext(), columnPath, rowGroupIndex, value)
+}
+
+// BloomFilterCheckWithContext checks a bloom filter using ctx.
+func (pr *ParquetReader) BloomFilterCheckWithContext(ctx context.Context, columnPath string, rowGroupIndex int, value any) (bool, error) {
+	if err := pr.setContext(ctx); err != nil {
+		return false, err
+	}
 	if rowGroupIndex < 0 || rowGroupIndex >= len(pr.Footer.RowGroups) {
 		return false, fmt.Errorf("row group index %d out of range [0, %d)", rowGroupIndex, len(pr.Footer.RowGroups))
 	}
@@ -95,11 +106,11 @@ func (pr *ParquetReader) BloomFilterCheck(columnPath string, rowGroupIndex int, 
 		return true, nil
 	}
 
-	pf, err := pr.PFile.Clone()
+	pf, err := source.CloneWithContext(ctx, pr.PFile)
 	if err != nil {
 		return false, fmt.Errorf("clone file reader: %w", err)
 	}
-	defer func() { _ = pf.Close() }()
+	defer func() { _ = source.CloseWithContext(ctx, pf) }()
 
 	filter, err := pr.readBloomFilterForColumn(pf, rowGroupIndex, columnOrdinal, rg, columnChunk)
 	if err != nil {
@@ -120,7 +131,7 @@ func (pr *ParquetReader) readBloomFilterForColumn(pf source.ParquetFileReader, r
 	}
 	offset := columnChunk.MetaData.GetBloomFilterOffset()
 	if columnChunk.GetCryptoMetadata() == nil {
-		return bloomfilter.ReadBloomFilter(pf, offset)
+		return bloomfilter.ReadBloomFilterWithContext(pr.context(), source.ReadSeekerWithContext{Ctx: pr.context(), ReadSeeker: pf}, offset)
 	}
 
 	algorithm := pr.encryptionAlgorithm()
@@ -139,7 +150,8 @@ func (pr *ParquetReader) readBloomFilterForColumn(pf source.ParquetFileReader, r
 	if rowGroup != nil && rowGroup.IsSetOrdinal() {
 		rowGroupOrdinal = rowGroup.GetOrdinal()
 	}
-	return bloomfilter.ReadEncryptedBloomFilter(pf, offset, bloomfilter.ReadOptions{
+	return bloomfilter.ReadEncryptedBloomFilter(source.ReadSeekerWithContext{Ctx: pr.context(), ReadSeeker: pf}, offset, bloomfilter.ReadOptions{
+		Context:         pr.context(),
 		Key:             key,
 		AADPrefix:       aadPrefix,
 		AADFileUnique:   aadFileUnique,

--- a/reader/bloom_test.go
+++ b/reader/bloom_test.go
@@ -2,6 +2,7 @@ package reader
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"testing"
 
@@ -27,16 +28,16 @@ func TestBloomFilterCheck(t *testing.T) {
 
 		var buf bytes.Buffer
 		fw := writerfile.NewWriterFile(&buf)
-		pw, err := writer.NewParquetWriter(fw, new(BloomRecord), writer.WithNP(1))
+		pw, err := writer.NewParquetWriterWithContext(context.Background(), fw, new(BloomRecord), writer.WithNP(1))
 		require.NoError(t, err)
 
 		for i := range 100 {
-			require.NoError(t, pw.Write(BloomRecord{
+			require.NoError(t, pw.WriteWithContext(context.Background(), BloomRecord{
 				ID:   int64(i * 100),
 				Name: fmt.Sprintf("name-%d", i),
 			}))
 		}
-		require.NoError(t, pw.WriteStop())
+		require.NoError(t, pw.WriteStopWithContext(context.Background()))
 
 		pf := buffer.NewBufferReaderFromBytesNoAlloc(buf.Bytes())
 		pr, err := NewParquetReader(pf, new(BloomRecord), WithNP(1))
@@ -64,14 +65,14 @@ func TestBloomFilterCheck(t *testing.T) {
 
 		var buf bytes.Buffer
 		fw := writerfile.NewWriterFile(&buf)
-		pw, err := writer.NewParquetWriter(fw, new(BloomRecord), writer.WithNP(1))
+		pw, err := writer.NewParquetWriterWithContext(context.Background(), fw, new(BloomRecord), writer.WithNP(1))
 		require.NoError(t, err)
 
 		// Write specific values
 		for i := range 10 {
-			require.NoError(t, pw.Write(BloomRecord{ID: int64(i * 1000)}))
+			require.NoError(t, pw.WriteWithContext(context.Background(), BloomRecord{ID: int64(i * 1000)}))
 		}
-		require.NoError(t, pw.WriteStop())
+		require.NoError(t, pw.WriteStopWithContext(context.Background()))
 
 		pf := buffer.NewBufferReaderFromBytesNoAlloc(buf.Bytes())
 		pr, err := NewParquetReader(pf, new(BloomRecord), WithNP(1))
@@ -100,10 +101,10 @@ func TestBloomFilterCheck(t *testing.T) {
 
 		var buf bytes.Buffer
 		fw := writerfile.NewWriterFile(&buf)
-		pw, err := writer.NewParquetWriter(fw, new(BloomRecord), writer.WithNP(1))
+		pw, err := writer.NewParquetWriterWithContext(context.Background(), fw, new(BloomRecord), writer.WithNP(1))
 		require.NoError(t, err)
-		require.NoError(t, pw.Write(BloomRecord{ID: 42, Name: "test"}))
-		require.NoError(t, pw.WriteStop())
+		require.NoError(t, pw.WriteWithContext(context.Background(), BloomRecord{ID: 42, Name: "test"}))
+		require.NoError(t, pw.WriteStopWithContext(context.Background()))
 
 		pf := buffer.NewBufferReaderFromBytesNoAlloc(buf.Bytes())
 		pr, err := NewParquetReader(pf, new(BloomRecord), WithNP(1))
@@ -123,10 +124,10 @@ func TestBloomFilterCheck(t *testing.T) {
 
 		var buf bytes.Buffer
 		fw := writerfile.NewWriterFile(&buf)
-		pw, err := writer.NewParquetWriter(fw, new(BloomRecord), writer.WithNP(1))
+		pw, err := writer.NewParquetWriterWithContext(context.Background(), fw, new(BloomRecord), writer.WithNP(1))
 		require.NoError(t, err)
-		require.NoError(t, pw.Write(BloomRecord{ID: 42}))
-		require.NoError(t, pw.WriteStop())
+		require.NoError(t, pw.WriteWithContext(context.Background(), BloomRecord{ID: 42}))
+		require.NoError(t, pw.WriteStopWithContext(context.Background()))
 
 		pf := buffer.NewBufferReaderFromBytesNoAlloc(buf.Bytes())
 		pr, err := NewParquetReader(pf, new(BloomRecord), WithNP(1))
@@ -149,10 +150,10 @@ func TestBloomFilterCheck(t *testing.T) {
 
 		var buf bytes.Buffer
 		fw := writerfile.NewWriterFile(&buf)
-		pw, err := writer.NewParquetWriter(fw, new(BloomRecord), writer.WithNP(1))
+		pw, err := writer.NewParquetWriterWithContext(context.Background(), fw, new(BloomRecord), writer.WithNP(1))
 		require.NoError(t, err)
-		require.NoError(t, pw.Write(BloomRecord{ID: 42}))
-		require.NoError(t, pw.WriteStop())
+		require.NoError(t, pw.WriteWithContext(context.Background(), BloomRecord{ID: 42}))
+		require.NoError(t, pw.WriteStopWithContext(context.Background()))
 
 		pf := buffer.NewBufferReaderFromBytesNoAlloc(buf.Bytes())
 		pr, err := NewParquetReader(pf, new(BloomRecord), WithNP(1))
@@ -172,16 +173,16 @@ func TestBloomFilterCheck(t *testing.T) {
 
 		var buf bytes.Buffer
 		fw := writerfile.NewWriterFile(&buf)
-		pw, err := writer.NewParquetWriter(fw, new(BloomRecord), writer.WithNP(1))
+		pw, err := writer.NewParquetWriterWithContext(context.Background(), fw, new(BloomRecord), writer.WithNP(1))
 		require.NoError(t, err)
 
 		for i := range 50 {
-			require.NoError(t, pw.Write(BloomRecord{
+			require.NoError(t, pw.WriteWithContext(context.Background(), BloomRecord{
 				ID:   int64(i),
 				Name: fmt.Sprintf("user-%d", i),
 			}))
 		}
-		require.NoError(t, pw.WriteStop())
+		require.NoError(t, pw.WriteStopWithContext(context.Background()))
 
 		pf := buffer.NewBufferReaderFromBytesNoAlloc(buf.Bytes())
 		pr, err := NewParquetReader(pf, new(BloomRecord), WithNP(1))
@@ -208,15 +209,18 @@ func TestBloomFilterCheck(t *testing.T) {
 
 		var buf bytes.Buffer
 		fw := writerfile.NewWriterFile(&buf)
+		//nolint:staticcheck
 		pw, err := writer.NewParquetWriter(fw, new(BloomRecord), writer.WithNP(1), writer.WithRowGroupSize(256), writer.WithPageSize(64))
 		require.NoError(t, err)
 
 		for i := range 1000 {
+			//nolint:staticcheck
 			require.NoError(t, pw.Write(BloomRecord{
 				ID:   int64(i),
 				Name: fmt.Sprintf("a-long-name-to-force-multiple-row-groups-%d", i),
 			}))
 		}
+		//nolint:staticcheck
 		require.NoError(t, pw.WriteStop())
 
 		pf := buffer.NewBufferReaderFromBytesNoAlloc(buf.Bytes())
@@ -247,9 +251,12 @@ func TestBloomFilterCheck(t *testing.T) {
 
 		var buf bytes.Buffer
 		fw := writerfile.NewWriterFile(&buf)
+		//nolint:staticcheck
 		pw, err := writer.NewParquetWriter(fw, new(BloomRecord), writer.WithNP(1))
 		require.NoError(t, err)
+		//nolint:staticcheck
 		require.NoError(t, pw.Write(BloomRecord{ID: 42}))
+		//nolint:staticcheck
 		require.NoError(t, pw.WriteStop())
 
 		pf := buffer.NewBufferReaderFromBytesNoAlloc(buf.Bytes())
@@ -270,9 +277,12 @@ func TestBloomFilterCheck(t *testing.T) {
 
 		var buf bytes.Buffer
 		fw := writerfile.NewWriterFile(&buf)
+		//nolint:staticcheck
 		pw, err := writer.NewParquetWriter(fw, new(BloomRecord), writer.WithNP(1))
 		require.NoError(t, err)
+		//nolint:staticcheck
 		require.NoError(t, pw.Write(BloomRecord{ID: 42}))
+		//nolint:staticcheck
 		require.NoError(t, pw.WriteStop())
 
 		pf := buffer.NewBufferReaderFromBytesNoAlloc(buf.Bytes())
@@ -294,9 +304,12 @@ func TestBloomFilterCheck(t *testing.T) {
 
 		var buf bytes.Buffer
 		fw := writerfile.NewWriterFile(&buf)
+		//nolint:staticcheck
 		pw, err := writer.NewParquetWriter(fw, new(BloomRecord), writer.WithNP(1))
 		require.NoError(t, err)
+		//nolint:staticcheck
 		require.NoError(t, pw.Write(BloomRecord{ID: 42}))
+		//nolint:staticcheck
 		require.NoError(t, pw.WriteStop())
 
 		pf := buffer.NewBufferReaderFromBytesNoAlloc(buf.Bytes())
@@ -324,11 +337,14 @@ func TestBloomFilterCheck(t *testing.T) {
 
 		var buf bytes.Buffer
 		fw := writerfile.NewWriterFile(&buf)
+		//nolint:staticcheck
 		pw, err := writer.NewParquetWriter(fw, new(BloomRecord), writer.WithNP(1))
 		require.NoError(t, err)
 		for i := range 100 {
+			//nolint:staticcheck
 			require.NoError(t, pw.Write(BloomRecord{Dotted: int64(i * 100)}))
 		}
+		//nolint:staticcheck
 		require.NoError(t, pw.WriteStop())
 
 		pf := buffer.NewBufferReaderFromBytesNoAlloc(buf.Bytes())
@@ -458,9 +474,12 @@ func TestDetectBloomFilters(t *testing.T) {
 		}
 		var buf bytes.Buffer
 		fw := writerfile.NewWriterFile(&buf)
+		//nolint:staticcheck
 		pw, err := writer.NewParquetWriter(fw, new(BloomRecord), writer.WithNP(1))
 		require.NoError(t, err)
+		//nolint:staticcheck
 		require.NoError(t, pw.Write(BloomRecord{Name: "test"}))
+		//nolint:staticcheck
 		require.NoError(t, pw.WriteStop())
 		_ = fw.Close()
 
@@ -493,7 +512,7 @@ func (f *failCloneReader) Clone() (source.ParquetFileReader, error) {
 func TestBloomFilterInterop(t *testing.T) {
 	t.Run("read_bloom_from_parquet_mr", func(t *testing.T) {
 		bloomURL := "https://github.com/apache/parquet-testing/raw/refs/heads/master/data/data_index_bloom_encoding_stats.parquet"
-		httpReader, err := phttp.NewHttpReader(bloomURL, false, false, map[string]string{})
+		httpReader, err := phttp.NewHttpReaderWithContext(context.Background(), bloomURL, false, false, map[string]string{})
 		require.NoError(t, err)
 		defer func() { _ = httpReader.Close() }()
 
@@ -516,7 +535,7 @@ func TestBloomFilterInterop(t *testing.T) {
 			pf, cloneErr := httpReader.Clone()
 			require.NoError(t, cloneErr)
 
-			filter, readErr := bloomfilter.ReadBloomFilter(pf, offset)
+			filter, readErr := bloomfilter.ReadBloomFilterWithContext(context.Background(), pf, offset)
 			_ = pf.Close()
 			require.NoError(t, readErr)
 			require.Greater(t, filter.NumBytes(), int32(0))
@@ -526,7 +545,7 @@ func TestBloomFilterInterop(t *testing.T) {
 
 	t.Run("bloom_filter_length_populated", func(t *testing.T) {
 		bloomWithLengthURL := "https://github.com/apache/parquet-testing/raw/refs/heads/master/data/data_index_bloom_encoding_with_length.parquet"
-		httpReader, err := phttp.NewHttpReader(bloomWithLengthURL, false, false, map[string]string{})
+		httpReader, err := phttp.NewHttpReaderWithContext(context.Background(), bloomWithLengthURL, false, false, map[string]string{})
 		require.NoError(t, err)
 		defer func() { _ = httpReader.Close() }()
 
@@ -550,7 +569,7 @@ func TestBloomFilterInterop(t *testing.T) {
 			pf, cloneErr := httpReader.Clone()
 			require.NoError(t, cloneErr)
 
-			filter, readErr := bloomfilter.ReadBloomFilter(pf, cc.MetaData.GetBloomFilterOffset())
+			filter, readErr := bloomfilter.ReadBloomFilterWithContext(context.Background(), pf, cc.MetaData.GetBloomFilterOffset())
 			_ = pf.Close()
 			require.NoError(t, readErr)
 			require.Greater(t, filter.NumBytes(), int32(0))

--- a/reader/column_key_test.go
+++ b/reader/column_key_test.go
@@ -268,6 +268,7 @@ func writeColumnKeyTestFile(t *testing.T, footerKey, nameKey []byte) []byte {
 	t.Helper()
 
 	var buf bytes.Buffer
+	//nolint:staticcheck
 	pw, err := writer.NewParquetWriter(
 		writerfile.NewWriterFile(&buf),
 		new(columnKeyTestRecord),
@@ -276,7 +277,9 @@ func writeColumnKeyTestFile(t *testing.T, footerKey, nameKey []byte) []byte {
 		writer.WithAADFileUnique([]byte("column-key-test")),
 	)
 	require.NoError(t, err)
+	//nolint:staticcheck
 	require.NoError(t, pw.Write(columnKeyTestRecord{ID: 1, Name: "alpha"}))
+	//nolint:staticcheck
 	require.NoError(t, pw.WriteStop())
 	return buf.Bytes()
 }
@@ -285,6 +288,7 @@ func writeRootNamedColumnKeyTestFile(t *testing.T, footerKey, nameKey []byte) []
 	t.Helper()
 
 	var buf bytes.Buffer
+	//nolint:staticcheck
 	pw, err := writer.NewParquetWriter(
 		writerfile.NewWriterFile(&buf),
 		new(columnKeyRootNamedTestRecord),
@@ -293,7 +297,9 @@ func writeRootNamedColumnKeyTestFile(t *testing.T, footerKey, nameKey []byte) []
 		writer.WithAADFileUnique([]byte("root-named-column-key-test")),
 	)
 	require.NoError(t, err)
+	//nolint:staticcheck
 	require.NoError(t, pw.Write(columnKeyRootNamedTestRecord{ID: 1, Root: columnKeyRootNamedGroup{Name: "alpha"}}))
+	//nolint:staticcheck
 	require.NoError(t, pw.WriteStop())
 	return buf.Bytes()
 }
@@ -341,6 +347,7 @@ func TestColumnEncryptionDistinguishesDottedNameFromNestedPath(t *testing.T) {
 	writeFile := func(t *testing.T, encRootless string) []byte {
 		t.Helper()
 		var buf bytes.Buffer
+		//nolint:staticcheck
 		pw, err := writer.NewParquetWriter(
 			writerfile.NewWriterFile(&buf),
 			new(dotAmbiguityRecord),
@@ -352,8 +359,11 @@ func TestColumnEncryptionDistinguishesDottedNameFromNestedPath(t *testing.T) {
 			writer.WithAADFileUnique([]byte("dot-ambiguity")),
 		)
 		require.NoError(t, err)
+		//nolint:staticcheck
 		require.NoError(t, pw.Write(dotAmbiguityRecord{Dotted: literalV0, Group: dotAmbiguityGroup{B: nestedV0}}))
+		//nolint:staticcheck
 		require.NoError(t, pw.Write(dotAmbiguityRecord{Dotted: literalV1, Group: dotAmbiguityGroup{B: nestedV1}}))
+		//nolint:staticcheck
 		require.NoError(t, pw.WriteStop())
 		return buf.Bytes()
 	}

--- a/reader/columnbuffer.go
+++ b/reader/columnbuffer.go
@@ -1,6 +1,7 @@
 package reader
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -72,13 +73,17 @@ func newColumnBuffer(pFile source.ParquetFileReader, footer *parquet.FileMetaDat
 			}
 		}
 	}
-	newPFile, err := pFile.Clone()
+	ctx := context.Background()
+	if opts != nil && opts.Context != nil {
+		ctx = opts.Context
+	}
+	newPFile, err := source.CloneWithContext(ctx, pFile)
 	if err != nil {
 		return nil, fmt.Errorf("clone file reader: %w", err)
 	}
 	// Capture the file size as a ceiling for metadata-declared counts. NextRowGroup
 	// re-seeks to the column offset before reading, so seeking to the end here is safe.
-	fileSize, err := newPFile.Seek(0, io.SeekEnd)
+	fileSize, err := source.SeekWithContext(ctx, newPFile, 0, io.SeekEnd)
 	if err != nil {
 		return nil, fmt.Errorf("determine file size: %w", err)
 	}
@@ -158,11 +163,11 @@ func (cbt *ColumnBufferType) NextRowGroup() error {
 		// returns a nil interface, which would otherwise clobber cbt.PFile and
 		// panic when ReadStop later calls Close on it. The previous handle is
 		// released only after the new one is opened.
-		pFile, err := cbt.PFile.Open(*columnChunks[i].FilePath)
+		pFile, err := source.OpenWithContext(cbt.context(), cbt.PFile, *columnChunks[i].FilePath)
 		if err != nil {
 			return fmt.Errorf("open file %s: %w", *columnChunks[i].FilePath, err)
 		}
-		_ = cbt.PFile.Close()
+		_ = source.CloseWithContext(cbt.context(), cbt.PFile)
 		cbt.PFile = pFile
 	}
 
@@ -176,14 +181,30 @@ func (cbt *ColumnBufferType) NextRowGroup() error {
 		_ = cbt.ThriftReader.Close()
 	}
 
-	thriftReader, thriftErr := source.ConvertToThriftReader(cbt.PFile, offset)
-	if thriftErr != nil {
-		return fmt.Errorf("convert to thrift reader at offset %d: %w", offset, thriftErr)
+	if _, err := source.SeekWithContext(cbt.context(), cbt.PFile, offset, io.SeekStart); err != nil {
+		return fmt.Errorf("seek to thrift reader offset %d: %w", offset, err)
 	}
+	thriftTransport := thrift.NewStreamTransportR(columnBufferReader{buffer: cbt})
+	thriftReader := thrift.NewTBufferedTransport(thriftTransport, 4096)
 	cbt.ThriftReader = thriftReader
 	cbt.ChunkReadValues = 0
 	cbt.DictPage = nil
 	return nil
+}
+
+func (cbt *ColumnBufferType) context() context.Context {
+	if cbt.PageReadOptions.Context == nil {
+		return context.Background()
+	}
+	return cbt.PageReadOptions.Context
+}
+
+type columnBufferReader struct {
+	buffer *ColumnBufferType
+}
+
+func (r columnBufferReader) Read(p []byte) (int, error) {
+	return source.ReadWithContext(r.buffer.context(), r.buffer.PFile, p)
 }
 
 func (cbt *ColumnBufferType) readMetaData() *parquet.ColumnMetaData {

--- a/reader/columnreader.go
+++ b/reader/columnreader.go
@@ -13,14 +13,26 @@ import (
 )
 
 // NewParquetColumnReader creates a parquet column reader.
+//
+// Deprecated: use NewParquetColumnReaderWithContext.
 func NewParquetColumnReader(pFile source.ParquetFileReader, opts ...ReaderOption) (*ParquetReader, error) {
+	return NewParquetColumnReaderWithContext(context.Background(), pFile, opts...)
+}
+
+// NewParquetColumnReaderWithContext creates a parquet column reader using ctx.
+func NewParquetColumnReaderWithContext(ctx context.Context, pFile source.ParquetFileReader, opts ...ReaderOption) (*ParquetReader, error) {
+	if ctx == nil {
+		return nil, fmt.Errorf("context is nil")
+	}
 	res := new(ParquetReader)
 	res.PFile = pFile
+	res.defaultCtx = ctx
+	res.ctx = ctx
 
 	if err := applyReaderDefaults(res, opts); err != nil {
 		return nil, fmt.Errorf("apply reader options: %w", err)
 	}
-	if err := res.ReadFooter(); err != nil {
+	if err := res.ReadFooterWithContext(ctx); err != nil {
 		return nil, fmt.Errorf("read footer: %w", err)
 	}
 	res.ColumnBuffers = make(map[string]*ColumnBufferType)
@@ -33,7 +45,17 @@ func NewParquetColumnReader(pFile source.ParquetFileReader, opts ...ReaderOption
 }
 
 // SkipRows skips num rows across all value columns in parallel.
+//
+// Deprecated: use SkipRowsWithContext.
 func (pr *ParquetReader) SkipRows(num int64) error {
+	return pr.SkipRowsWithContext(pr.defaultContext(), num)
+}
+
+// SkipRowsWithContext skips num rows across all value columns using ctx.
+func (pr *ParquetReader) SkipRowsWithContext(ctx context.Context, num int64) error {
+	if err := pr.setContext(ctx); err != nil {
+		return err
+	}
 	var err error
 	if num <= 0 {
 		return nil
@@ -47,11 +69,18 @@ func (pr *ParquetReader) SkipRows(num int64) error {
 		}
 	}
 
-	g, _ := errgroup.WithContext(context.Background())
+	g, ctx := errgroup.WithContext(ctx)
 	sem := make(chan struct{}, max(1, int(pr.np)))
+	var launchErr error
+launch:
 	for key := range pr.ColumnBuffers {
 		pathStr := key
-		sem <- struct{}{}
+		select {
+		case sem <- struct{}{}:
+		case <-ctx.Done():
+			launchErr = ctx.Err()
+			break launch
+		}
 		g.Go(func() error {
 			defer func() { <-sem }()
 			if _, err := pr.ColumnBuffers[pathStr].SkipRows(int64(num)); err != nil && errors.Is(err, io.EOF) {
@@ -62,13 +91,26 @@ func (pr *ParquetReader) SkipRows(num int64) error {
 			return nil
 		})
 	}
-	return g.Wait()
+	if err := g.Wait(); err != nil {
+		return err
+	}
+	return launchErr
 }
 
 // SkipRowsByPath skips num rows in the column identified by pathStr. pathStr
 // components must be separated by common.ParGoPathDelimiter (build it with
 // common.PathToStr); "." is an ordinary character in a name, not a separator.
+//
+// Deprecated: use SkipRowsByPathWithContext.
 func (pr *ParquetReader) SkipRowsByPath(pathStr string, num int64) error {
+	return pr.SkipRowsByPathWithContext(pr.defaultContext(), pathStr, num)
+}
+
+// SkipRowsByPathWithContext skips rows in a column using ctx.
+func (pr *ParquetReader) SkipRowsByPathWithContext(ctx context.Context, pathStr string, num int64) error {
+	if err := pr.setContext(ctx); err != nil {
+		return err
+	}
 	errPathNotFound := fmt.Errorf("path %v not found", pathStr)
 
 	if pr.SchemaHandler == nil {
@@ -109,7 +151,17 @@ func (pr *ParquetReader) SkipRowsByPath(pathStr string, num int64) error {
 
 // SkipRowsByIndex skips rows by index and returns any errors encountered.
 // This is the error-returning version of SkipRowsByIndex.
+//
+// Deprecated: use SkipRowsByIndexWithContext.
 func (pr *ParquetReader) SkipRowsByIndex(index, num int64) error {
+	return pr.SkipRowsByIndexWithContext(pr.defaultContext(), index, num)
+}
+
+// SkipRowsByIndexWithContext skips rows by column index using ctx.
+func (pr *ParquetReader) SkipRowsByIndexWithContext(ctx context.Context, index, num int64) error {
+	if err := pr.setContext(ctx); err != nil {
+		return err
+	}
 	if pr.SchemaHandler == nil {
 		return fmt.Errorf("SchemaHandler is nil")
 	}
@@ -120,7 +172,7 @@ func (pr *ParquetReader) SkipRowsByIndex(index, num int64) error {
 		return fmt.Errorf("index %d out of range (max: %d)", index, len(pr.SchemaHandler.ValueColumns)-1)
 	}
 	pathStr := pr.SchemaHandler.ValueColumns[index]
-	if err := pr.SkipRowsByPath(pathStr, num); err != nil {
+	if err := pr.SkipRowsByPathWithContext(ctx, pathStr, num); err != nil {
 		return fmt.Errorf("skip rows by path %s: %w", pathStr, err)
 	}
 	return nil
@@ -129,7 +181,17 @@ func (pr *ParquetReader) SkipRowsByIndex(index, num int64) error {
 // ReadColumnByPath reads column by path in schema. pathStr components must be
 // separated by common.ParGoPathDelimiter (build it with common.PathToStr); "." is
 // an ordinary character in a name, not a separator.
+//
+// Deprecated: use ReadColumnByPathWithContext.
 func (pr *ParquetReader) ReadColumnByPath(pathStr string, num int64) (values []any, rls, dls []int32, err error) {
+	return pr.ReadColumnByPathWithContext(pr.defaultContext(), pathStr, num)
+}
+
+// ReadColumnByPathWithContext reads a column by path using ctx.
+func (pr *ParquetReader) ReadColumnByPathWithContext(ctx context.Context, pathStr string, num int64) (values []any, rls, dls []int32, err error) {
+	if err := pr.setContext(ctx); err != nil {
+		return nil, nil, nil, err
+	}
 	errPathNotFound := fmt.Errorf("path %v not found", pathStr)
 
 	pathStr, err = pr.SchemaHandler.ConvertToInPathStr(pathStr)
@@ -162,12 +224,22 @@ func (pr *ParquetReader) ReadColumnByPath(pathStr string, num int64) (values []a
 }
 
 // ReadColumnByIndex reads column by index. The index of first column is 0.
+//
+// Deprecated: use ReadColumnByIndexWithContext.
 func (pr *ParquetReader) ReadColumnByIndex(index, num int64) ([]any, []int32, []int32, error) {
+	return pr.ReadColumnByIndexWithContext(pr.defaultContext(), index, num)
+}
+
+// ReadColumnByIndexWithContext reads a column by index using ctx.
+func (pr *ParquetReader) ReadColumnByIndexWithContext(ctx context.Context, index, num int64) ([]any, []int32, []int32, error) {
+	if err := pr.setContext(ctx); err != nil {
+		return nil, nil, nil, err
+	}
 	if index < 0 || index >= int64(len(pr.SchemaHandler.ValueColumns)) {
 		return nil, nil, nil, fmt.Errorf("index %v out of range [0, %v)", index, len(pr.SchemaHandler.ValueColumns))
 	}
 	pathStr := pr.SchemaHandler.ValueColumns[index]
-	values, rls, dls, err := pr.ReadColumnByPath(pathStr, num)
+	values, rls, dls, err := pr.ReadColumnByPathWithContext(ctx, pathStr, num)
 	if err != nil {
 		return values, rls, dls, fmt.Errorf("read column by index %v: %w", index, err)
 	}

--- a/reader/context.go
+++ b/reader/context.go
@@ -1,0 +1,37 @@
+package reader
+
+import (
+	"context"
+	"fmt"
+)
+
+func (pr *ParquetReader) context() context.Context {
+	if pr.ctx == nil {
+		return context.Background()
+	}
+	return pr.ctx
+}
+
+func (pr *ParquetReader) defaultContext() context.Context {
+	if pr.defaultCtx == nil {
+		return context.Background()
+	}
+	return pr.defaultCtx
+}
+
+func (pr *ParquetReader) setContext(ctx context.Context) error {
+	if ctx == nil {
+		return fmt.Errorf("context is nil")
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	pr.ctx = ctx
+	for _, cb := range pr.ColumnBuffers {
+		if cb == nil {
+			continue
+		}
+		cb.PageReadOptions.Context = ctx
+	}
+	return nil
+}

--- a/reader/context_test.go
+++ b/reader/context_test.go
@@ -1,0 +1,141 @@
+package reader
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hangxie/parquet-go/v3/source"
+	"github.com/hangxie/parquet-go/v3/source/buffer"
+	"github.com/hangxie/parquet-go/v3/writer"
+)
+
+type contextTrackingReader struct {
+	source.ParquetFileReader
+	contexts *[]context.Context
+}
+
+func (r *contextTrackingReader) ReadContext(ctx context.Context, p []byte) (int, error) {
+	*r.contexts = append(*r.contexts, ctx)
+	return r.Read(p)
+}
+
+func (r *contextTrackingReader) SeekContext(ctx context.Context, offset int64, whence int) (int64, error) {
+	*r.contexts = append(*r.contexts, ctx)
+	return r.Seek(offset, whence)
+}
+
+func (r *contextTrackingReader) CloneContext(ctx context.Context) (source.ParquetFileReader, error) {
+	*r.contexts = append(*r.contexts, ctx)
+	clone, err := r.Clone()
+	if err != nil {
+		return nil, err
+	}
+	return &contextTrackingReader{ParquetFileReader: clone, contexts: r.contexts}, nil
+}
+
+func (r *contextTrackingReader) OpenContext(ctx context.Context, name string) (source.ParquetFileReader, error) {
+	*r.contexts = append(*r.contexts, ctx)
+	opened, err := r.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	return &contextTrackingReader{ParquetFileReader: opened, contexts: r.contexts}, nil
+}
+
+func TestParquetReaderWithContext(t *testing.T) {
+	file := buffer.NewBufferWriter()
+	//nolint:staticcheck
+	pw, err := writer.NewParquetWriter(file, new(Record), writer.WithNP(1))
+	require.NoError(t, err)
+	//nolint:staticcheck
+	require.NoError(t, pw.Write(Record{Str1: "context"}))
+	//nolint:staticcheck
+	require.NoError(t, pw.Write(Record{Str1: "context"}))
+	//nolint:staticcheck
+	require.NoError(t, pw.WriteStop())
+
+	var contexts []context.Context
+	tracking := &contextTrackingReader{ParquetFileReader: buffer.NewBufferReaderFromBytes(file.Bytes()), contexts: &contexts}
+	type contextKey struct{}
+	ctx := context.WithValue(context.Background(), contextKey{}, "constructor")
+	pr, err := NewParquetReaderWithContext(ctx, tracking, new(Record), WithNP(1))
+	require.NoError(t, err)
+	require.NotEmpty(t, contexts)
+	for _, got := range contexts {
+		require.Equal(t, "constructor", got.Value(contextKey{}))
+	}
+
+	contexts = nil
+	rows := make([]Record, 1)
+	require.NoError(t, pr.Read(&rows))
+	require.NotEmpty(t, contexts)
+	for _, got := range contexts {
+		require.Equal(t, "constructor", got.Value(contextKey{}))
+	}
+
+	contexts = nil
+	readCtx := context.WithValue(context.Background(), contextKey{}, "read")
+	require.NoError(t, pr.ReadWithContext(readCtx, &rows))
+	require.Equal(t, "context", rows[0].Str1)
+	require.Equal(t, "read", pr.context().Value(contextKey{}))
+
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.ErrorIs(t, pr.ReadWithContext(canceled, &rows), context.Canceled)
+}
+
+func TestParquetReaderContextVariantsRejectCanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	pr := new(ParquetReader)
+	_, err := NewParquetReaderWithContext(ctx, nil, nil)
+	require.ErrorIs(t, err, context.Canceled)
+	_, err = NewParquetColumnReaderWithContext(ctx, nil)
+	require.ErrorIs(t, err, context.Canceled)
+	nilCtx := map[string]context.Context{}["missing"]
+	_, err = NewParquetReaderWithContext(nilCtx, nil, nil)
+	require.ErrorContains(t, err, "context is nil")
+	_, err = NewParquetColumnReaderWithContext(nilCtx, nil)
+	require.ErrorContains(t, err, "context is nil")
+
+	tests := []struct {
+		name string
+		run  func() error
+	}{
+		{name: "footer size", run: func() error { _, err := pr.GetFooterSizeWithContext(ctx); return err }},
+		{name: "footer", run: func() error { return pr.ReadFooterWithContext(ctx) }},
+		{name: "read", run: func() error { return pr.ReadWithContext(ctx, nil) }},
+		{name: "read by number", run: func() error { _, err := pr.ReadByNumberWithContext(ctx, 1); return err }},
+		{name: "read partial", run: func() error { return pr.ReadPartialWithContext(ctx, nil, "") }},
+		{name: "read partial by number", run: func() error { _, err := pr.ReadPartialByNumberWithContext(ctx, 1, ""); return err }},
+		{name: "skip", run: func() error { return pr.SkipRowsWithContext(ctx, 1) }},
+		{name: "skip by path", run: func() error { return pr.SkipRowsByPathWithContext(ctx, "", 1) }},
+		{name: "skip by index", run: func() error { return pr.SkipRowsByIndexWithContext(ctx, 0, 1) }},
+		{name: "column by path", run: func() error { _, _, _, err := pr.ReadColumnByPathWithContext(ctx, "", 1); return err }},
+		{name: "column by index", run: func() error { _, _, _, err := pr.ReadColumnByIndexWithContext(ctx, 0, 1); return err }},
+		{name: "bloom filter", run: func() error { _, err := pr.BloomFilterCheckWithContext(ctx, "", 0, nil); return err }},
+		{name: "column index", run: func() error { _, err := pr.ReadColumnIndexWithContext(ctx, 0, 0); return err }},
+		{name: "offset index", run: func() error { _, err := pr.ReadOffsetIndexWithContext(ctx, 0, 0); return err }},
+		{name: "all page headers", run: func() error { _, err := pr.GetAllPageHeadersWithContext(ctx, 0, 0); return err }},
+		{name: "first page header", run: func() error { _, err := pr.GetFirstDataPageHeaderWithContext(ctx, 0, 0); return err }},
+		{name: "dictionary values", run: func() error { _, err := pr.ReadDictionaryPageValuesWithContext(ctx, 0, 0, 0); return err }},
+		{name: "column dictionary values", run: func() error { _, err := pr.ReadDictionaryPageValuesInColumnWithContext(ctx, 0, 0); return err }},
+		{name: "reset", run: func() error { return pr.ResetWithContext(ctx) }},
+		{name: "stop", run: func() error { return pr.ReadStopWithContext(ctx) }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.ErrorIs(t, tt.run(), context.Canceled)
+		})
+	}
+
+	ctx = nil
+	for _, tt := range tests {
+		t.Run("nil/"+tt.name, func(t *testing.T) {
+			require.ErrorContains(t, tt.run(), "context is nil")
+		})
+	}
+}

--- a/reader/encryption.go
+++ b/reader/encryption.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hangxie/parquet-go/v3/internal/encryption"
 	"github.com/hangxie/parquet-go/v3/internal/layout"
 	"github.com/hangxie/parquet-go/v3/parquet"
+	"github.com/hangxie/parquet-go/v3/source"
 )
 
 // ErrColumnKeyRequired reports an encrypted column without a direct,
@@ -23,14 +24,14 @@ var ErrColumnKeyRequired = errors.New("decryption key required")
 
 func (pr *ParquetReader) readEncryptedFooter(size uint32) error {
 	section := make([]byte, size)
-	if _, err := pr.PFile.Seek(-int64(8+size), io.SeekEnd); err != nil {
+	if _, err := source.SeekWithContext(pr.context(), pr.PFile, -int64(8+size), io.SeekEnd); err != nil {
 		return fmt.Errorf("seek to encrypted footer section: %w", err)
 	}
-	if _, err := io.ReadFull(pr.PFile, section); err != nil {
+	if _, err := source.ReadFullWithContext(pr.context(), pr.PFile, section); err != nil {
 		return fmt.Errorf("read encrypted footer section: %w", err)
 	}
 
-	fileCrypto, consumed, err := readFileCryptoMetaData(section)
+	fileCrypto, consumed, err := readFileCryptoMetaData(pr.context(), section)
 	if err != nil {
 		return fmt.Errorf("read file crypto metadata: %w", err)
 	}
@@ -56,7 +57,7 @@ func (pr *ParquetReader) readEncryptedFooter(size uint32) error {
 		return fmt.Errorf("decrypt footer: %w", err)
 	}
 
-	footer, err := readFileMetaDataFromBytes(footerBytes)
+	footer, err := readFileMetaDataFromBytes(pr.context(), footerBytes)
 	if err != nil {
 		return fmt.Errorf("read decrypted footer: %w", err)
 	}
@@ -65,24 +66,24 @@ func (pr *ParquetReader) readEncryptedFooter(size uint32) error {
 	return nil
 }
 
-func readFileCryptoMetaData(buf []byte) (*parquet.FileCryptoMetaData, int, error) {
+func readFileCryptoMetaData(ctx context.Context, buf []byte) (*parquet.FileCryptoMetaData, int, error) {
 	mem := thrift.NewTMemoryBufferLen(len(buf))
 	if _, err := mem.Write(buf); err != nil {
 		return nil, 0, fmt.Errorf("buffer file crypto metadata: %w", err)
 	}
 	protocol := thrift.NewTCompactProtocolConf(mem, &thrift.TConfiguration{})
 	meta := parquet.NewFileCryptoMetaData()
-	if err := meta.Read(context.TODO(), protocol); err != nil {
+	if err := meta.Read(ctx, protocol); err != nil {
 		return nil, 0, fmt.Errorf("decode file crypto metadata: %w", err)
 	}
 	remaining := int(mem.RemainingBytes())
 	return meta, len(buf) - remaining, nil
 }
 
-func readFileMetaDataFromBytes(buf []byte) (*parquet.FileMetaData, error) {
+func readFileMetaDataFromBytes(ctx context.Context, buf []byte) (*parquet.FileMetaData, error) {
 	footer := parquet.NewFileMetaData()
 	protocol := thrift.NewTCompactProtocolConf(thrift.NewTBufferedTransport(thrift.NewStreamTransportR(bytes.NewReader(buf)), len(buf)), &thrift.TConfiguration{})
-	if err := footer.Read(context.TODO(), protocol); err != nil {
+	if err := footer.Read(ctx, protocol); err != nil {
 		return nil, fmt.Errorf("decode file metadata: %w", err)
 	}
 	return footer, nil
@@ -94,7 +95,7 @@ func (pr *ParquetReader) verifyPlaintextFooter(section []byte) error {
 	}
 	footerBytes := section[:len(section)-28]
 	signature := section[len(section)-28:]
-	footer, err := readFileMetaDataFromBytes(footerBytes)
+	footer, err := readFileMetaDataFromBytes(pr.context(), footerBytes)
 	if err != nil {
 		return fmt.Errorf("read signed plaintext footer: %w", err)
 	}
@@ -123,10 +124,10 @@ func (pr *ParquetReader) verifyPlaintextFooter(section []byte) error {
 	return nil
 }
 
-func readColumnMetaDataFromBytes(buf []byte) (*parquet.ColumnMetaData, error) {
+func readColumnMetaDataFromBytes(ctx context.Context, buf []byte) (*parquet.ColumnMetaData, error) {
 	meta := parquet.NewColumnMetaData()
 	protocol := thrift.NewTCompactProtocolConf(thrift.NewStreamTransportR(bytes.NewReader(buf)), &thrift.TConfiguration{})
-	if err := meta.Read(context.TODO(), protocol); err != nil {
+	if err := meta.Read(ctx, protocol); err != nil {
 		return nil, fmt.Errorf("decode column metadata: %w", err)
 	}
 	return meta, nil
@@ -289,7 +290,7 @@ func (pr *ParquetReader) decryptEncryptedColumnMetadataChunk(chunk *parquet.Colu
 	if err != nil {
 		return fmt.Errorf("row group %d column %d: decrypt: %w", rowGroupIndex, columnOrdinal, err)
 	}
-	meta, err := readColumnMetaDataFromBytes(plain)
+	meta, err := readColumnMetaDataFromBytes(pr.context(), plain)
 	if err != nil {
 		return fmt.Errorf("row group %d column %d: read metadata: %w", rowGroupIndex, columnOrdinal, err)
 	}

--- a/reader/encryption_test.go
+++ b/reader/encryption_test.go
@@ -1205,7 +1205,7 @@ func TestReadPageHeaderEncryptedErrors(t *testing.T) {
 
 	t.Run("read module length fails", func(t *testing.T) {
 		t.Parallel()
-		_, _, err := readPageHeader(bytes.NewReader(nil), 0, decryptor)
+		_, _, err := readPageHeader(context.Background(), bytes.NewReader(nil), 0, decryptor)
 		require.ErrorContains(t, err, "read encrypted page header module")
 	})
 
@@ -1225,7 +1225,7 @@ func TestReadPageHeaderEncryptedErrors(t *testing.T) {
 		encoded, err := encryption.EncodeModule(mod)
 		require.NoError(t, err)
 
-		_, _, err = readPageHeader(bytes.NewReader(encoded), 0, decryptor)
+		_, _, err = readPageHeader(context.Background(), bytes.NewReader(encoded), 0, decryptor)
 		require.ErrorContains(t, err, "decrypt page header")
 	})
 }
@@ -1267,6 +1267,7 @@ func buildEncryptedInspectionFile(t *testing.T, footerKey, nameKey []byte, algoO
 	t.Helper()
 
 	var out bytes.Buffer
+	//nolint:staticcheck
 	pw, err := writer.NewParquetWriter(
 		writerfile.NewWriterFile(&out),
 		new(encryptedReaderRecord),
@@ -1283,12 +1284,19 @@ func buildEncryptedInspectionFile(t *testing.T, footerKey, nameKey []byte, algoO
 	require.NoError(t, err)
 	// Small page size + multiple unique names ensures the dictionary is written
 	// and we get more than one data page after it.
+	//nolint:staticcheck
 	require.NoError(t, pw.Write(encryptedReaderRecord{ID: 1, Name: "alpha"}))
+	//nolint:staticcheck
 	require.NoError(t, pw.Write(encryptedReaderRecord{ID: 2, Name: "beta"}))
+	//nolint:staticcheck
 	require.NoError(t, pw.Write(encryptedReaderRecord{ID: 3, Name: "gamma"}))
+	//nolint:staticcheck
 	require.NoError(t, pw.Write(encryptedReaderRecord{ID: 4, Name: "alpha"}))
+	//nolint:staticcheck
 	require.NoError(t, pw.Write(encryptedReaderRecord{ID: 5, Name: "beta"}))
+	//nolint:staticcheck
 	require.NoError(t, pw.Write(encryptedReaderRecord{ID: 6, Name: "gamma"}))
+	//nolint:staticcheck
 	require.NoError(t, pw.WriteStop())
 	return out.Bytes()
 }
@@ -1933,6 +1941,7 @@ func buildPlaintextFooterEncryptedColumnData(t *testing.T, footerKey, nameKey []
 	t.Helper()
 
 	var out bytes.Buffer
+	//nolint:staticcheck
 	pw, err := writer.NewParquetWriter(
 		writerfile.NewWriterFile(&out),
 		new(encryptedReaderRecord),
@@ -1947,8 +1956,11 @@ func buildPlaintextFooterEncryptedColumnData(t *testing.T, footerKey, nameKey []
 		writer.WithAADFileUnique([]byte("reader-test-001")),
 	)
 	require.NoError(t, err)
+	//nolint:staticcheck
 	require.NoError(t, pw.Write(encryptedReaderRecord{ID: 1, Name: "alpha"}))
+	//nolint:staticcheck
 	require.NoError(t, pw.Write(encryptedReaderRecord{ID: 2, Name: "beta"}))
+	//nolint:staticcheck
 	require.NoError(t, pw.WriteStop())
 	return out.Bytes()
 }
@@ -1957,6 +1969,7 @@ func buildMixedPlaintextFooterSuppliedAADData(t *testing.T, footerKey, nameKey, 
 	t.Helper()
 
 	var out bytes.Buffer
+	//nolint:staticcheck
 	pw, err := writer.NewParquetWriter(
 		writerfile.NewWriterFile(&out),
 		new(encryptedReaderRecord),
@@ -1972,8 +1985,11 @@ func buildMixedPlaintextFooterSuppliedAADData(t *testing.T, footerKey, nameKey, 
 		writer.WithAADFileUnique([]byte("reader-test-002")),
 	)
 	require.NoError(t, err)
+	//nolint:staticcheck
 	require.NoError(t, pw.Write(encryptedReaderRecord{ID: 1, Name: "alpha"}))
+	//nolint:staticcheck
 	require.NoError(t, pw.Write(encryptedReaderRecord{ID: 2, Name: "beta"}))
+	//nolint:staticcheck
 	require.NoError(t, pw.WriteStop())
 	return out.Bytes()
 }

--- a/reader/footer.go
+++ b/reader/footer.go
@@ -48,11 +48,11 @@ func cloneFileMetaData(footer *parquet.FileMetaData) (*parquet.FileMetaData, err
 	}
 	ts := thrift.NewTSerializer()
 	ts.Protocol = thrift.NewTCompactProtocolFactoryConf(&thrift.TConfiguration{}).GetProtocol(ts.Transport)
-	buf, err := ts.Write(context.TODO(), footer)
+	buf, err := ts.Write(context.Background(), footer)
 	if err != nil {
 		return nil, fmt.Errorf("encode file metadata: %w", err)
 	}
-	return readFileMetaDataFromBytes(buf)
+	return readFileMetaDataFromBytes(context.Background(), buf)
 }
 
 func renameFooterSchema(sh *schema.SchemaHandler, footer *parquet.FileMetaData, caseInsensitive bool) {

--- a/reader/footer_test.go
+++ b/reader/footer_test.go
@@ -228,9 +228,12 @@ func writeFooterRenamedColumnParquet(t *testing.T) []byte {
 
 	var buf bytes.Buffer
 	fw := writerfile.NewWriterFile(&buf)
+	//nolint:staticcheck
 	pw, err := writer.NewParquetWriter(fw, new(footerRenamedColumnRecord), writer.WithNP(1))
 	require.NoError(t, err)
+	//nolint:staticcheck
 	require.NoError(t, pw.Write(footerRenamedColumnRecord{ColL1: "value"}))
+	//nolint:staticcheck
 	require.NoError(t, pw.WriteStop())
 
 	return buf.Bytes()

--- a/reader/index.go
+++ b/reader/index.go
@@ -15,7 +15,17 @@ import (
 
 // ReadColumnIndex reads the column index for a row-group column. It returns nil
 // when the column chunk does not have a column index.
+//
+// Deprecated: use ReadColumnIndexWithContext.
 func (pr *ParquetReader) ReadColumnIndex(rowGroupIndex, columnIndex int) (*parquet.ColumnIndex, error) {
+	return pr.ReadColumnIndexWithContext(pr.defaultContext(), rowGroupIndex, columnIndex)
+}
+
+// ReadColumnIndexWithContext reads a column index using ctx.
+func (pr *ParquetReader) ReadColumnIndexWithContext(ctx context.Context, rowGroupIndex, columnIndex int) (*parquet.ColumnIndex, error) {
+	if err := pr.setContext(ctx); err != nil {
+		return nil, err
+	}
 	column, rowGroupOrdinal, columnOrdinal, err := pr.indexColumn(rowGroupIndex, columnIndex)
 	if err != nil {
 		return nil, fmt.Errorf("locate column for column index: %w", err)
@@ -29,7 +39,7 @@ func (pr *ParquetReader) ReadColumnIndex(rowGroupIndex, columnIndex int) (*parqu
 		return nil, fmt.Errorf("read column index module: %w", err)
 	}
 	index := parquet.NewColumnIndex()
-	if err := readCompactThrift(buf, index); err != nil {
+	if err := readCompactThrift(ctx, buf, index); err != nil {
 		return nil, fmt.Errorf("read column index: %w", err)
 	}
 	return index, nil
@@ -37,7 +47,17 @@ func (pr *ParquetReader) ReadColumnIndex(rowGroupIndex, columnIndex int) (*parqu
 
 // ReadOffsetIndex reads the offset index for a row-group column. It returns nil
 // when the column chunk does not have an offset index.
+//
+// Deprecated: use ReadOffsetIndexWithContext.
 func (pr *ParquetReader) ReadOffsetIndex(rowGroupIndex, columnIndex int) (*parquet.OffsetIndex, error) {
+	return pr.ReadOffsetIndexWithContext(pr.defaultContext(), rowGroupIndex, columnIndex)
+}
+
+// ReadOffsetIndexWithContext reads an offset index using ctx.
+func (pr *ParquetReader) ReadOffsetIndexWithContext(ctx context.Context, rowGroupIndex, columnIndex int) (*parquet.OffsetIndex, error) {
+	if err := pr.setContext(ctx); err != nil {
+		return nil, err
+	}
 	column, rowGroupOrdinal, columnOrdinal, err := pr.indexColumn(rowGroupIndex, columnIndex)
 	if err != nil {
 		return nil, fmt.Errorf("locate column for offset index: %w", err)
@@ -51,7 +71,7 @@ func (pr *ParquetReader) ReadOffsetIndex(rowGroupIndex, columnIndex int) (*parqu
 		return nil, fmt.Errorf("read offset index module: %w", err)
 	}
 	index := parquet.NewOffsetIndex()
-	if err := readCompactThrift(buf, index); err != nil {
+	if err := readCompactThrift(ctx, buf, index); err != nil {
 		return nil, fmt.Errorf("read offset index: %w", err)
 	}
 	return index, nil
@@ -83,14 +103,15 @@ func (pr *ParquetReader) readIndexModule(column *parquet.ColumnChunk, rowGroupOr
 	if pr.PFile == nil {
 		return nil, fmt.Errorf("file reader is nil")
 	}
-	pf, err := pr.PFile.Clone()
+	pf, err := source.CloneWithContext(pr.context(), pr.PFile)
 	if err != nil {
 		return nil, fmt.Errorf("clone file reader: %w", err)
 	}
-	defer func() { _ = pf.Close() }()
+	defer func() { _ = source.CloseWithContext(pr.context(), pf) }()
+	contextFile := source.ReadSeekerWithContext{Ctx: pr.context(), ReadSeeker: pf}
 
 	if column.GetCryptoMetadata() == nil {
-		return readPlainIndexModule(pf, offset, length)
+		return readPlainIndexModule(contextFile, offset, length)
 	}
 
 	algorithm := pr.encryptionAlgorithm()
@@ -105,10 +126,10 @@ func (pr *ParquetReader) readIndexModule(column *parquet.ColumnChunk, rowGroupOr
 	if err != nil {
 		return nil, fmt.Errorf("resolve column key: %w", err)
 	}
-	if _, err := pf.Seek(offset, io.SeekStart); err != nil {
+	if _, err := contextFile.Seek(offset, io.SeekStart); err != nil {
 		return nil, fmt.Errorf("seek to index offset %d: %w", offset, err)
 	}
-	module, err := encryption.ReadModule(pf, int64(length))
+	module, err := encryption.ReadModule(contextFile, int64(length))
 	if err != nil {
 		return nil, fmt.Errorf("read encrypted index module: %w", err)
 	}
@@ -120,7 +141,7 @@ func (pr *ParquetReader) readIndexModule(column *parquet.ColumnChunk, rowGroupOr
 	return plain, nil
 }
 
-func readPlainIndexModule(pf source.ParquetFileReader, offset int64, length int32) ([]byte, error) {
+func readPlainIndexModule(pf io.ReadSeeker, offset int64, length int32) ([]byte, error) {
 	if length < 0 {
 		return nil, fmt.Errorf("negative index length: %d", length)
 	}
@@ -138,7 +159,7 @@ type thriftReadable interface {
 	Read(context.Context, thrift.TProtocol) error
 }
 
-func readCompactThrift(buf []byte, v thriftReadable) error {
+func readCompactThrift(ctx context.Context, buf []byte, v thriftReadable) error {
 	protocol := thrift.NewTCompactProtocolConf(thrift.NewStreamTransportR(bytes.NewReader(buf)), &thrift.TConfiguration{})
-	return v.Read(context.Background(), protocol)
+	return v.Read(ctx, protocol)
 }

--- a/reader/lifecycle.go
+++ b/reader/lifecycle.go
@@ -1,0 +1,80 @@
+package reader
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/hangxie/parquet-go/v3/source"
+)
+
+// GetNumRows returns the number of rows declared by the file footer.
+func (pr *ParquetReader) GetNumRows() int64 {
+	return pr.Footer.GetNumRows()
+}
+
+// Reset closes and recreates all column buffers, allowing the file to be
+// re-read from the beginning without creating a new reader.
+//
+// Deprecated: use ResetWithContext.
+func (pr *ParquetReader) Reset() error {
+	return pr.ResetWithContext(pr.defaultContext())
+}
+
+// ResetWithContext closes and recreates column buffers using ctx. Cancellation
+// is never allowed to interrupt the close step, but a cancellation that occurs
+// during closing is still returned together with the close errors.
+func (pr *ParquetReader) ResetWithContext(ctx context.Context) error {
+	if ctx == nil {
+		return fmt.Errorf("context is nil")
+	}
+	var errs []error
+	for pathStr, cb := range pr.ColumnBuffers {
+		if cb == nil || cb.PFile == nil {
+			continue
+		}
+		if err := source.CloseWithContext(ctx, cb.PFile); err != nil {
+			errs = append(errs, fmt.Errorf("close column buffer for path %s: %w", pathStr, err))
+		}
+	}
+	if err := errors.Join(append(errs, ctx.Err())...); err != nil {
+		return err
+	}
+	if err := pr.setContext(ctx); err != nil {
+		return err
+	}
+	for pathStr := range pr.ColumnBuffers {
+		newCB, err := pr.newColumnBuffer(pathStr)
+		if err != nil {
+			return fmt.Errorf("recreate column buffer for %s: %w", pathStr, err)
+		}
+		pr.ColumnBuffers[pathStr] = newCB
+	}
+	return nil
+}
+
+// ReadStop closes all column buffer file handles.
+//
+// Deprecated: use ReadStopWithContext.
+func (pr *ParquetReader) ReadStop() error {
+	return pr.ReadStopWithContext(pr.defaultContext())
+}
+
+// ReadStopWithContext closes all column-buffer file handles using ctx.
+// Cancellation is never allowed to interrupt closing, but a cancellation that
+// occurs during closing is still returned together with the close errors.
+func (pr *ParquetReader) ReadStopWithContext(ctx context.Context) error {
+	if ctx == nil {
+		return fmt.Errorf("context is nil")
+	}
+	var errs []error
+	for pathStr, cb := range pr.ColumnBuffers {
+		if cb == nil || cb.PFile == nil {
+			continue
+		}
+		if err := source.CloseWithContext(ctx, cb.PFile); err != nil {
+			errs = append(errs, fmt.Errorf("close column buffer for path %s: %w", pathStr, err))
+		}
+	}
+	return errors.Join(append(errs, ctx.Err())...)
+}

--- a/reader/lifecycle_test.go
+++ b/reader/lifecycle_test.go
@@ -1,0 +1,81 @@
+package reader
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hangxie/parquet-go/v3/source"
+)
+
+type closeErrorReader struct{}
+
+func (closeErrorReader) Read([]byte) (int, error) { return 0, io.EOF }
+
+func (closeErrorReader) Seek(int64, int) (int64, error) { return 0, nil }
+
+func (closeErrorReader) Close() error { return io.ErrClosedPipe }
+
+func (r closeErrorReader) Open(string) (source.ParquetFileReader, error) { return r, nil }
+
+func (r closeErrorReader) Clone() (source.ParquetFileReader, error) { return r, nil }
+
+type closeTrackingFile struct {
+	closeErrorReader
+	closed bool
+}
+
+func (f *closeTrackingFile) Close() error {
+	f.closed = true
+	return nil
+}
+
+func TestLifecycleWithContextCanceledClosesBuffers(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(*ParquetReader, context.Context) error
+	}{
+		{name: "reset", run: func(pr *ParquetReader, ctx context.Context) error { return pr.ResetWithContext(ctx) }},
+		{name: "stop", run: func(pr *ParquetReader, ctx context.Context) error { return pr.ReadStopWithContext(ctx) }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+			files := []*closeTrackingFile{{}, {}}
+			pr := &ParquetReader{ColumnBuffers: map[string]*ColumnBufferType{
+				"first":  {PFile: files[0]},
+				"second": {PFile: files[1]},
+			}}
+			require.ErrorIs(t, tt.run(pr, ctx), context.Canceled)
+			for _, file := range files {
+				require.True(t, file.closed)
+			}
+		})
+	}
+}
+
+func TestLifecycleWithContextCloseErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(*ParquetReader) error
+	}{
+		{name: "reset", run: func(pr *ParquetReader) error { return pr.ResetWithContext(context.Background()) }},
+		{name: "stop", run: func(pr *ParquetReader) error { return pr.ReadStopWithContext(context.Background()) }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pr := &ParquetReader{ColumnBuffers: map[string]*ColumnBufferType{
+				"column": {PFile: closeErrorReader{}},
+			}}
+			err := tt.run(pr)
+			require.Error(t, err)
+			require.True(t, errors.Is(err, io.ErrClosedPipe))
+		})
+	}
+}

--- a/reader/page.go
+++ b/reader/page.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hangxie/parquet-go/v3/internal/encryption"
 	"github.com/hangxie/parquet-go/v3/internal/layout"
 	"github.com/hangxie/parquet-go/v3/parquet"
+	"github.com/hangxie/parquet-go/v3/source"
 )
 
 // PageHeaderInfo contains metadata about a page extracted from its header
@@ -86,7 +87,7 @@ func (p *positionTracker) Open() error {
 // decrypted in place. The returned headerSize is the number of bytes consumed
 // on disk by the header (including the 4-byte length prefix for encrypted
 // modules).
-func readPageHeader(pFile io.ReadSeeker, offset int64, decryptor *layout.PageDecryptor) (*parquet.PageHeader, int64, error) {
+func readPageHeader(ctx context.Context, pFile io.ReadSeeker, offset int64, decryptor *layout.PageDecryptor) (*parquet.PageHeader, int64, error) {
 	if _, err := pFile.Seek(offset, io.SeekStart); err != nil {
 		return nil, 0, fmt.Errorf("seek to page: %w", err)
 	}
@@ -96,7 +97,7 @@ func readPageHeader(pFile io.ReadSeeker, offset int64, decryptor *layout.PageDec
 		proto := thrift.NewTCompactProtocolConf(trackingTransport, nil)
 
 		pageHeader := parquet.NewPageHeader()
-		if err := pageHeader.Read(context.Background(), proto); err != nil {
+		if err := pageHeader.Read(ctx, proto); err != nil {
 			return nil, 0, fmt.Errorf("decode page header: %w", err)
 		}
 
@@ -111,7 +112,7 @@ func readPageHeader(pFile io.ReadSeeker, offset int64, decryptor *layout.PageDec
 	if err != nil {
 		return nil, 0, fmt.Errorf("read encrypted page header module: %w", err)
 	}
-	pageHeader, err := layout.DecryptPageHeader(module, decryptor)
+	pageHeader, err := layout.DecryptPageHeaderWithContext(ctx, module, decryptor)
 	if err != nil {
 		return nil, 0, fmt.Errorf("decrypt page header: %w", err)
 	}
@@ -204,7 +205,7 @@ func ExtractPageHeaderInfo(pageHeader *parquet.PageHeader, offset int64, index i
 // decryptor is non-nil page headers are decrypted and body lengths are read
 // from the encrypted module prefix. The decryptor's PageOrdinal is advanced
 // after each data page so the next header's AAD matches the file layout.
-func readAllPageHeaders(pFile io.ReadSeeker, columnChunk *parquet.ColumnChunk, decryptor *layout.PageDecryptor) ([]PageHeaderInfo, error) {
+func readAllPageHeaders(ctx context.Context, pFile io.ReadSeeker, columnChunk *parquet.ColumnChunk, decryptor *layout.PageDecryptor) ([]PageHeaderInfo, error) {
 	meta := columnChunk.MetaData
 	if meta == nil {
 		return nil, fmt.Errorf("column chunk metadata is nil")
@@ -223,7 +224,7 @@ func readAllPageHeaders(pFile io.ReadSeeker, columnChunk *parquet.ColumnChunk, d
 
 	// Read pages until we've read all values
 	for totalValuesRead < meta.NumValues {
-		pageHeader, headerSize, err := readPageHeader(pFile, currentOffset, decryptor)
+		pageHeader, headerSize, err := readPageHeader(ctx, pFile, currentOffset, decryptor)
 		if err != nil {
 			return nil, fmt.Errorf("read page header at offset %d: %w", currentOffset, err)
 		}
@@ -261,7 +262,7 @@ func readAllPageHeaders(pFile io.ReadSeeker, columnChunk *parquet.ColumnChunk, d
 // first data page header. When decryptor is non-nil pages are decrypted as
 // they are walked; dictionary headers occupy ordinal 0 so the data-page
 // ordinal does not need to advance before the first data page.
-func readFirstDataPageHeader(pFile io.ReadSeeker, columnChunk *parquet.ColumnChunk, decryptor *layout.PageDecryptor) (*PageHeaderInfo, error) {
+func readFirstDataPageHeader(ctx context.Context, pFile io.ReadSeeker, columnChunk *parquet.ColumnChunk, decryptor *layout.PageDecryptor) (*PageHeaderInfo, error) {
 	meta := columnChunk.MetaData
 	if meta == nil {
 		return nil, fmt.Errorf("column chunk metadata is nil")
@@ -276,7 +277,7 @@ func readFirstDataPageHeader(pFile io.ReadSeeker, columnChunk *parquet.ColumnChu
 
 	// Read page headers sequentially until we find the first data page
 	for {
-		pageHeader, headerSize, err := readPageHeader(pFile, offset, decryptor)
+		pageHeader, headerSize, err := readPageHeader(ctx, pFile, offset, decryptor)
 		if err != nil {
 			return nil, fmt.Errorf("read page header at offset %d: %w", offset, err)
 		}
@@ -321,8 +322,12 @@ func ReadPageData(pFile io.ReadSeeker, offset int64, pageHeader *parquet.PageHea
 	if opts != nil {
 		opt = *opts
 	}
+	ctx := opt.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	// Re-read the header to get exact header size
-	_, headerSize, err := readPageHeader(pFile, offset, nil)
+	_, headerSize, err := readPageHeader(ctx, pFile, offset, nil)
 	if err != nil {
 		return nil, fmt.Errorf("read page header: %w", err)
 	}
@@ -409,7 +414,17 @@ func DecodeDictionaryPage(data []byte, pageHeader *parquet.PageHeader, physicalT
 // column is encrypted the reader's configured keys are used to decrypt page
 // headers transparently. Missing keys surface the standard "decryption key
 // required for column" error.
+//
+// Deprecated: use GetAllPageHeadersWithContext.
 func (pr *ParquetReader) GetAllPageHeaders(rgIndex, colIndex int) ([]PageHeaderInfo, error) {
+	return pr.GetAllPageHeadersWithContext(pr.defaultContext(), rgIndex, colIndex)
+}
+
+// GetAllPageHeadersWithContext returns metadata for all pages using ctx.
+func (pr *ParquetReader) GetAllPageHeadersWithContext(ctx context.Context, rgIndex, colIndex int) ([]PageHeaderInfo, error) {
+	if err := pr.setContext(ctx); err != nil {
+		return nil, err
+	}
 	if rgIndex < 0 || rgIndex >= len(pr.Footer.RowGroups) {
 		return nil, fmt.Errorf("invalid row group index: %d (valid range: 0-%d)", rgIndex, len(pr.Footer.RowGroups)-1)
 	}
@@ -424,13 +439,23 @@ func (pr *ParquetReader) GetAllPageHeaders(rgIndex, colIndex int) ([]PageHeaderI
 	if err != nil {
 		return nil, err
 	}
-	return readAllPageHeaders(pr.PFile, column, decryptor)
+	return readAllPageHeaders(ctx, source.ReadSeekerWithContext{Ctx: ctx, ReadSeeker: pr.PFile}, column, decryptor)
 }
 
 // GetFirstDataPageHeader returns metadata for the first data page in a column
 // chunk. When the column is encrypted the reader's configured keys are used to
 // decrypt page headers transparently.
+//
+// Deprecated: use GetFirstDataPageHeaderWithContext.
 func (pr *ParquetReader) GetFirstDataPageHeader(rgIndex, colIndex int) (*PageHeaderInfo, error) {
+	return pr.GetFirstDataPageHeaderWithContext(pr.defaultContext(), rgIndex, colIndex)
+}
+
+// GetFirstDataPageHeaderWithContext returns first-page metadata using ctx.
+func (pr *ParquetReader) GetFirstDataPageHeaderWithContext(ctx context.Context, rgIndex, colIndex int) (*PageHeaderInfo, error) {
+	if err := pr.setContext(ctx); err != nil {
+		return nil, err
+	}
 	if rgIndex < 0 || rgIndex >= len(pr.Footer.RowGroups) {
 		return nil, fmt.Errorf("invalid row group index: %d (valid range: 0-%d)", rgIndex, len(pr.Footer.RowGroups)-1)
 	}
@@ -445,14 +470,24 @@ func (pr *ParquetReader) GetFirstDataPageHeader(rgIndex, colIndex int) (*PageHea
 	if err != nil {
 		return nil, err
 	}
-	return readFirstDataPageHeader(pr.PFile, column, decryptor)
+	return readFirstDataPageHeader(ctx, source.ReadSeekerWithContext{Ctx: ctx, ReadSeeker: pr.PFile}, column, decryptor)
 }
 
 // ReadDictionaryPageValues reads and decodes dictionary page values at the
 // given offset. This offset-based form is plaintext-only because the offset
 // cannot identify the column whose key would be required to decrypt the page;
 // use ReadDictionaryPageValuesInColumn for encrypted columns.
+//
+// Deprecated: use ReadDictionaryPageValuesWithContext.
 func (pr *ParquetReader) ReadDictionaryPageValues(offset int64, codec parquet.CompressionCodec, physicalType parquet.Type) ([]interface{}, error) {
+	return pr.ReadDictionaryPageValuesWithContext(pr.defaultContext(), offset, codec, physicalType)
+}
+
+// ReadDictionaryPageValuesWithContext reads dictionary-page values using ctx.
+func (pr *ParquetReader) ReadDictionaryPageValuesWithContext(ctx context.Context, offset int64, codec parquet.CompressionCodec, physicalType parquet.Type) ([]interface{}, error) {
+	if err := pr.setContext(ctx); err != nil {
+		return nil, err
+	}
 	encrypted, err := pr.pageOffsetEncrypted(offset)
 	if err != nil {
 		return nil, err
@@ -462,7 +497,8 @@ func (pr *ParquetReader) ReadDictionaryPageValues(offset int64, codec parquet.Co
 	}
 
 	// Read page header at the offset
-	pageHeader, _, err := readPageHeader(pr.PFile, offset, nil)
+	contextFile := source.ReadSeekerWithContext{Ctx: ctx, ReadSeeker: pr.PFile}
+	pageHeader, _, err := readPageHeader(ctx, contextFile, offset, nil)
 	if err != nil {
 		return nil, fmt.Errorf("read page header: %w", err)
 	}
@@ -473,7 +509,7 @@ func (pr *ParquetReader) ReadDictionaryPageValues(offset int64, codec parquet.Co
 	}
 
 	// Read and decode the page data
-	data, err := ReadPageData(pr.PFile, offset, pageHeader, codec, &layout.PageReadOptions{CRCMode: pr.crcMode, MaxPageSize: layout.DefaultMaxPageSize})
+	data, err := ReadPageData(contextFile, offset, pageHeader, codec, &layout.PageReadOptions{Context: ctx, CRCMode: pr.crcMode, MaxPageSize: layout.DefaultMaxPageSize})
 	if err != nil {
 		return nil, fmt.Errorf("read page data: %w", err)
 	}
@@ -490,7 +526,17 @@ func (pr *ParquetReader) ReadDictionaryPageValues(offset int64, codec parquet.Co
 // for the dictionary page of the given column chunk. Offset, codec, and
 // physical type are derived from the column metadata, and encrypted columns
 // are decrypted transparently when the reader has the right keys.
+//
+// Deprecated: use ReadDictionaryPageValuesInColumnWithContext.
 func (pr *ParquetReader) ReadDictionaryPageValuesInColumn(rgIndex, colIndex int) ([]interface{}, error) {
+	return pr.ReadDictionaryPageValuesInColumnWithContext(pr.defaultContext(), rgIndex, colIndex)
+}
+
+// ReadDictionaryPageValuesInColumnWithContext reads column dictionary values using ctx.
+func (pr *ParquetReader) ReadDictionaryPageValuesInColumnWithContext(ctx context.Context, rgIndex, colIndex int) ([]interface{}, error) {
+	if err := pr.setContext(ctx); err != nil {
+		return nil, err
+	}
 	if rgIndex < 0 || rgIndex >= len(pr.Footer.RowGroups) {
 		return nil, fmt.Errorf("invalid row group index: %d (valid range: 0-%d)", rgIndex, len(pr.Footer.RowGroups)-1)
 	}
@@ -513,7 +559,8 @@ func (pr *ParquetReader) ReadDictionaryPageValuesInColumn(rgIndex, colIndex int)
 	}
 
 	offset := column.MetaData.GetDictionaryPageOffset()
-	pageHeader, headerSize, err := readPageHeader(pr.PFile, offset, decryptor)
+	contextFile := source.ReadSeekerWithContext{Ctx: ctx, ReadSeeker: pr.PFile}
+	pageHeader, headerSize, err := readPageHeader(ctx, contextFile, offset, decryptor)
 	if err != nil {
 		return nil, fmt.Errorf("read page header: %w", err)
 	}
@@ -521,7 +568,7 @@ func (pr *ParquetReader) ReadDictionaryPageValuesInColumn(rgIndex, colIndex int)
 		return nil, fmt.Errorf("expected dictionary page but got %v", pageHeader.Type)
 	}
 
-	data, err := readPageBody(pr.PFile, offset+headerSize, pageHeader, column.MetaData.GetCodec(), pr.crcMode, decryptor)
+	data, err := readPageBody(contextFile, offset+headerSize, pageHeader, column.MetaData.GetCodec(), pr.crcMode, decryptor)
 	if err != nil {
 		return nil, fmt.Errorf("read page data: %w", err)
 	}

--- a/reader/page_test.go
+++ b/reader/page_test.go
@@ -2,6 +2,7 @@ package reader
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -278,8 +279,8 @@ func TestReadPageData_V2(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	pw, err := writer.NewParquetWriterFromWriter(
-		&buf, new(Record),
+	pw, err := writer.NewParquetWriterFromWriterWithContext(
+		context.Background(), &buf, new(Record),
 		writer.WithNP(1),
 		writer.WithDataPageVersion(2),
 		writer.WithCompressionCodec(parquet.CompressionCodec_SNAPPY),
@@ -288,9 +289,9 @@ func TestReadPageData_V2(t *testing.T) {
 
 	for i := range 100 {
 		s := fmt.Sprintf("name_%d", i)
-		require.NoError(t, pw.Write(Record{Name: &s}))
+		require.NoError(t, pw.WriteWithContext(context.Background(), Record{Name: &s}))
 	}
-	require.NoError(t, pw.WriteStop())
+	require.NoError(t, pw.WriteStopWithContext(context.Background()))
 
 	// Read back and verify ReadPageData handles V2 pages with level data
 	data := buf.Bytes()
@@ -1342,7 +1343,7 @@ func TestReadAllPageHeaders_NilMetadata(t *testing.T) {
 		MetaData: nil,
 	}
 
-	_, err := readAllPageHeaders(buf, cc, nil)
+	_, err := readAllPageHeaders(context.Background(), buf, cc, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "metadata is nil")
 }

--- a/reader/read_test.go
+++ b/reader/read_test.go
@@ -94,16 +94,19 @@ func TestParquetReader_ReadPartial_SiblingPrefix(t *testing.T) {
 
 	var buf bytes.Buffer
 	fw := writerfile.NewWriterFile(&buf)
+	//nolint:staticcheck
 	pw, err := writer.NewParquetWriter(fw, new(siblingRecord), writer.WithNP(1))
 	require.NoError(t, err)
 
 	const rows = 3
 	for i := range int64(rows) {
+		//nolint:staticcheck
 		require.NoError(t, pw.Write(siblingRecord{
 			Name:  &siblingInner{Value: i},
 			Name2: &siblingInner{Value: i + 100},
 		}))
 	}
+	//nolint:staticcheck
 	require.NoError(t, pw.WriteStop())
 
 	// Run multiple times: before the fix, map iteration order made the sibling
@@ -340,11 +343,14 @@ func roundTripComplexRows(t *testing.T, dataPageVersion int32) []rtComplexRow {
 	if dataPageVersion == 2 {
 		opts = append(opts, writer.WithDataPageVersion(2))
 	}
+	//nolint:staticcheck
 	pw, err := writer.NewParquetWriter(fw, new(rtComplexRow), opts...)
 	require.NoError(t, err)
 	for _, r := range in {
+		//nolint:staticcheck
 		require.NoError(t, pw.Write(r))
 	}
+	//nolint:staticcheck
 	require.NoError(t, pw.WriteStop())
 
 	fr := buffer.NewBufferReaderFromBytesNoAlloc(buf.Bytes())
@@ -392,10 +398,14 @@ func TestReadUnknownLogicalType(t *testing.T) {
 
 	var buf bytes.Buffer
 	fw := writerfile.NewWriterFile(&buf)
+	//nolint:staticcheck
 	pw, err := writer.NewParquetWriter(fw, new(Row), writer.WithNP(1))
 	require.NoError(t, err)
+	//nolint:staticcheck
 	require.NoError(t, pw.Write(Row{Name: "foo", NullCol: nil}))
+	//nolint:staticcheck
 	require.NoError(t, pw.Write(Row{Name: "bar", NullCol: nil}))
+	//nolint:staticcheck
 	require.NoError(t, pw.WriteStop())
 
 	fr := buffer.NewBufferReaderFromBytesNoAlloc(buf.Bytes())
@@ -423,10 +433,13 @@ func TestReadUnknownLogicalType_LooseRead(t *testing.T) {
 
 	var buf bytes.Buffer
 	fw := writerfile.NewWriterFile(&buf)
+	//nolint:staticcheck
 	pw, err := writer.NewParquetWriter(fw, new(WriterRow), writer.WithNP(1))
 	require.NoError(t, err)
 	val := int32(42)
+	//nolint:staticcheck
 	require.NoError(t, pw.Write(WriterRow{Name: "foo", NullCol: &val}))
+	//nolint:staticcheck
 	require.NoError(t, pw.WriteStop())
 
 	// Patch the footer: mark null_col as UNKNOWN logical type.
@@ -616,13 +629,16 @@ func TestNestedListWithEmptyStrings(t *testing.T) {
 			// Write to buffer
 			var buf bytes.Buffer
 			fw := writerfile.NewWriterFile(&buf)
+			//nolint:staticcheck
 			pw, err := writer.NewParquetWriter(fw, jsonSchema, writer.WithNP(1), writer.WithCompressionCodec(parquet.CompressionCodec_UNCOMPRESSED))
 			require.NoError(t, err)
 
 			for _, rec := range tc.records {
+				//nolint:staticcheck
 				err = pw.Write(rec)
 				require.NoError(t, err)
 			}
+			//nolint:staticcheck
 			err = pw.WriteStop()
 			require.NoError(t, err)
 
@@ -661,9 +677,12 @@ func TestGeospatialConfigRoundTrip(t *testing.T) {
 	// Write
 	var buf bytes.Buffer
 	fw := writerfile.NewWriterFile(&buf)
+	//nolint:staticcheck
 	pw, err := writer.NewParquetWriter(fw, new(GeoRow), writer.WithNP(1))
 	require.NoError(t, err)
+	//nolint:staticcheck
 	require.NoError(t, pw.Write(GeoRow{Geom: wkbPoint}))
+	//nolint:staticcheck
 	require.NoError(t, pw.WriteStop())
 	require.NoError(t, fw.Close())
 

--- a/reader/reader.go
+++ b/reader/reader.go
@@ -3,7 +3,6 @@ package reader
 import (
 	"context"
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"io"
 	"reflect"
@@ -51,6 +50,8 @@ type ParquetReader struct {
 	keyCache           sync.Map
 	footerMu           sync.Mutex
 	footerLoaded       bool
+	defaultCtx         context.Context
+	ctx                context.Context
 
 	// encryptedPageOffsets is populated once from the immutable footer and then
 	// treated as read-only. It tracks every per-column offset that belongs to an
@@ -66,15 +67,28 @@ type ParquetReader struct {
 }
 
 // NewParquetReader creates a parquet reader. obj is an object with schema tags or a JSON schema string.
+//
+// Deprecated: use NewParquetReaderWithContext.
 func NewParquetReader(pFile source.ParquetFileReader, obj any, opts ...ReaderOption) (*ParquetReader, error) {
+	return NewParquetReaderWithContext(context.Background(), pFile, obj, opts...)
+}
+
+// NewParquetReaderWithContext creates a parquet reader using ctx for footer,
+// schema, and column-buffer initialization.
+func NewParquetReaderWithContext(ctx context.Context, pFile source.ParquetFileReader, obj any, opts ...ReaderOption) (*ParquetReader, error) {
+	if ctx == nil {
+		return nil, fmt.Errorf("context is nil")
+	}
 	var err error
 	res := new(ParquetReader)
 	res.PFile = pFile
+	res.defaultCtx = ctx
+	res.ctx = ctx
 
 	if err = applyReaderDefaults(res, opts); err != nil {
 		return nil, fmt.Errorf("apply reader options: %w", err)
 	}
-	if err = res.ReadFooter(); err != nil {
+	if err = res.ReadFooterWithContext(ctx); err != nil {
 		return nil, fmt.Errorf("read footer: %w", err)
 	}
 	res.ColumnBuffers = make(map[string]*ColumnBufferType)
@@ -146,7 +160,7 @@ func (pr *ParquetReader) SetSchemaHandlerFromJSON(jsonSchema string) error {
 }
 
 func (pr *ParquetReader) newColumnBuffer(pathStr string) (*ColumnBufferType, error) {
-	cb, err := newColumnBuffer(pr.PFile, pr.Footer, pr.SchemaHandler, pathStr, &layout.PageReadOptions{CRCMode: pr.crcMode, MaxPageSize: layout.DefaultMaxPageSize}, pr.caseInsensitive)
+	cb, err := newColumnBuffer(pr.PFile, pr.Footer, pr.SchemaHandler, pathStr, &layout.PageReadOptions{Context: pr.context(), CRCMode: pr.crcMode, MaxPageSize: layout.DefaultMaxPageSize}, pr.caseInsensitive)
 	if err != nil {
 		return nil, fmt.Errorf("new column buffer for %s: %w", pathStr, err)
 	}
@@ -158,21 +172,27 @@ func (pr *ParquetReader) newColumnBuffer(pathStr string) (*ColumnBufferType, err
 	return cb, nil
 }
 
-func (pr *ParquetReader) GetNumRows() int64 {
-	return pr.Footer.GetNumRows()
+// Get the footer size
+//
+// Deprecated: use GetFooterSizeWithContext.
+func (pr *ParquetReader) GetFooterSize() (uint32, error) {
+	return pr.GetFooterSizeWithContext(pr.defaultContext())
 }
 
-// Get the footer size
-func (pr *ParquetReader) GetFooterSize() (uint32, error) {
+// GetFooterSizeWithContext returns the footer size using ctx.
+func (pr *ParquetReader) GetFooterSizeWithContext(ctx context.Context) (uint32, error) {
+	if err := pr.setContext(ctx); err != nil {
+		return 0, err
+	}
 	if pr.PFile == nil {
 		return 0, fmt.Errorf("PFile is nil")
 	}
 
 	buf := make([]byte, 4)
-	if _, err := pr.PFile.Seek(-8, io.SeekEnd); err != nil {
+	if _, err := source.SeekWithContext(pr.context(), pr.PFile, -8, io.SeekEnd); err != nil {
 		return 0, fmt.Errorf("seek to footer size: %w", err)
 	}
-	if _, err := io.ReadFull(pr.PFile, buf); err != nil {
+	if _, err := source.ReadFullWithContext(pr.context(), pr.PFile, buf); err != nil {
 		return 0, fmt.Errorf("read footer size: %w", err)
 	}
 	return binary.LittleEndian.Uint32(buf), nil
@@ -184,10 +204,10 @@ func (pr *ParquetReader) getFooterTail() (uint32, string, error) {
 	}
 
 	buf := make([]byte, 8)
-	if _, err := pr.PFile.Seek(-8, io.SeekEnd); err != nil {
+	if _, err := source.SeekWithContext(pr.context(), pr.PFile, -8, io.SeekEnd); err != nil {
 		return 0, "", fmt.Errorf("seek to footer tail: %w", err)
 	}
-	if _, err := io.ReadFull(pr.PFile, buf); err != nil {
+	if _, err := source.ReadFullWithContext(pr.context(), pr.PFile, buf); err != nil {
 		return 0, "", fmt.Errorf("read footer tail: %w", err)
 	}
 	return binary.LittleEndian.Uint32(buf[:4]), string(buf[4:]), nil
@@ -197,7 +217,17 @@ func (pr *ParquetReader) getFooterTail() (uint32, string, error) {
 //
 // After a successful read, the reader treats Footer as immutable. Repeated calls
 // return without reloading so internal caches remain tied to the same footer.
+//
+// Deprecated: use ReadFooterWithContext.
 func (pr *ParquetReader) ReadFooter() error {
+	return pr.ReadFooterWithContext(pr.defaultContext())
+}
+
+// ReadFooterWithContext reads and publishes the file footer once using ctx.
+func (pr *ParquetReader) ReadFooterWithContext(ctx context.Context) error {
+	if err := pr.setContext(ctx); err != nil {
+		return err
+	}
 	pr.footerMu.Lock()
 	defer pr.footerMu.Unlock()
 
@@ -227,24 +257,24 @@ func (pr *ParquetReader) ReadFooter() error {
 }
 
 func (pr *ParquetReader) readPlainFooter(size uint32) error {
-	if _, err := pr.PFile.Seek(-int64(8+size), io.SeekEnd); err != nil {
+	if _, err := source.SeekWithContext(pr.context(), pr.PFile, -int64(8+size), io.SeekEnd); err != nil {
 		return fmt.Errorf("seek to footer: %w", err)
 	}
 	pr.Footer = parquet.NewFileMetaData()
 	pf := thrift.NewTCompactProtocolFactoryConf(&thrift.TConfiguration{})
-	thriftReader := thrift.NewStreamTransportR(pr.PFile)
+	thriftReader := thrift.NewStreamTransportR(source.ReaderWithContext{Ctx: pr.context(), Reader: pr.PFile})
 	bufferReader := thrift.NewTBufferedTransport(thriftReader, int(size))
 	protocol := pf.GetProtocol(bufferReader)
-	if err := pr.Footer.Read(context.TODO(), protocol); err != nil {
+	if err := pr.Footer.Read(pr.context(), protocol); err != nil {
 		return fmt.Errorf("read footer: %w", err)
 	}
 
 	if pr.Footer.IsSetEncryptionAlgorithm() {
-		if _, err := pr.PFile.Seek(-int64(8+size), io.SeekEnd); err != nil {
+		if _, err := source.SeekWithContext(pr.context(), pr.PFile, -int64(8+size), io.SeekEnd); err != nil {
 			return fmt.Errorf("seek to plaintext footer section: %w", err)
 		}
 		section := make([]byte, size)
-		if _, err := io.ReadFull(pr.PFile, section); err != nil {
+		if _, err := source.ReadFullWithContext(pr.context(), pr.PFile, section); err != nil {
 			return fmt.Errorf("read plaintext footer section: %w", err)
 		}
 		if err := pr.verifyPlaintextFooter(section); err != nil {
@@ -255,12 +285,32 @@ func (pr *ParquetReader) readPlainFooter(size uint32) error {
 }
 
 // Read reads rows of the parquet file and unmarshals them into dst.
+//
+// Deprecated: use ReadWithContext.
 func (pr *ParquetReader) Read(dstInterface any) error {
+	return pr.ReadWithContext(pr.defaultContext(), dstInterface)
+}
+
+// ReadWithContext reads rows of the parquet file using ctx.
+func (pr *ParquetReader) ReadWithContext(ctx context.Context, dstInterface any) error {
+	if err := pr.setContext(ctx); err != nil {
+		return err
+	}
 	return pr.read(dstInterface, "")
 }
 
 // ReadByNumber reads up to maxReadNumber objects.
+//
+// Deprecated: use ReadByNumberWithContext.
 func (pr *ParquetReader) ReadByNumber(maxReadNumber int) ([]any, error) {
+	return pr.ReadByNumberWithContext(pr.defaultContext(), maxReadNumber)
+}
+
+// ReadByNumberWithContext reads up to maxReadNumber objects using ctx.
+func (pr *ParquetReader) ReadByNumberWithContext(ctx context.Context, maxReadNumber int) ([]any, error) {
+	if err := pr.setContext(ctx); err != nil {
+		return nil, err
+	}
 	if maxReadNumber < 0 {
 		return nil, fmt.Errorf("negative maxReadNumber: %d", maxReadNumber)
 	}
@@ -276,7 +326,7 @@ func (pr *ParquetReader) ReadByNumber(maxReadNumber int) ([]any, error) {
 	res := reflect.New(vs.Type())
 	res.Elem().Set(vs)
 
-	if err = pr.Read(res.Interface()); err != nil {
+	if err = pr.ReadWithContext(ctx, res.Interface()); err != nil {
 		return nil, fmt.Errorf("read by number: %w", err)
 	}
 
@@ -291,7 +341,17 @@ func (pr *ParquetReader) ReadByNumber(maxReadNumber int) ([]any, error) {
 // ReadPartial reads rows and unmarshals only the subtree rooted at prefixPath.
 // prefixPath components must be separated by common.ParGoPathDelimiter (build it
 // with common.PathToStr, e.g. common.PathToStr([]string{"parquet_go_root", "name"})).
+//
+// Deprecated: use ReadPartialWithContext.
 func (pr *ParquetReader) ReadPartial(dstInterface any, prefixPath string) error {
+	return pr.ReadPartialWithContext(pr.defaultContext(), dstInterface, prefixPath)
+}
+
+// ReadPartialWithContext reads a subtree rooted at prefixPath using ctx.
+func (pr *ParquetReader) ReadPartialWithContext(ctx context.Context, dstInterface any, prefixPath string) error {
+	if err := pr.setContext(ctx); err != nil {
+		return err
+	}
 	prefixPath, err := pr.SchemaHandler.ConvertToInPathStr(prefixPath)
 	if err != nil {
 		return fmt.Errorf("convert path: %w", err)
@@ -305,7 +365,17 @@ func (pr *ParquetReader) ReadPartial(dstInterface any, prefixPath string) error 
 // ReadPartialByNumber reads up to maxReadNumber partial objects rooted at prefixPath.
 // prefixPath components must be separated by common.ParGoPathDelimiter (build it
 // with common.PathToStr, e.g. common.PathToStr([]string{"parquet_go_root", "name"})).
+//
+// Deprecated: use ReadPartialByNumberWithContext.
 func (pr *ParquetReader) ReadPartialByNumber(maxReadNumber int, prefixPath string) ([]any, error) {
+	return pr.ReadPartialByNumberWithContext(pr.defaultContext(), maxReadNumber, prefixPath)
+}
+
+// ReadPartialByNumberWithContext reads up to maxReadNumber partial objects using ctx.
+func (pr *ParquetReader) ReadPartialByNumberWithContext(ctx context.Context, maxReadNumber int, prefixPath string) ([]any, error) {
+	if err := pr.setContext(ctx); err != nil {
+		return nil, err
+	}
 	if maxReadNumber < 0 {
 		return nil, fmt.Errorf("negative maxReadNumber: %d", maxReadNumber)
 	}
@@ -321,7 +391,7 @@ func (pr *ParquetReader) ReadPartialByNumber(maxReadNumber int, prefixPath strin
 	res := reflect.New(vs.Type())
 	res.Elem().Set(vs)
 
-	if err = pr.ReadPartial(res.Interface(), prefixPath); err != nil {
+	if err = pr.ReadPartialWithContext(ctx, res.Interface(), prefixPath); err != nil {
 		return nil, fmt.Errorf("read partial by number: %w", err)
 	}
 
@@ -385,6 +455,14 @@ func (pr *ParquetReader) fetchColumnData(num int, prefixPath string, tmap map[st
 	}
 	for key := range pr.ColumnBuffers {
 		if prefixPath == "" || common.IsChildPath(prefixPath, key) {
+			if err := pr.context().Err(); err != nil {
+				errMu.Lock()
+				if firstErr == nil {
+					firstErr = err
+				}
+				errMu.Unlock()
+				break
+			}
 			taskChan <- key
 		}
 	}
@@ -428,39 +506,4 @@ func (pr *ParquetReader) unmarshalToResult(num int, tmap map[string]*layout.Tabl
 		dstValue.Set(reflect.AppendSlice(dstValue, reflect.ValueOf(dst).Elem()))
 	}
 	return firstErr
-}
-
-// Reset closes and recreates all column buffers, allowing the file to be
-// re-read from the beginning without creating a new reader.
-func (pr *ParquetReader) Reset() error {
-	for _, cb := range pr.ColumnBuffers {
-		if cb == nil || cb.PFile == nil {
-			continue
-		}
-		if err := cb.PFile.Close(); err != nil {
-			return fmt.Errorf("close column buffer: %w", err)
-		}
-	}
-	for pathStr := range pr.ColumnBuffers {
-		newCB, err := pr.newColumnBuffer(pathStr)
-		if err != nil {
-			return fmt.Errorf("recreate column buffer for %s: %w", pathStr, err)
-		}
-		pr.ColumnBuffers[pathStr] = newCB
-	}
-	return nil
-}
-
-// ReadStop closes all column buffer file handles.
-func (pr *ParquetReader) ReadStop() error {
-	var errs []error
-	for pathStr, cb := range pr.ColumnBuffers {
-		if cb == nil || cb.PFile == nil {
-			continue
-		}
-		if err := cb.PFile.Close(); err != nil {
-			errs = append(errs, fmt.Errorf("close column buffer for path %s: %w", pathStr, err))
-		}
-	}
-	return errors.Join(errs...)
 }

--- a/reader/reader_fuzz_test.go
+++ b/reader/reader_fuzz_test.go
@@ -23,6 +23,7 @@ func validReaderSeed(tb testing.TB) []byte {
 	tb.Helper()
 	var buf bytes.Buffer
 	fw := writerfile.NewWriterFile(&buf)
+	//nolint:staticcheck
 	pw, err := writer.NewParquetWriter(fw, new(fuzzReaderRow), writer.WithNP(1))
 	if err != nil {
 		tb.Fatalf("new writer: %v", err)
@@ -33,10 +34,12 @@ func validReaderSeed(tb testing.TB) []byte {
 		{ID: 2, Name: "bob", Val: nil, Tags: []string{}},
 	}
 	for _, r := range rows {
+		//nolint:staticcheck
 		if err := pw.Write(r); err != nil {
 			tb.Fatalf("write: %v", err)
 		}
 	}
+	//nolint:staticcheck
 	if err := pw.WriteStop(); err != nil {
 		tb.Fatalf("write stop: %v", err)
 	}

--- a/reader/reader_test.go
+++ b/reader/reader_test.go
@@ -92,20 +92,24 @@ func parquetReader() (*ParquetReader, error) {
 		var buf bytes.Buffer
 		fw := writerfile.NewWriterFile(&buf)
 		var pw *writer.ParquetWriter
+		//nolint:staticcheck
 		pw, err = writer.NewParquetWriter(fw, new(Record), writer.WithNP(1), writer.WithRowGroupSize(1*1024*1024), writer.WithPageSize(4*1024))
 		if err != nil {
 			return
 		}
 		for i := range numRecord {
 			strVal := strconv.FormatInt(i, 10)
+			//nolint:staticcheck
 			err = pw.Write(Record{strVal, strVal, strVal, strVal, i, i, i, i})
 			if err != nil {
 				return
 			}
 		}
+		//nolint:staticcheck
 		if err = pw.WriteStop(); err != nil {
 			return
 		}
+		//nolint:staticcheck
 		err = pw.WriteStop()
 		parquetBuf = buf.Bytes()
 	})
@@ -141,6 +145,7 @@ type NestedRecord struct {
 func createNestedParquetData() ([]byte, error) {
 	var buf bytes.Buffer
 	fw := writerfile.NewWriterFile(&buf)
+	//nolint:staticcheck
 	pw, err := writer.NewParquetWriter(fw, new(NestedRecord), writer.WithNP(1))
 	if err != nil {
 		return nil, err
@@ -165,11 +170,13 @@ func createNestedParquetData() ([]byte, error) {
 	}
 
 	for _, record := range records {
+		//nolint:staticcheck
 		if err := pw.Write(record); err != nil {
 			return nil, err
 		}
 	}
 
+	//nolint:staticcheck
 	if err := pw.WriteStop(); err != nil {
 		return nil, err
 	}
@@ -698,16 +705,19 @@ func TestNewParquetReader_WithOptions(t *testing.T) {
 	// Create a simple parquet file buffer using the existing pattern
 	var buf bytes.Buffer
 	fw := writerfile.NewWriterFile(&buf)
+	//nolint:staticcheck
 	pw, err := writer.NewParquetWriter(fw, new(Record), writer.WithNP(1))
 	require.NoError(t, err)
 
 	// Write a few records
 	for i := int64(0); i < 5; i++ {
 		strVal := strconv.FormatInt(i, 10)
+		//nolint:staticcheck
 		err = pw.Write(Record{strVal, strVal, strVal, strVal, i, i, i, i})
 		require.NoError(t, err)
 	}
 
+	//nolint:staticcheck
 	err = pw.WriteStop()
 	require.NoError(t, err)
 

--- a/source/README.md
+++ b/source/README.md
@@ -20,6 +20,8 @@ type ParquetFileWriter interface {
 
 `ParquetFileReader.Open` returns a reader with an independent file handle for the requested file. The new reader may reuse the source's underlying storage client, but closing it must not invalidate the original reader.
 
+Context-aware parquet operations use optional capability interfaces named `ContextReader`, `ContextWriter`, `ContextSeeker`, `ContextOpener`, `ContextCloner`, `ContextCreator`, and `ContextCloser`. Existing source implementations remain compatible without implementing them: the library checks cancellation before falling back to the original method, except that close always runs and reports cancellation afterward. Remote sources should implement the relevant optional interfaces so deadlines can cancel in-flight backend requests.
+
 Supported sources:
 * Local
 * HDFS

--- a/source/azblob/reader.go
+++ b/source/azblob/reader.go
@@ -93,6 +93,10 @@ func (s *azBlobReader) Seek(offset int64, whence int) (int64, error) {
 
 // Read up to len(p) bytes into p and return the number of bytes read
 func (s *azBlobReader) Read(p []byte) (n int, err error) {
+	return s.ReadContext(s.ctx, p)
+}
+
+func (s *azBlobReader) ReadContext(ctx context.Context, p []byte) (n int, err error) {
 	if s.blockBlobClient == nil {
 		return 0, errReadNotOpened
 	}
@@ -102,7 +106,7 @@ func (s *azBlobReader) Read(p []byte) (n int, err error) {
 	}
 
 	count := int64(len(p))
-	resp, err := s.blockBlobClient.DownloadStream(s.ctx, &blob.DownloadStreamOptions{
+	resp, err := s.blockBlobClient.DownloadStream(ctx, &blob.DownloadStreamOptions{
 		Range: blob.HTTPRange{
 			Offset: s.offset,
 			Count:  count,
@@ -138,6 +142,10 @@ func (s *azBlobReader) Close() error {
 
 // Open creates a new block blob to perform reads
 func (s *azBlobReader) Open(URL string) (source.ParquetFileReader, error) {
+	return s.OpenContext(s.ctx, URL)
+}
+
+func (s *azBlobReader) OpenContext(ctx context.Context, URL string) (source.ParquetFileReader, error) {
 	var u *url.URL
 	if len(URL) == 0 && s.url != nil {
 		// ColumnBuffer passes in an empty string for name
@@ -148,7 +156,7 @@ func (s *azBlobReader) Open(URL string) (source.ParquetFileReader, error) {
 			return s, err
 		}
 	}
-	props, err := s.blockBlobClient.GetProperties(s.ctx, nil)
+	props, err := s.blockBlobClient.GetProperties(ctx, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -156,7 +164,7 @@ func (s *azBlobReader) Open(URL string) (source.ParquetFileReader, error) {
 
 	pf := &azBlobReader{
 		azBlockBlob: azBlockBlob{
-			ctx:             s.ctx,
+			ctx:             ctx,
 			url:             u,
 			blockBlobClient: s.blockBlobClient,
 		},
@@ -167,11 +175,18 @@ func (s *azBlobReader) Open(URL string) (source.ParquetFileReader, error) {
 }
 
 func (s azBlobReader) Clone() (source.ParquetFileReader, error) {
+	return s.CloneContext(s.ctx)
+}
+
+func (s azBlobReader) CloneContext(ctx context.Context) (source.ParquetFileReader, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	// Create a new instance without making network calls
 	// Reuse already-known metadata
 	return &azBlobReader{
 		azBlockBlob: azBlockBlob{
-			ctx:             s.ctx,
+			ctx:             ctx,
 			url:             s.url,
 			blockBlobClient: s.blockBlobClient,
 		},

--- a/source/azblob/reader_test.go
+++ b/source/azblob/reader_test.go
@@ -256,3 +256,10 @@ func TestAzBlobReader_Clone(t *testing.T) {
 		require.Equal(t, buf3, buf4)
 	})
 }
+
+func TestAzBlobReaderCloneContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := new(azBlobReader).CloneContext(ctx)
+	require.ErrorIs(t, err, context.Canceled)
+}

--- a/source/azblob/writer.go
+++ b/source/azblob/writer.go
@@ -101,6 +101,10 @@ func (s *azBlobWriter) Close() error {
 
 // Create a new blob url to perform writes
 func (s *azBlobWriter) Create(URL string) (source.ParquetFileWriter, error) {
+	return s.CreateContext(s.ctx, URL)
+}
+
+func (s *azBlobWriter) CreateContext(ctx context.Context, URL string) (source.ParquetFileWriter, error) {
 	var u *url.URL
 	if len(URL) == 0 && s.url != nil {
 		// ColumnBuffer passes in an empty string for name
@@ -114,7 +118,7 @@ func (s *azBlobWriter) Create(URL string) (source.ParquetFileWriter, error) {
 
 	pf := &azBlobWriter{
 		azBlockBlob: azBlockBlob{
-			ctx:             s.ctx,
+			ctx:             ctx,
 			url:             u,
 			blockBlobClient: s.blockBlobClient,
 		},

--- a/source/gcs/reader.go
+++ b/source/gcs/reader.go
@@ -3,6 +3,7 @@ package gcs
 import (
 	"context"
 	"fmt"
+	"io"
 
 	"cloud.google.com/go/storage"
 	"github.com/bobg/gcsobj"
@@ -16,6 +17,8 @@ var _ source.ParquetFileReader = (*gcsReader)(nil)
 type gcsReader struct {
 	gcsFile
 	generation int64
+	size       int64
+	offset     int64
 	gcsReader  *gcsobj.Reader
 }
 
@@ -41,10 +44,11 @@ func NewGcsFileReader(ctx context.Context, projectID, bucketName, name string, g
 func NewGcsFileReaderWithClient(ctx context.Context, client *storage.Client, projectID, bucketName, name string, generation int64) (*gcsReader, error) {
 	obj := client.Bucket(bucketName).Object(name).Generation(generation)
 
-	reader, err := gcsobj.NewReader(ctx, obj)
+	attrs, err := obj.Attrs(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("create new reader: %w", err)
 	}
+	reader := gcsobj.NewReaderWithSize(ctx, obj, attrs.Size)
 
 	return &gcsReader{
 		gcsFile: gcsFile{
@@ -58,6 +62,7 @@ func NewGcsFileReaderWithClient(ctx context.Context, client *storage.Client, pro
 		},
 		gcsReader:  reader,
 		generation: generation,
+		size:       attrs.Size,
 	}, nil
 }
 
@@ -65,14 +70,18 @@ func NewGcsFileReaderWithClient(ctx context.Context, client *storage.Client, pro
 // passed named. If name is left empty the same object as currently opened
 // will be re-opened.
 func (g *gcsReader) Open(name string) (source.ParquetFileReader, error) {
+	return g.OpenContext(g.ctx, name)
+}
+
+func (g *gcsReader) OpenContext(ctx context.Context, name string) (source.ParquetFileReader, error) {
 	if g.gcsClient == nil {
-		r, err := NewGcsFileReader(g.ctx, g.projectID, g.bucketName, name, -1)
+		r, err := NewGcsFileReader(ctx, g.projectID, g.bucketName, name, -1)
 		if err != nil {
 			return nil, fmt.Errorf("open gcs reader: %w", err)
 		}
 		return r, nil
 	}
-	r, err := NewGcsFileReaderWithClient(g.ctx, g.gcsClient, g.projectID, g.bucketName, name, -1)
+	r, err := NewGcsFileReaderWithClient(ctx, g.gcsClient, g.projectID, g.bucketName, name, -1)
 	if err != nil {
 		return nil, fmt.Errorf("open gcs reader with client: %w", err)
 	}
@@ -81,12 +90,14 @@ func (g *gcsReader) Open(name string) (source.ParquetFileReader, error) {
 
 // Clone will make a copy of reader
 func (g gcsReader) Clone() (source.ParquetFileReader, error) {
-	// Create a new reader without making network calls
-	// The underlying gcsobj.Reader manages its own offset internally
-	reader, err := gcsobj.NewReader(g.ctx, g.object)
-	if err != nil {
+	return g.CloneContext(g.ctx)
+}
+
+func (g gcsReader) CloneContext(ctx context.Context) (source.ParquetFileReader, error) {
+	if err := ctx.Err(); err != nil {
 		return nil, fmt.Errorf("create new reader: %w", err)
 	}
+	reader := gcsobj.NewReaderWithSize(ctx, g.object, g.size)
 
 	return &gcsReader{
 		gcsFile: gcsFile{
@@ -95,22 +106,56 @@ func (g gcsReader) Clone() (source.ParquetFileReader, error) {
 			filePath:       g.filePath,
 			gcsClient:      g.gcsClient,
 			object:         g.object,
-			ctx:            g.ctx,
+			ctx:            ctx,
 			externalClient: g.externalClient,
 		},
 		gcsReader:  reader,
 		generation: g.generation,
+		size:       g.size,
 	}, nil
 }
 
 // Seek implements io.Seeker.
 func (g *gcsReader) Seek(offset int64, whence int) (int64, error) {
-	return g.gcsReader.Seek(offset, whence)
+	var position int64
+	switch whence {
+	case io.SeekStart:
+		position = offset
+	case io.SeekCurrent:
+		position = g.offset + offset
+	case io.SeekEnd:
+		position = g.size + offset
+	default:
+		return 0, fmt.Errorf("illegal whence value %d", whence)
+	}
+	position, err := g.gcsReader.Seek(position, io.SeekStart)
+	if err == nil {
+		g.offset = position
+	}
+	return position, err
 }
 
 // Read implements io.Reader.
 func (g *gcsReader) Read(b []byte) (int, error) {
-	return g.gcsReader.Read(b)
+	n, err := g.gcsReader.Read(b)
+	g.offset += int64(n)
+	return n, err
+}
+
+func (g *gcsReader) ReadContext(ctx context.Context, b []byte) (int, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+	if ctx != g.ctx {
+		reader := gcsobj.NewReaderWithSize(ctx, g.object, g.size)
+		if _, err := reader.Seek(g.offset, io.SeekStart); err != nil {
+			return 0, fmt.Errorf("restore reader offset: %w", err)
+		}
+		_ = g.gcsReader.Close()
+		g.gcsReader = reader
+		g.ctx = ctx
+	}
+	return g.Read(b)
 }
 
 // Close implements io.Closer.

--- a/source/gcs/reader_test.go
+++ b/source/gcs/reader_test.go
@@ -220,6 +220,17 @@ func TestGcsReader_Seek(t *testing.T) {
 	offset, err := reader.Seek(10, io.SeekStart)
 	require.NoError(t, err)
 	require.Equal(t, int64(10), offset)
+
+	offset, err = reader.Seek(5, io.SeekCurrent)
+	require.NoError(t, err)
+	require.Equal(t, int64(15), offset)
+
+	offset, err = reader.Seek(-1, io.SeekEnd)
+	require.NoError(t, err)
+	require.Equal(t, reader.size-1, offset)
+
+	_, err = reader.Seek(0, -1)
+	require.ErrorContains(t, err, "illegal whence")
 }
 
 func TestGcsReader_Read(t *testing.T) {
@@ -236,6 +247,16 @@ func TestGcsReader_Read(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 4, bytesRead)
 	require.Equal(t, common.MagicBytes, string(buf))
+
+	readCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	bytesRead, err = reader.ReadContext(readCtx, buf)
+	require.NoError(t, err)
+	require.Equal(t, 4, bytesRead)
+
+	cancel()
+	_, err = reader.ReadContext(readCtx, buf)
+	require.ErrorIs(t, err, context.Canceled)
 }
 
 func TestNewGcsFileReaderWithClient(t *testing.T) {

--- a/source/gcs/writer.go
+++ b/source/gcs/writer.go
@@ -63,14 +63,18 @@ func NewGcsFileWriterWithClient(ctx context.Context, client *storage.Client, pro
 // passed named. If name is left empty the same object as currently opened
 // will be re-opened.
 func (g *gcsFileWriter) Create(name string) (source.ParquetFileWriter, error) {
+	return g.CreateContext(g.ctx, name)
+}
+
+func (g *gcsFileWriter) CreateContext(ctx context.Context, name string) (source.ParquetFileWriter, error) {
 	if g.gcsClient == nil {
-		w, err := NewGcsFileWriter(g.ctx, g.projectID, g.bucketName, name)
+		w, err := NewGcsFileWriter(ctx, g.projectID, g.bucketName, name)
 		if err != nil {
 			return nil, fmt.Errorf("open gcs writer: %w", err)
 		}
 		return w, nil
 	}
-	w, err := NewGcsFileWriterWithClient(g.ctx, g.gcsClient, g.projectID, g.bucketName, name)
+	w, err := NewGcsFileWriterWithClient(ctx, g.gcsClient, g.projectID, g.bucketName, name)
 	if err != nil {
 		return nil, fmt.Errorf("open gcs writer with client: %w", err)
 	}

--- a/source/gocloud/reader.go
+++ b/source/gocloud/reader.go
@@ -50,7 +50,11 @@ func (b *blobReader) Seek(offset int64, whence int) (int64, error) {
 }
 
 func (b *blobReader) Read(p []byte) (n int, err error) {
-	r, err := b.bucket.NewRangeReader(b.ctx, b.key, b.offset, int64(len(p)), nil)
+	return b.ReadContext(b.ctx, p)
+}
+
+func (b *blobReader) ReadContext(ctx context.Context, p []byte) (n int, err error) {
+	r, err := b.bucket.NewRangeReader(ctx, b.key, b.offset, int64(len(p)), nil)
 	if err != nil {
 		return 0, fmt.Errorf("open reader key=%s offset=%d len=%d: %w", b.key, b.offset, len(p), err)
 	}
@@ -69,9 +73,13 @@ func (b *blobReader) Close() error {
 }
 
 func (b *blobReader) Open(name string) (source.ParquetFileReader, error) {
+	return b.OpenContext(b.ctx, name)
+}
+
+func (b *blobReader) OpenContext(ctx context.Context, name string) (source.ParquetFileReader, error) {
 	bf := &blobReader{
 		blobFile: blobFile{
-			ctx:    b.ctx,
+			ctx:    ctx,
 			bucket: b.bucket,
 		},
 	}
@@ -91,11 +99,18 @@ func (b *blobReader) Open(name string) (source.ParquetFileReader, error) {
 }
 
 func (b blobReader) Clone() (source.ParquetFileReader, error) {
+	return b.CloneContext(b.ctx)
+}
+
+func (b blobReader) CloneContext(ctx context.Context) (source.ParquetFileReader, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	// Create a new instance without making network calls
 	// Reuse already-known metadata
 	return &blobReader{
 		blobFile: blobFile{
-			ctx:    b.ctx,
+			ctx:    ctx,
 			bucket: b.bucket,
 			key:    b.key,
 			size:   b.size,

--- a/source/gocloud/reader_test.go
+++ b/source/gocloud/reader_test.go
@@ -127,6 +127,13 @@ func TestBlobReader_Clone(t *testing.T) {
 	require.Equal(t, testData, all)
 }
 
+func TestBlobReaderCloneContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := new(blobReader).CloneContext(ctx)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
 func TestBlobReader_OpenNonexistent(t *testing.T) {
 	b := memblob.OpenBucket(nil)
 	defer func() {

--- a/source/gocloud/writer.go
+++ b/source/gocloud/writer.go
@@ -31,11 +31,15 @@ func NewBlobWriter(ctx context.Context, b *blob.Bucket, name string) (source.Par
 // Note that for blob storage, calling write on an existing blob overwrites that blob as opposed to appending to it.
 // Additionally Write is not guaranteed to have succeeded unless Close() also succeeds
 func (b *blobWriter) Write(p []byte) (n int, err error) {
+	return b.WriteContext(b.ctx, p)
+}
+
+func (b *blobWriter) WriteContext(ctx context.Context, p []byte) (n int, err error) {
 	if b.writer == nil && b.key == "" {
 		return 0, fmt.Errorf("writer not created or opened")
 	}
 	if b.writer == nil {
-		if w, err := b.bucket.NewWriter(b.ctx, b.key, nil); err != nil {
+		if w, err := b.bucket.NewWriter(ctx, b.key, nil); err != nil {
 			return 0, fmt.Errorf("create blob writer key=%s: %w", b.key, err)
 		} else {
 			b.writer = w
@@ -57,13 +61,17 @@ func (b *blobWriter) Close() error {
 }
 
 func (b *blobWriter) Create(name string) (source.ParquetFileWriter, error) {
+	return b.CreateContext(b.ctx, name)
+}
+
+func (b *blobWriter) CreateContext(ctx context.Context, name string) (source.ParquetFileWriter, error) {
 	if name == "" {
 		return nil, fmt.Errorf("file name empty")
 	}
 
 	bf := &blobWriter{
 		blobFile: blobFile{
-			ctx:    b.ctx,
+			ctx:    ctx,
 			bucket: b.bucket,
 		},
 	}

--- a/source/http/http_reader.go
+++ b/source/http/http_reader.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"io"
@@ -30,11 +31,17 @@ const (
 
 // NewHttpReaderWithClient creates an HTTP-based ParquetFileReader using the provided client.
 func NewHttpReaderWithClient(uri string, client *http.Client, extraHeaders map[string]string) (source.ParquetFileReader, error) {
+	return NewHttpReaderWithClientAndContext(context.Background(), uri, client, extraHeaders)
+}
+
+// NewHttpReaderWithClientAndContext creates an HTTP reader and uses ctx for
+// the initial range request.
+func NewHttpReaderWithClientAndContext(ctx context.Context, uri string, client *http.Client, extraHeaders map[string]string) (source.ParquetFileReader, error) {
 	if client == nil {
 		return nil, fmt.Errorf("client must not be nil")
 	}
 
-	req, err := http.NewRequest(http.MethodGet, uri, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, uri, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -76,7 +83,15 @@ func NewHttpReaderWithClient(uri string, client *http.Client, extraHeaders map[s
 }
 
 // NewHttpReader creates an HTTP-based ParquetFileReader.
+//
+// Deprecated: use NewHttpReaderWithContext.
 func NewHttpReader(uri string, dedicatedTransport, ignoreTLSError bool, extraHeaders map[string]string) (source.ParquetFileReader, error) {
+	return NewHttpReaderWithContext(context.Background(), uri, dedicatedTransport, ignoreTLSError, extraHeaders)
+}
+
+// NewHttpReaderWithContext creates an HTTP reader and uses ctx for the initial
+// range request.
+func NewHttpReaderWithContext(ctx context.Context, uri string, dedicatedTransport, ignoreTLSError bool, extraHeaders map[string]string) (source.ParquetFileReader, error) {
 	var transport *http.Transport
 	if dedicatedTransport {
 		transport = &http.Transport{}
@@ -88,11 +103,15 @@ func NewHttpReader(uri string, dedicatedTransport, ignoreTLSError bool, extraHea
 	transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: ignoreTLSError}
 	client := &http.Client{Transport: transport}
 
-	return NewHttpReaderWithClient(uri, client, extraHeaders)
+	return NewHttpReaderWithClientAndContext(ctx, uri, client, extraHeaders)
 }
 
 func (r *httpReader) Open(_ string) (source.ParquetFileReader, error) {
 	return NewHttpReaderWithClient(r.url, r.httpClient, r.extraHeaders)
+}
+
+func (r *httpReader) OpenContext(ctx context.Context, _ string) (source.ParquetFileReader, error) {
+	return NewHttpReaderWithClientAndContext(ctx, r.url, r.httpClient, r.extraHeaders)
 }
 
 func (r httpReader) Clone() (source.ParquetFileReader, error) {
@@ -105,6 +124,13 @@ func (r httpReader) Clone() (source.ParquetFileReader, error) {
 		httpClient:   r.httpClient,
 		extraHeaders: r.extraHeaders,
 	}, nil
+}
+
+func (r httpReader) CloneContext(ctx context.Context) (source.ParquetFileReader, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return r.Clone()
 }
 
 func (r *httpReader) Seek(offset int64, pos int) (int64, error) {
@@ -129,7 +155,11 @@ func (r *httpReader) Seek(offset int64, pos int) (int64, error) {
 }
 
 func (r *httpReader) Read(b []byte) (int, error) {
-	req, err := http.NewRequest(http.MethodGet, r.url, nil)
+	return r.ReadContext(context.Background(), b)
+}
+
+func (r *httpReader) ReadContext(ctx context.Context, b []byte) (int, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, r.url, nil)
 	if err != nil {
 		return 0, err
 	}

--- a/source/http/http_reader_test.go
+++ b/source/http/http_reader_test.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -9,11 +10,49 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/hangxie/parquet-go/v3/source"
 )
+
+func TestHttpReader_ReadContextCancellation(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if requests <= 2 {
+			w.Header().Set("Content-Range", "bytes 0-0/2")
+			w.WriteHeader(http.StatusPartialContent)
+			_, _ = w.Write([]byte("x"))
+			return
+		}
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	reader, err := NewHttpReader(server.URL, false, false, nil)
+	require.NoError(t, err)
+	contextReader, ok := reader.(source.ContextReader)
+	require.True(t, ok)
+	contextOpener, ok := reader.(source.ContextOpener)
+	require.True(t, ok)
+	opened, err := contextOpener.OpenContext(context.Background(), "")
+	require.NoError(t, err)
+	require.NoError(t, opened.Close())
+	contextCloner, ok := reader.(source.ContextCloner)
+	require.True(t, ok)
+	cloned, err := contextCloner.CloneContext(context.Background())
+	require.NoError(t, err)
+	require.NoError(t, cloned.Close())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	_, err = contextReader.ReadContext(ctx, make([]byte, 1))
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	_, err = contextCloner.CloneContext(ctx)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
 
 // Mock data for testing
 var testData = []byte("Hello, this is test data for HTTP reader testing with parquet file content simulation")

--- a/source/s3v2/reader.go
+++ b/source/s3v2/reader.go
@@ -106,6 +106,10 @@ func (s *s3Reader) Seek(offset int64, whence int) (int64, error) {
 
 // Read up to len(p) bytes into p and return the number of bytes read
 func (s *s3Reader) Read(p []byte) (n int, err error) {
+	return s.ReadContext(s.ctx, p)
+}
+
+func (s *s3Reader) ReadContext(ctx context.Context, p []byte) (n int, err error) {
 	if s.fileSize > 0 && s.offset >= s.fileSize {
 		return 0, io.EOF
 	}
@@ -117,7 +121,7 @@ func (s *s3Reader) Read(p []byte) (n int, err error) {
 	}()
 
 	if s.socket == nil {
-		err = s.openSocket(int64(len(p)))
+		err = s.openSocket(ctx, int64(len(p)))
 		if err != nil {
 			return 0, err
 		}
@@ -138,7 +142,7 @@ func (s *s3Reader) Read(p []byte) (n int, err error) {
 
 // openSocket issues a new GetObject request to retrieve the next chunk of data from the
 // object.
-func (s *s3Reader) openSocket(numBytes int64) error {
+func (s *s3Reader) openSocket(ctx context.Context, numBytes int64) error {
 	if numBytes < s.minRequestSize {
 		numBytes = s.minRequestSize
 	}
@@ -152,7 +156,7 @@ func (s *s3Reader) openSocket(numBytes int64) error {
 		getObj.Range = aws.String(getObjRange)
 	}
 
-	out, err := s.client.GetObject(s.ctx, getObj)
+	out, err := s.client.GetObject(ctx, getObj)
 	if err != nil {
 		return fmt.Errorf("get S3 object: %w", err)
 	}
@@ -176,11 +180,15 @@ func (s *s3Reader) Close() error {
 
 // Open creates a new S3 File instance to perform concurrent reads
 func (s *s3Reader) Open(name string) (source.ParquetFileReader, error) {
+	return s.OpenContext(s.ctx, name)
+}
+
+func (s *s3Reader) OpenContext(ctx context.Context, name string) (source.ParquetFileReader, error) {
 	s.lock.RLock()
 	readOpened := s.readOpened
 	s.lock.RUnlock()
 	if !readOpened {
-		if err := s.openRead(); err != nil {
+		if err := s.openRead(ctx); err != nil {
 			return nil, fmt.Errorf("open s3 object: %w", err)
 		}
 	}
@@ -193,7 +201,7 @@ func (s *s3Reader) Open(name string) (source.ParquetFileReader, error) {
 	// create a new instance
 	pf := &s3Reader{
 		s3File: s3File{
-			ctx:        s.ctx,
+			ctx:        ctx,
 			bucketName: s.bucketName,
 			key:        name,
 		},
@@ -208,11 +216,18 @@ func (s *s3Reader) Open(name string) (source.ParquetFileReader, error) {
 }
 
 func (s *s3Reader) Clone() (source.ParquetFileReader, error) {
+	return s.CloneContext(s.ctx)
+}
+
+func (s *s3Reader) CloneContext(ctx context.Context) (source.ParquetFileReader, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	// Create a new instance without making network calls
 	// Reuse already-known metadata
 	return &s3Reader{
 		s3File: s3File{
-			ctx:        s.ctx,
+			ctx:        ctx,
 			bucketName: s.bucketName,
 			key:        s.key,
 		},
@@ -228,14 +243,14 @@ func (s *s3Reader) Clone() (source.ParquetFileReader, error) {
 
 // openRead verifies the requested file is accessible and
 // tracks the file size
-func (s *s3Reader) openRead() error {
+func (s *s3Reader) openRead(ctx context.Context) error {
 	hoi := &s3.HeadObjectInput{
 		Bucket:    aws.String(s.bucketName),
 		Key:       aws.String(s.key),
 		VersionId: s.version,
 	}
 
-	hoo, err := s.client.HeadObject(s.ctx, hoi)
+	hoo, err := s.client.HeadObject(ctx, hoi)
 	if err != nil {
 		return fmt.Errorf("head object: %w", err)
 	}

--- a/source/s3v2/reader_test.go
+++ b/source/s3v2/reader_test.go
@@ -371,6 +371,13 @@ func TestS3Reader_Clone(t *testing.T) {
 	})
 }
 
+func TestS3ReaderCloneContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := new(s3Reader).CloneContext(ctx)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
 func TestS3Reader_Close(t *testing.T) {
 	ctx := context.Background()
 	client := newMockS3ReadClient()

--- a/source/s3v2/writer.go
+++ b/source/s3v2/writer.go
@@ -73,7 +73,7 @@ func (s *s3Writer) Write(p []byte) (n int, err error) {
 	writeOpened := s.writeOpened
 	s.lock.RUnlock()
 	if !writeOpened {
-		s.openWrite()
+		s.openWrite(s.ctx)
 	}
 
 	s.lock.RLock()
@@ -119,9 +119,13 @@ func (s *s3Writer) Close() error {
 
 // Create creates a new S3 File instance to perform writes
 func (s *s3Writer) Create(key string) (source.ParquetFileWriter, error) {
+	return s.CreateContext(s.ctx, key)
+}
+
+func (s *s3Writer) CreateContext(ctx context.Context, key string) (source.ParquetFileWriter, error) {
 	pf := &s3Writer{
 		s3File: s3File{
-			ctx:        s.ctx,
+			ctx:        ctx,
 			bucketName: s.bucketName,
 			key:        key,
 		},
@@ -130,13 +134,13 @@ func (s *s3Writer) Create(key string) (source.ParquetFileWriter, error) {
 		uploadInputOptions: s.uploadInputOptions,
 		writeDone:          make(chan error),
 	}
-	pf.openWrite()
+	pf.openWrite(ctx)
 	return pf, nil
 }
 
 // openWrite creates an S3 transfer manager that consumes the Reader end of an io.Pipe.
 // Calling Close signals write completion.
-func (s *s3Writer) openWrite() {
+func (s *s3Writer) openWrite(ctx context.Context) {
 	pr, pw := io.Pipe()
 	tm := transfermanager.New(s.client, s.tmOptions...)
 	s.lock.Lock()
@@ -159,7 +163,7 @@ func (s *s3Writer) openWrite() {
 		defer close(done)
 
 		// upload data and signal done when complete
-		_, err := tm.UploadObject(s.ctx, params)
+		_, err := tm.UploadObject(ctx, params)
 		if err != nil {
 			s.lock.Lock()
 			s.err = err

--- a/source/source.go
+++ b/source/source.go
@@ -1,6 +1,8 @@
 package source
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"io"
 
@@ -24,18 +26,189 @@ type ParquetFileWriter interface {
 	Create(name string) (ParquetFileWriter, error)
 }
 
+// ContextReader optionally provides context-aware reads.
+type ContextReader interface {
+	ReadContext(context.Context, []byte) (int, error)
+}
+
+// ContextWriter optionally provides context-aware writes.
+type ContextWriter interface {
+	WriteContext(context.Context, []byte) (int, error)
+}
+
+// ContextSeeker optionally provides context-aware seeks.
+type ContextSeeker interface {
+	SeekContext(context.Context, int64, int) (int64, error)
+}
+
+// ContextOpener optionally provides context-aware opening of external column files.
+type ContextOpener interface {
+	OpenContext(context.Context, string) (ParquetFileReader, error)
+}
+
+// ContextCloner optionally provides context-aware reader cloning.
+type ContextCloner interface {
+	CloneContext(context.Context) (ParquetFileReader, error)
+}
+
+// ContextCreator optionally provides context-aware writer creation.
+type ContextCreator interface {
+	CreateContext(context.Context, string) (ParquetFileWriter, error)
+}
+
+// ContextCloser optionally provides context-aware closing.
+type ContextCloser interface {
+	CloseContext(context.Context) error
+}
+
 const bufferSize = 4096
 
 // ConvertToThriftReader converts a file reader to a Thrift buffered transport.
 // It seeks to the given offset before wrapping the reader.
+//
+// Deprecated: use ConvertToThriftReaderWithContext.
 func ConvertToThriftReader(file ParquetFileReader, offset int64) (*thrift.TBufferedTransport, error) {
+	return ConvertToThriftReaderWithContext(context.Background(), file, offset)
+}
+
+// ConvertToThriftReaderWithContext converts a file reader to a Thrift buffered
+// transport and uses ctx for the initial seek and subsequent reads.
+func ConvertToThriftReaderWithContext(ctx context.Context, file ParquetFileReader, offset int64) (*thrift.TBufferedTransport, error) {
 	if file == nil {
 		return nil, fmt.Errorf("file reader is nil")
 	}
-	if _, err := file.Seek(offset, io.SeekStart); err != nil {
+	if _, err := SeekWithContext(ctx, file, offset, io.SeekStart); err != nil {
 		return nil, fmt.Errorf("seek to offset %d: %w", offset, err)
 	}
-	thriftReader := thrift.NewStreamTransportR(file)
+	thriftReader := thrift.NewStreamTransportR(ReaderWithContext{Ctx: ctx, Reader: file})
 	bufferReader := thrift.NewTBufferedTransport(thriftReader, bufferSize)
 	return bufferReader, nil
+}
+
+// ReaderWithContext wraps an io.Reader with a context.Context so that every
+// Read checks ctx and calls the reader's ContextReader.ReadContext when
+// available.
+type ReaderWithContext struct {
+	Ctx    context.Context
+	Reader io.Reader
+}
+
+func (r ReaderWithContext) Read(p []byte) (int, error) {
+	return ReadWithContext(r.Ctx, r.Reader, p)
+}
+
+// ReadSeekerWithContext wraps an io.ReadSeeker with a context.Context so that
+// every Read and Seek checks ctx and calls the underlying type's context-aware
+// methods when available.
+type ReadSeekerWithContext struct {
+	Ctx        context.Context
+	ReadSeeker io.ReadSeeker
+}
+
+func (r ReadSeekerWithContext) Read(p []byte) (int, error) {
+	return ReadWithContext(r.Ctx, r.ReadSeeker, p)
+}
+
+func (r ReadSeekerWithContext) Seek(offset int64, whence int) (int64, error) {
+	return SeekWithContext(r.Ctx, r.ReadSeeker, offset, whence)
+}
+
+// ReadWithContext calls a reader's optional context-aware method, falling back
+// to io.Reader after checking whether ctx is already done.
+func ReadWithContext(ctx context.Context, reader io.Reader, p []byte) (int, error) {
+	if err := contextError(ctx); err != nil {
+		return 0, err
+	}
+	if reader, ok := reader.(ContextReader); ok {
+		return reader.ReadContext(ctx, p)
+	}
+	return reader.Read(p)
+}
+
+// ReadFullWithContext reads exactly len(p) bytes using ReadWithContext.
+func ReadFullWithContext(ctx context.Context, reader io.Reader, p []byte) (int, error) {
+	return io.ReadFull(ReaderWithContext{Ctx: ctx, Reader: reader}, p)
+}
+
+// WriteWithContext calls a writer's optional context-aware method, falling back
+// to io.Writer after checking whether ctx is already done.
+func WriteWithContext(ctx context.Context, writer io.Writer, p []byte) (int, error) {
+	if err := contextError(ctx); err != nil {
+		return 0, err
+	}
+	if writer, ok := writer.(ContextWriter); ok {
+		return writer.WriteContext(ctx, p)
+	}
+	return writer.Write(p)
+}
+
+// SeekWithContext calls a seeker's optional context-aware method, falling back
+// to io.Seeker after checking whether ctx is already done.
+func SeekWithContext(ctx context.Context, seeker io.Seeker, offset int64, whence int) (int64, error) {
+	if err := contextError(ctx); err != nil {
+		return 0, err
+	}
+	if seeker, ok := seeker.(ContextSeeker); ok {
+		return seeker.SeekContext(ctx, offset, whence)
+	}
+	return seeker.Seek(offset, whence)
+}
+
+// OpenWithContext calls a file reader's optional context-aware method, falling
+// back to Open after checking whether ctx is already done.
+func OpenWithContext(ctx context.Context, file ParquetFileReader, name string) (ParquetFileReader, error) {
+	if err := contextError(ctx); err != nil {
+		return nil, err
+	}
+	if file, ok := file.(ContextOpener); ok {
+		return file.OpenContext(ctx, name)
+	}
+	return file.Open(name)
+}
+
+// CloneWithContext calls a file reader's optional context-aware method, falling
+// back to Clone after checking whether ctx is already done.
+func CloneWithContext(ctx context.Context, file ParquetFileReader) (ParquetFileReader, error) {
+	if err := contextError(ctx); err != nil {
+		return nil, err
+	}
+	if file, ok := file.(ContextCloner); ok {
+		return file.CloneContext(ctx)
+	}
+	return file.Clone()
+}
+
+// CreateWithContext calls a file writer's optional context-aware method,
+// falling back to Create after checking whether ctx is already done.
+func CreateWithContext(ctx context.Context, file ParquetFileWriter, name string) (ParquetFileWriter, error) {
+	if err := contextError(ctx); err != nil {
+		return nil, err
+	}
+	if file, ok := file.(ContextCreator); ok {
+		return file.CreateContext(ctx, name)
+	}
+	return file.Create(name)
+}
+
+// CloseWithContext calls a closer's optional context-aware method, falling back
+// to io.Closer. Cancellation is never allowed to interrupt cleanup, but a
+// cancellation that occurs during the close is still reported to the caller.
+func CloseWithContext(ctx context.Context, closer io.Closer) error {
+	if ctx == nil {
+		return fmt.Errorf("context is nil")
+	}
+	var closeErr error
+	if contextCloser, ok := closer.(ContextCloser); ok {
+		closeErr = contextCloser.CloseContext(context.WithoutCancel(ctx))
+	} else {
+		closeErr = closer.Close()
+	}
+	return errors.Join(ctx.Err(), closeErr)
+}
+
+func contextError(ctx context.Context) error {
+	if ctx == nil {
+		return fmt.Errorf("context is nil")
+	}
+	return ctx.Err()
 }

--- a/source/source_test.go
+++ b/source/source_test.go
@@ -2,12 +2,180 @@ package source
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+type contextFile struct {
+	*mockParquetFileReader
+	gotContext context.Context
+}
+
+func (f *contextFile) ReadContext(ctx context.Context, p []byte) (int, error) {
+	f.gotContext = ctx
+	return f.Read(p)
+}
+
+func (f *contextFile) SeekContext(ctx context.Context, offset int64, whence int) (int64, error) {
+	f.gotContext = ctx
+	return f.Seek(offset, whence)
+}
+
+func (f *contextFile) OpenContext(ctx context.Context, _ string) (ParquetFileReader, error) {
+	f.gotContext = ctx
+	return f, nil
+}
+
+func (f *contextFile) CloneContext(ctx context.Context) (ParquetFileReader, error) {
+	f.gotContext = ctx
+	return f, nil
+}
+
+func (f *contextFile) CloseContext(ctx context.Context) error {
+	f.gotContext = ctx
+	return nil
+}
+
+type contextWriter struct {
+	bytes.Buffer
+	gotContext context.Context
+}
+
+type legacyWriter struct {
+	bytes.Buffer
+}
+
+func (w *legacyWriter) Close() error { return nil }
+
+func (w *legacyWriter) Create(string) (ParquetFileWriter, error) { return w, nil }
+
+func (w *contextWriter) Close() error { return nil }
+
+func (w *contextWriter) Create(string) (ParquetFileWriter, error) { return w, nil }
+
+func (w *contextWriter) WriteContext(ctx context.Context, p []byte) (int, error) {
+	w.gotContext = ctx
+	return w.Write(p)
+}
+
+func (w *contextWriter) CreateContext(ctx context.Context, _ string) (ParquetFileWriter, error) {
+	w.gotContext = ctx
+	return w, nil
+}
+
+func (w *contextWriter) CloseContext(ctx context.Context) error {
+	w.gotContext = ctx
+	return nil
+}
+
+type closeTrackingReader struct {
+	*mockParquetFileReader
+	closed bool
+}
+
+func (r *closeTrackingReader) Close() error {
+	r.closed = true
+	return nil
+}
+
+func TestContextOperations(t *testing.T) {
+	type contextKey struct{}
+	key := contextKey{}
+	ctx := context.WithValue(context.Background(), key, "value")
+	reader := &contextFile{mockParquetFileReader: newMockParquetFileReader([]byte("data"))}
+	writer := new(contextWriter)
+
+	_, err := ReadWithContext(ctx, reader, make([]byte, 1))
+	require.NoError(t, err)
+	require.Same(t, ctx, reader.gotContext)
+	_, err = SeekWithContext(ctx, reader, 0, io.SeekStart)
+	require.NoError(t, err)
+	require.Same(t, ctx, reader.gotContext)
+	_, err = OpenWithContext(ctx, reader, "file")
+	require.NoError(t, err)
+	require.Same(t, ctx, reader.gotContext)
+	_, err = CloneWithContext(ctx, reader)
+	require.NoError(t, err)
+	require.Same(t, ctx, reader.gotContext)
+	require.NoError(t, CloseWithContext(ctx, reader))
+	require.Equal(t, ctx.Value(key), reader.gotContext.Value(key))
+
+	_, err = WriteWithContext(ctx, writer, []byte("data"))
+	require.NoError(t, err)
+	require.Same(t, ctx, writer.gotContext)
+	_, err = CreateWithContext(ctx, writer, "file")
+	require.NoError(t, err)
+	require.Same(t, ctx, writer.gotContext)
+	require.NoError(t, CloseWithContext(ctx, writer))
+	require.Equal(t, ctx.Value(key), writer.gotContext.Value(key))
+}
+
+func TestContextOperationsFallback(t *testing.T) {
+	nilCtx := map[string]context.Context{}["missing"]
+	require.ErrorContains(t, CloseWithContext(nilCtx, newMockParquetFileReader(nil)), "context is nil")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	reader := newMockParquetFileReader([]byte("data"))
+
+	_, err := ReadWithContext(ctx, reader, make([]byte, 1))
+	require.ErrorIs(t, err, context.Canceled)
+	require.Zero(t, reader.position)
+	_, err = SeekWithContext(ctx, reader, 0, io.SeekStart)
+	require.ErrorIs(t, err, context.Canceled)
+	_, err = OpenWithContext(ctx, reader, "file")
+	require.ErrorIs(t, err, context.Canceled)
+	_, err = CloneWithContext(ctx, reader)
+	require.ErrorIs(t, err, context.Canceled)
+	closeTracking := &closeTrackingReader{mockParquetFileReader: reader}
+	require.ErrorIs(t, CloseWithContext(ctx, closeTracking), context.Canceled)
+	require.True(t, closeTracking.closed)
+	contextCloseTracking := &contextFile{mockParquetFileReader: newMockParquetFileReader(nil)}
+	require.ErrorIs(t, CloseWithContext(ctx, contextCloseTracking), context.Canceled)
+	require.NoError(t, contextCloseTracking.gotContext.Err())
+
+	canceledWriter := new(legacyWriter)
+	_, err = WriteWithContext(ctx, canceledWriter, []byte("data"))
+	require.ErrorIs(t, err, context.Canceled)
+	_, err = CreateWithContext(ctx, canceledWriter, "file")
+	require.ErrorIs(t, err, context.Canceled)
+
+	ctx = context.Background()
+	n, err := ReadWithContext(ctx, reader, make([]byte, 1))
+	require.NoError(t, err)
+	require.Equal(t, 1, n)
+
+	full := make([]byte, 3)
+	n, err = ReadFullWithContext(ctx, reader, full)
+	require.NoError(t, err)
+	require.Equal(t, 3, n)
+
+	_, err = SeekWithContext(ctx, reader, 0, io.SeekStart)
+	require.NoError(t, err)
+	opened, err := OpenWithContext(ctx, reader, "file")
+	require.NoError(t, err)
+	require.NotNil(t, opened)
+	cloned, err := CloneWithContext(ctx, reader)
+	require.NoError(t, err)
+	require.NotNil(t, cloned)
+	require.NoError(t, CloseWithContext(ctx, reader))
+
+	writer := new(legacyWriter)
+	n, err = WriteWithContext(ctx, writer, []byte("data"))
+	require.NoError(t, err)
+	require.Equal(t, 4, n)
+	created, err := CreateWithContext(ctx, writer, "file")
+	require.NoError(t, err)
+	require.Same(t, writer, created)
+	require.NoError(t, CloseWithContext(ctx, writer))
+
+	_, err = ReadWithContext(nilCtx, reader, make([]byte, 1))
+	require.ErrorContains(t, err, "context is nil")
+}
 
 // Mock implementation of ParquetFileReader for testing
 type mockParquetFileReader struct {

--- a/writer/arrow.go
+++ b/writer/arrow.go
@@ -1,6 +1,7 @@
 package writer
 
 import (
+	"context"
 	"fmt"
 	"io"
 
@@ -20,19 +21,33 @@ type ArrowWriter struct {
 }
 
 // NewArrowWriterFromWriter creates an ArrowWriter from an io.Writer.
+//
+// Deprecated: use NewArrowWriterFromWriterWithContext.
 func NewArrowWriterFromWriter(arrowSchema *arrow.Schema, w io.Writer, opts ...WriterOption) (*ArrowWriter, error) {
+	return NewArrowWriterFromWriterWithContext(context.Background(), arrowSchema, w, opts...)
+}
+
+// NewArrowWriterFromWriterWithContext creates an ArrowWriter using ctx.
+func NewArrowWriterFromWriterWithContext(ctx context.Context, arrowSchema *arrow.Schema, w io.Writer, opts ...WriterOption) (*ArrowWriter, error) {
 	wf := writerfile.NewWriterFile(w)
-	return NewArrowWriter(arrowSchema, wf, opts...)
+	return NewArrowWriterWithContext(ctx, arrowSchema, wf, opts...)
 }
 
 // NewArrowWriter creates a parquet writer from an Arrow schema.
 // The default compression for Arrow writers is GZIP (unlike SNAPPY for other writers).
 // Use WithCompressionCodec to override.
+//
+// Deprecated: use NewArrowWriterWithContext.
 func NewArrowWriter(arrowSchema *arrow.Schema, pfile source.ParquetFileWriter, opts ...WriterOption) (*ArrowWriter, error) {
+	return NewArrowWriterWithContext(context.Background(), arrowSchema, pfile, opts...)
+}
+
+// NewArrowWriterWithContext creates an ArrowWriter using ctx.
+func NewArrowWriterWithContext(ctx context.Context, arrowSchema *arrow.Schema, pfile source.ParquetFileWriter, opts ...WriterOption) (*ArrowWriter, error) {
 	res := new(ArrowWriter)
 	// ArrowWriter defaults to GZIP; user opts come after and can override.
 	allOpts := append([]WriterOption{WithCompressionCodec(parquet.CompressionCodec_GZIP)}, opts...)
-	if err := res.initBase(pfile, allOpts...); err != nil {
+	if err := res.initBase(ctx, pfile, allOpts...); err != nil {
 		return nil, fmt.Errorf("init arrow writer base: %w", err)
 	}
 
@@ -56,7 +71,17 @@ func NewArrowWriter(arrowSchema *arrow.Schema, pfile source.ParquetFileWriter, o
 
 // WriteArrow writes an Arrow RecordBatch to the parquet file.
 // It transposes columnar Arrow data into row-oriented format for parquet-go.
+//
+// Deprecated: use WriteArrowWithContext.
 func (w *ArrowWriter) WriteArrow(batch arrow.RecordBatch) error {
+	return w.WriteArrowWithContext(w.defaultContext(), batch)
+}
+
+// WriteArrowWithContext writes an Arrow record batch using ctx.
+func (w *ArrowWriter) WriteArrowWithContext(ctx context.Context, batch arrow.RecordBatch) error {
+	if err := w.setContext(ctx); err != nil {
+		return err
+	}
 	table := make([][]any, 0)
 	for i, column := range batch.Columns() {
 		columnFromRecord, err := common.ArrowColToParquetCol(
@@ -72,7 +97,7 @@ func (w *ArrowWriter) WriteArrow(batch arrow.RecordBatch) error {
 	}
 	transposedTable := common.TransposeTable(table)
 	for _, row := range transposedTable {
-		if err := w.Write(row); err != nil {
+		if err := w.WriteWithContext(ctx, row); err != nil {
 			return fmt.Errorf("write row: %w", err)
 		}
 	}

--- a/writer/arrow_test.go
+++ b/writer/arrow_test.go
@@ -2,6 +2,7 @@ package writer
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"reflect"
 	"testing"
@@ -285,10 +286,10 @@ func TestWriteArrow_EmptyRecord(t *testing.T) {
 
 	// Verify the file is valid with 0 rows
 	pf := buffer.NewBufferReaderFromBytesNoAlloc(buf.Bytes())
-	pr, err := reader.NewParquetReader(pf, nil, reader.WithNP(1))
+	pr, err := reader.NewParquetReaderWithContext(context.Background(), pf, nil, reader.WithNP(1))
 	require.NoError(t, err)
 	require.Equal(t, int64(0), pr.GetNumRows())
-	_ = pr.ReadStop()
+	_ = pr.ReadStopWithContext(context.Background())
 	require.NoError(t, pf.Close())
 }
 
@@ -322,12 +323,12 @@ func TestArrowWriterFloat16RoundTrip(t *testing.T) {
 
 	rawPF := buffer.NewBufferReaderFromBytesNoAlloc(buf.Bytes())
 	rawReader := &reader.ParquetReader{PFile: rawPF}
-	require.NoError(t, rawReader.ReadFooter())
+	require.NoError(t, rawReader.ReadFooterWithContext(context.Background()))
 	require.Equal(t, "float16_field", rawReader.Footer.Schema[1].GetName())
 	require.NoError(t, rawPF.Close())
 
 	pf := buffer.NewBufferReaderFromBytesNoAlloc(buf.Bytes())
-	pr, err := reader.NewParquetReader(pf, nil, reader.WithNP(1))
+	pr, err := reader.NewParquetReaderWithContext(context.Background(), pf, nil, reader.WithNP(1))
 	require.NoError(t, err)
 
 	expectedMin := float16FromFloat32(-2.5)
@@ -348,13 +349,13 @@ func TestArrowWriterFloat16RoundTrip(t *testing.T) {
 	require.NotNil(t, stats.NullCount)
 	require.Equal(t, int64(1), *stats.NullCount)
 
-	columnIndex, err := pr.ReadColumnIndex(0, 0)
+	columnIndex, err := pr.ReadColumnIndexWithContext(context.Background(), 0, 0)
 	require.NoError(t, err)
 	require.Equal(t, [][]byte{expectedMin}, columnIndex.MinValues)
 	require.Equal(t, [][]byte{expectedMax}, columnIndex.MaxValues)
 	require.Equal(t, []int64{1}, columnIndex.NullCounts)
 
-	rows, err := pr.ReadByNumber(int(pr.GetNumRows()))
+	rows, err := pr.ReadByNumberWithContext(context.Background(), int(pr.GetNumRows()))
 	require.NoError(t, err)
 	actual := make([][]any, 0, len(rows))
 	for _, row := range rows {
@@ -367,7 +368,7 @@ func TestArrowWriterFloat16RoundTrip(t *testing.T) {
 	}, actual)
 
 	require.NoError(t, fw.Close())
-	require.NoError(t, pr.ReadStop())
+	require.NoError(t, pr.ReadStopWithContext(context.Background()))
 	require.NoError(t, pf.Close())
 }
 
@@ -407,7 +408,7 @@ func TestArrowWriterFloat16TotalOrderStats(t *testing.T) {
 	require.NoError(t, aw.WriteStop())
 
 	pf := buffer.NewBufferReaderFromBytesNoAlloc(buf.Bytes())
-	pr, err := reader.NewParquetReader(pf, nil, reader.WithNP(1))
+	pr, err := reader.NewParquetReaderWithContext(context.Background(), pf, nil, reader.WithNP(1))
 	require.NoError(t, err)
 
 	expectedMin := float16LE(0xFE00)
@@ -417,13 +418,13 @@ func TestArrowWriterFloat16TotalOrderStats(t *testing.T) {
 	require.Equal(t, expectedMin, stats.MinValue)
 	require.Equal(t, expectedMax, stats.MaxValue)
 
-	columnIndex, err := pr.ReadColumnIndex(0, 0)
+	columnIndex, err := pr.ReadColumnIndexWithContext(context.Background(), 0, 0)
 	require.NoError(t, err)
 	require.Equal(t, [][]byte{expectedMin}, columnIndex.MinValues)
 	require.Equal(t, [][]byte{expectedMax}, columnIndex.MaxValues)
 
 	require.NoError(t, fw.Close())
-	require.NoError(t, pr.ReadStop())
+	require.NoError(t, pr.ReadStopWithContext(context.Background()))
 	require.NoError(t, pf.Close())
 }
 
@@ -473,15 +474,15 @@ func TestArrowWriterFloat16MixedSchema(t *testing.T) {
 
 	rawPF := buffer.NewBufferReaderFromBytesNoAlloc(buf.Bytes())
 	rawReader := &reader.ParquetReader{PFile: rawPF}
-	require.NoError(t, rawReader.ReadFooter())
+	require.NoError(t, rawReader.ReadFooterWithContext(context.Background()))
 	require.Equal(t, "fp16", rawReader.Footer.Schema[2].GetName())
 	require.NoError(t, rawPF.Close())
 
 	pf := buffer.NewBufferReaderFromBytesNoAlloc(buf.Bytes())
-	pr, err := reader.NewParquetReader(pf, nil, reader.WithNP(1))
+	pr, err := reader.NewParquetReaderWithContext(context.Background(), pf, nil, reader.WithNP(1))
 	require.NoError(t, err)
 
-	rows, err := pr.ReadByNumber(int(pr.GetNumRows()))
+	rows, err := pr.ReadByNumberWithContext(context.Background(), int(pr.GetNumRows()))
 	require.NoError(t, err)
 	actual := make([][]any, 0, len(rows))
 	for _, row := range rows {
@@ -499,7 +500,7 @@ func TestArrowWriterFloat16MixedSchema(t *testing.T) {
 	require.NotNil(t, fp16Element.LogicalType.FLOAT16)
 
 	require.NoError(t, fw.Close())
-	require.NoError(t, pr.ReadStop())
+	require.NoError(t, pr.ReadStopWithContext(context.Background()))
 	require.NoError(t, pf.Close())
 }
 
@@ -922,11 +923,11 @@ func TestArrowWriter(t *testing.T) {
 
 		parquetFile := buffer.NewBufferReaderFromBytesNoAlloc(buf.Bytes())
 
-		pr, err := reader.NewParquetReader(parquetFile, nil, reader.WithNP(1))
+		pr, err := reader.NewParquetReaderWithContext(context.Background(), parquetFile, nil, reader.WithNP(1))
 		require.Nil(t, err)
 
 		num := int(pr.GetNumRows())
-		res, err := pr.ReadByNumber(num)
+		res, err := pr.ReadByNumberWithContext(context.Background(), num)
 		require.Nil(t, err)
 
 		actualTable := ""
@@ -937,7 +938,7 @@ func TestArrowWriter(t *testing.T) {
 
 		err = fw.Close()
 		require.Nil(t, err)
-		err = pr.ReadStop()
+		err = pr.ReadStopWithContext(context.Background())
 		require.Nil(t, err)
 		err = parquetFile.Close()
 		require.Nil(t, err)
@@ -965,11 +966,11 @@ func TestArrowWriter(t *testing.T) {
 
 		parquetFile := buffer.NewBufferReaderFromBytesNoAlloc(buf.Bytes())
 
-		pr, err := reader.NewParquetReader(parquetFile, nil, reader.WithNP(1))
+		pr, err := reader.NewParquetReaderWithContext(context.Background(), parquetFile, nil, reader.WithNP(1))
 		require.Nil(t, err)
 
 		num := int(pr.GetNumRows())
-		res, err := pr.ReadByNumber(num)
+		res, err := pr.ReadByNumberWithContext(context.Background(), num)
 		require.Nil(t, err)
 
 		actualTable := [][]any{}
@@ -1008,7 +1009,7 @@ func TestArrowWriter(t *testing.T) {
 
 		err = fw.Close()
 		require.Nil(t, err)
-		err = pr.ReadStop()
+		err = pr.ReadStopWithContext(context.Background())
 		require.Nil(t, err)
 		err = parquetFile.Close()
 		require.Nil(t, err)
@@ -1036,11 +1037,11 @@ func TestArrowWriter(t *testing.T) {
 
 		parquetFile := buffer.NewBufferReaderFromBytesNoAlloc(buf.Bytes())
 
-		pr, err := reader.NewParquetReader(parquetFile, nil, reader.WithNP(1))
+		pr, err := reader.NewParquetReaderWithContext(context.Background(), parquetFile, nil, reader.WithNP(1))
 		require.Nil(t, err)
 
 		num := int(pr.GetNumRows())
-		res, err := pr.ReadByNumber(num)
+		res, err := pr.ReadByNumberWithContext(context.Background(), num)
 		require.Nil(t, err)
 
 		actualTable := ""
@@ -1051,7 +1052,7 @@ func TestArrowWriter(t *testing.T) {
 
 		err = fw.Close()
 		require.Nil(t, err)
-		err = pr.ReadStop()
+		err = pr.ReadStopWithContext(context.Background())
 		require.Nil(t, err)
 		err = parquetFile.Close()
 		require.Nil(t, err)

--- a/writer/bloomfilter.go
+++ b/writer/bloomfilter.go
@@ -1,7 +1,6 @@
 package writer
 
 import (
-	"context"
 	"fmt"
 	"sync"
 
@@ -25,7 +24,7 @@ func (pw *ParquetWriter) writeBloomFilters() error {
 			if data == nil {
 				continue
 			}
-			if _, err := pw.PFile.Write(data); err != nil {
+			if _, err := pw.write(data); err != nil {
 				return fmt.Errorf("write bloom filter: %w", err)
 			}
 			pos := pw.offset
@@ -76,7 +75,7 @@ func (pw *ParquetWriter) serializeBloomFilters() error {
 			pw.bloomFilterData = append(pw.bloomFilterData, nil)
 			continue
 		}
-		headerBuf, err := ts.Write(context.TODO(), bf.Header())
+		headerBuf, err := ts.Write(pw.context(), bf.Header())
 		if err != nil {
 			return fmt.Errorf("serialize bloom filter header for column %s: %w", path, err)
 		}

--- a/writer/bloomfilter_test.go
+++ b/writer/bloomfilter_test.go
@@ -253,7 +253,7 @@ func TestInsertBloomValues(t *testing.T) {
 func readBloomFilter(pf source.ParquetFileReader, offset int64) (*parquet.BloomFilterHeader, []byte, error) {
 	header := parquet.NewBloomFilterHeader()
 	tpf := thrift.NewTCompactProtocolFactoryConf(nil)
-	triftReader, err := source.ConvertToThriftReader(pf, offset)
+	triftReader, err := source.ConvertToThriftReaderWithContext(context.Background(), pf, offset)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -300,7 +300,7 @@ func TestBloomFilter(t *testing.T) {
 
 		// Read footer and verify bloom filter metadata
 		pf := buffer.NewBufferReaderFromBytesNoAlloc(buf.Bytes())
-		pr, err := reader.NewParquetReader(pf, new(BloomRecord), reader.WithNP(1))
+		pr, err := reader.NewParquetReaderWithContext(context.Background(), pf, new(BloomRecord), reader.WithNP(1))
 		require.NoError(t, err)
 
 		require.Len(t, pr.Footer.RowGroups, 1)
@@ -317,7 +317,7 @@ func TestBloomFilter(t *testing.T) {
 		nameCol := rg.Columns[1]
 		require.False(t, nameCol.MetaData.IsSetBloomFilterOffset())
 
-		_ = pr.ReadStop()
+		_ = pr.ReadStopWithContext(context.Background())
 	})
 
 	t.Run("bloom_filter_content_check", func(t *testing.T) {
@@ -335,7 +335,7 @@ func TestBloomFilter(t *testing.T) {
 
 		// Read the bloom filter data and verify it works
 		pf := buffer.NewBufferReaderFromBytesNoAlloc(buf.Bytes())
-		pr, err := reader.NewParquetReader(pf, new(BloomRecord), reader.WithNP(1))
+		pr, err := reader.NewParquetReaderWithContext(context.Background(), pf, new(BloomRecord), reader.WithNP(1))
 		require.NoError(t, err)
 
 		rg := pr.Footer.RowGroups[0]
@@ -357,7 +357,7 @@ func TestBloomFilter(t *testing.T) {
 			require.True(t, f.Check(h))
 		}
 
-		_ = pr.ReadStop()
+		_ = pr.ReadStopWithContext(context.Background())
 	})
 
 	t.Run("bloom_filter_with_dict_encoding", func(t *testing.T) {
@@ -376,7 +376,7 @@ func TestBloomFilter(t *testing.T) {
 
 		// Read and verify bloom filter works for dict-encoded column
 		pf := buffer.NewBufferReaderFromBytesNoAlloc(buf.Bytes())
-		pr, err := reader.NewParquetReader(pf, new(BloomRecord), reader.WithNP(1))
+		pr, err := reader.NewParquetReaderWithContext(context.Background(), pf, new(BloomRecord), reader.WithNP(1))
 		require.NoError(t, err)
 
 		rg := pr.Footer.RowGroups[0]
@@ -396,7 +396,7 @@ func TestBloomFilter(t *testing.T) {
 			require.True(t, f.Check(h))
 		}
 
-		_ = pr.ReadStop()
+		_ = pr.ReadStopWithContext(context.Background())
 	})
 
 	t.Run("bloom_filter_custom_size", func(t *testing.T) {
@@ -411,6 +411,7 @@ func TestBloomFilter(t *testing.T) {
 		require.NoError(t, pw.WriteStop())
 
 		pf := buffer.NewBufferReaderFromBytesNoAlloc(buf.Bytes())
+		//nolint:staticcheck
 		pr, err := reader.NewParquetReader(pf, new(BloomRecord), reader.WithNP(1))
 		require.NoError(t, err)
 
@@ -421,6 +422,7 @@ func TestBloomFilter(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, int32(2048), header.NumBytes)
 
+		//nolint:staticcheck
 		_ = pr.ReadStop()
 	})
 
@@ -440,6 +442,7 @@ func TestBloomFilter(t *testing.T) {
 		require.NoError(t, pw.WriteStop())
 
 		pf := buffer.NewBufferReaderFromBytesNoAlloc(buf.Bytes())
+		//nolint:staticcheck
 		pr, err := reader.NewParquetReader(pf, new(BloomRecord), reader.WithNP(1))
 		require.NoError(t, err)
 
@@ -462,6 +465,7 @@ func TestBloomFilter(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, f.Check(h2))
 
+		//nolint:staticcheck
 		_ = pr.ReadStop()
 	})
 
@@ -484,6 +488,7 @@ func TestBloomFilter(t *testing.T) {
 		require.NoError(t, pw.WriteStop())
 
 		pf := buffer.NewBufferReaderFromBytesNoAlloc(buf.Bytes())
+		//nolint:staticcheck
 		pr, err := reader.NewParquetReader(pf, new(BloomRecord), reader.WithNP(1))
 		require.NoError(t, err)
 
@@ -495,6 +500,7 @@ func TestBloomFilter(t *testing.T) {
 			require.True(t, col.MetaData.IsSetBloomFilterOffset())
 		}
 
+		//nolint:staticcheck
 		_ = pr.ReadStop()
 	})
 
@@ -511,6 +517,7 @@ func TestBloomFilter(t *testing.T) {
 		require.NoError(t, pw.WriteStop())
 
 		pf := buffer.NewBufferReaderFromBytesNoAlloc(buf.Bytes())
+		//nolint:staticcheck
 		pr, err := reader.NewParquetReader(pf, new(NoBloomRecord), reader.WithNP(1))
 		require.NoError(t, err)
 
@@ -518,6 +525,7 @@ func TestBloomFilter(t *testing.T) {
 			require.False(t, col.MetaData.IsSetBloomFilterOffset())
 		}
 
+		//nolint:staticcheck
 		_ = pr.ReadStop()
 	})
 }

--- a/writer/csv.go
+++ b/writer/csv.go
@@ -1,6 +1,7 @@
 package writer
 
 import (
+	"context"
 	"fmt"
 	"io"
 
@@ -17,15 +18,29 @@ type CSVWriter struct {
 }
 
 // NewCSVWriterFromWriter creates a CSVWriter from an io.Writer.
+//
+// Deprecated: use NewCSVWriterFromWriterWithContext.
 func NewCSVWriterFromWriter(md []string, w io.Writer, opts ...WriterOption) (*CSVWriter, error) {
+	return NewCSVWriterFromWriterWithContext(context.Background(), md, w, opts...)
+}
+
+// NewCSVWriterFromWriterWithContext creates a CSVWriter using ctx.
+func NewCSVWriterFromWriterWithContext(ctx context.Context, md []string, w io.Writer, opts ...WriterOption) (*CSVWriter, error) {
 	wf := writerfile.NewWriterFile(w)
-	return NewCSVWriter(md, wf, opts...)
+	return NewCSVWriterWithContext(ctx, md, wf, opts...)
 }
 
 // NewCSVWriter creates a CSVWriter from a schema metadata list and a ParquetFileWriter.
+//
+// Deprecated: use NewCSVWriterWithContext.
 func NewCSVWriter(md []string, pfile source.ParquetFileWriter, opts ...WriterOption) (*CSVWriter, error) {
+	return NewCSVWriterWithContext(context.Background(), md, pfile, opts...)
+}
+
+// NewCSVWriterWithContext creates a CSVWriter using ctx.
+func NewCSVWriterWithContext(ctx context.Context, md []string, pfile source.ParquetFileWriter, opts ...WriterOption) (*CSVWriter, error) {
 	res := new(CSVWriter)
-	if err := res.initBase(pfile, opts...); err != nil {
+	if err := res.initBase(ctx, pfile, opts...); err != nil {
 		return nil, fmt.Errorf("init CSV writer base: %w", err)
 	}
 
@@ -48,7 +63,17 @@ func NewCSVWriter(md []string, pfile source.ParquetFileWriter, opts ...WriterOpt
 }
 
 // WriteString writes string values to parquet file.
+//
+// Deprecated: use WriteStringWithContext.
 func (w *CSVWriter) WriteString(recsi any) error {
+	return w.WriteStringWithContext(w.defaultContext(), recsi)
+}
+
+// WriteStringWithContext writes string values using ctx.
+func (w *CSVWriter) WriteStringWithContext(ctx context.Context, recsi any) error {
+	if err := w.setContext(ctx); err != nil {
+		return err
+	}
 	var err error
 	recs, ok := recsi.([]*string)
 	if !ok {
@@ -73,7 +98,7 @@ func (w *CSVWriter) WriteString(recsi any) error {
 		}
 	}
 
-	if err := w.Write(rec); err != nil {
+	if err := w.WriteWithContext(ctx, rec); err != nil {
 		return fmt.Errorf("write row: %w", err)
 	}
 	return nil

--- a/writer/encryption.go
+++ b/writer/encryption.go
@@ -167,7 +167,7 @@ func (pw *ParquetWriter) encryptPage(page *layout.Page, key []byte, rowGroupOrdi
 		return nil
 	}
 	// Serialize the original header to locate the body within RawData.
-	originalHeaderBuf, err := serializeCompact(page.Header)
+	originalHeaderBuf, err := serializeCompact(pw.context(), page.Header)
 	if err != nil {
 		return fmt.Errorf("serialize page header: %w", err)
 	}
@@ -207,7 +207,7 @@ func (pw *ParquetWriter) encryptPage(page *layout.Page, key []byte, rowGroupOrdi
 	page.Header.CompressedPageSize = int32(len(encodedBody))
 
 	// Re-serialize the header with the updated CompressedPageSize.
-	headerBuf, err := serializeCompact(page.Header)
+	headerBuf, err := serializeCompact(pw.context(), page.Header)
 	if err != nil {
 		return fmt.Errorf("re-serialize page header: %w", err)
 	}
@@ -237,10 +237,10 @@ func (pw *ParquetWriter) moduleAAD(moduleType encryption.ModuleType, rowGroupOrd
 	)
 }
 
-func serializeCompact(v thrift.TStruct) ([]byte, error) {
+func serializeCompact(ctx context.Context, v thrift.TStruct) ([]byte, error) {
 	ts := thrift.NewTSerializer()
 	ts.Protocol = thrift.NewTCompactProtocolFactoryConf(&thrift.TConfiguration{}).GetProtocol(ts.Transport)
-	return ts.Write(context.TODO(), v)
+	return ts.Write(ctx, v)
 }
 
 func (pw *ParquetWriter) encryptThriftModule(key []byte, moduleType encryption.ModuleType, rowGroupOrdinal, columnOrdinal int16, plain []byte) ([]byte, error) {
@@ -271,7 +271,7 @@ func (pw *ParquetWriter) encryptFooter(footerBuf []byte) ([]byte, string, error)
 	fileCrypto := parquet.NewFileCryptoMetaData()
 	fileCrypto.EncryptionAlgorithm = pw.encryptionState.parquetAlgorithm()
 	fileCrypto.KeyMetadata = append([]byte(nil), pw.encryptionState.footerKeyMetadata...)
-	fileCryptoBuf, err := serializeCompact(fileCrypto)
+	fileCryptoBuf, err := serializeCompact(pw.context(), fileCrypto)
 	if err != nil {
 		return nil, "", fmt.Errorf("serialize file crypto metadata: %w", err)
 	}

--- a/writer/encryption_config_test.go
+++ b/writer/encryption_config_test.go
@@ -2,6 +2,7 @@ package writer
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"testing"
 
@@ -43,18 +44,18 @@ func TestEncryptedWriterKeyRetriever(t *testing.T) {
 	require.NoError(t, pw.Write(encryptedWriterRecord{ID: 1, Name: "alpha"}))
 	require.NoError(t, pw.WriteStop())
 
-	pr, err := reader.NewParquetReader(
-		buffer.NewBufferReaderFromBytesNoAlloc(buf.Bytes()),
+	pr, err := reader.NewParquetReaderWithContext(
+		context.Background(), buffer.NewBufferReaderFromBytesNoAlloc(buf.Bytes()),
 		new(encryptedWriterRecord),
 		reader.WithKeyRetriever(keyRetriever),
 	)
 	require.NoError(t, err)
 	defer func() {
-		require.NoError(t, pr.ReadStop())
+		require.NoError(t, pr.ReadStopWithContext(context.Background()))
 	}()
 
 	rows := make([]encryptedWriterRecord, 1)
-	require.NoError(t, pr.Read(&rows))
+	require.NoError(t, pr.ReadWithContext(context.Background(), &rows))
 	require.Equal(t, []encryptedWriterRecord{{ID: 1, Name: "alpha"}}, rows)
 }
 
@@ -86,18 +87,18 @@ func TestEncryptedWriterFooterKeyPrecedence(t *testing.T) {
 	require.NoError(t, pw.WriteStop())
 
 	// WithFooterKey wins: file was encrypted with footerKey, not wrongFooterKey from retriever
-	pr, err := reader.NewParquetReader(
-		buffer.NewBufferReaderFromBytesNoAlloc(buf.Bytes()),
+	pr, err := reader.NewParquetReaderWithContext(
+		context.Background(), buffer.NewBufferReaderFromBytesNoAlloc(buf.Bytes()),
 		new(encryptedWriterRecord),
 		reader.WithFooterKey(footerKey),
 	)
 	require.NoError(t, err)
 	defer func() {
-		require.NoError(t, pr.ReadStop())
+		require.NoError(t, pr.ReadStopWithContext(context.Background()))
 	}()
 
 	rows := make([]encryptedWriterRecord, 1)
-	require.NoError(t, pr.Read(&rows))
+	require.NoError(t, pr.ReadWithContext(context.Background(), &rows))
 	require.Equal(t, []encryptedWriterRecord{{ID: 1, Name: "alpha"}}, rows)
 }
 
@@ -132,19 +133,19 @@ func TestEncryptedWriterColumnKeyPrecedence(t *testing.T) {
 	require.NoError(t, pw.Write(encryptedWriterRecord{ID: 1, Name: "alpha"}))
 	require.NoError(t, pw.WriteStop())
 
-	pr, err := reader.NewParquetReader(
-		buffer.NewBufferReaderFromBytesNoAlloc(buf.Bytes()),
+	pr, err := reader.NewParquetReaderWithContext(
+		context.Background(), buffer.NewBufferReaderFromBytesNoAlloc(buf.Bytes()),
 		new(encryptedWriterRecord),
 		reader.WithFooterKey(footerKey),
 		reader.WithColumnKey("name", nameKey),
 	)
 	require.NoError(t, err)
 	defer func() {
-		require.NoError(t, pr.ReadStop())
+		require.NoError(t, pr.ReadStopWithContext(context.Background()))
 	}()
 
 	rows := make([]encryptedWriterRecord, 1)
-	require.NoError(t, pr.Read(&rows))
+	require.NoError(t, pr.ReadWithContext(context.Background(), &rows))
 	require.Equal(t, []encryptedWriterRecord{{ID: 1, Name: "alpha"}}, rows)
 }
 

--- a/writer/encryption_test.go
+++ b/writer/encryption_test.go
@@ -2,6 +2,7 @@ package writer
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -116,21 +117,21 @@ func TestEncryptedWriterRoundTrip(t *testing.T) {
 			data := buf.Bytes()
 			require.Equal(t, tt.wantTailMagic, string(data[len(data)-4:]))
 
-			pr, err := reader.NewParquetReader(buffer.NewBufferReaderFromBytesNoAlloc(data), new(encryptedWriterRecord), tt.readerOptions...)
+			pr, err := reader.NewParquetReaderWithContext(context.Background(), buffer.NewBufferReaderFromBytesNoAlloc(data), new(encryptedWriterRecord), tt.readerOptions...)
 			require.NoError(t, err)
 			defer func() {
-				require.NoError(t, pr.ReadStop())
+				require.NoError(t, pr.ReadStopWithContext(context.Background()))
 			}()
 
 			rows := make([]encryptedWriterRecord, 2)
-			require.NoError(t, pr.Read(&rows))
+			require.NoError(t, pr.ReadWithContext(context.Background(), &rows))
 			require.Equal(t, []encryptedWriterRecord{{ID: 1, Name: "alpha"}, {ID: 2, Name: "beta"}}, rows)
 
-			columnIndex, err := pr.ReadColumnIndex(0, 1)
+			columnIndex, err := pr.ReadColumnIndexWithContext(context.Background(), 0, 1)
 			require.NoError(t, err)
 			require.NotNil(t, columnIndex)
 
-			found, err := pr.BloomFilterCheck("name", 0, "alpha")
+			found, err := pr.BloomFilterCheckWithContext(context.Background(), "name", 0, "alpha")
 			require.NoError(t, err)
 			require.True(t, found)
 		})
@@ -160,17 +161,17 @@ func TestEncryptedWriterAuthFailure(t *testing.T) {
 	}
 
 	tryRead := func(data []byte, opts ...reader.ReaderOption) error {
-		pr, err := reader.NewParquetReader(
-			buffer.NewBufferReaderFromBytesNoAlloc(data),
+		pr, err := reader.NewParquetReaderWithContext(
+			context.Background(), buffer.NewBufferReaderFromBytesNoAlloc(data),
 			new(encryptedWriterRecord),
 			opts...,
 		)
 		if err != nil {
 			return err
 		}
-		defer pr.ReadStop() //nolint:errcheck
+		defer pr.ReadStopWithContext(context.Background()) //nolint:errcheck
 		rows := make([]encryptedWriterRecord, 1)
-		return pr.Read(&rows)
+		return pr.ReadWithContext(context.Background(), &rows)
 	}
 
 	t.Run("wrong footer key", func(t *testing.T) {
@@ -248,46 +249,46 @@ func TestEncryptedWriterColumnKeyProtectsBloomAndIndex(t *testing.T) {
 
 	// With correct keys: column index works for every column, bloom filter
 	// works for the name column (encrypted with its own key).
-	pr, err := reader.NewParquetReader(
-		buffer.NewBufferReaderFromBytesNoAlloc(data),
+	pr, err := reader.NewParquetReaderWithContext(
+		context.Background(), buffer.NewBufferReaderFromBytesNoAlloc(data),
 		new(encryptedWriterRecord),
 		reader.WithFooterKey(footerKey),
 		reader.WithColumnKey("name", nameKey),
 	)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, pr.ReadStop()) }()
+	defer func() { require.NoError(t, pr.ReadStopWithContext(context.Background())) }()
 
 	for rg, rowGroup := range pr.Footer.RowGroups {
 		for col := range rowGroup.GetColumns() {
-			idx, idxErr := pr.ReadColumnIndex(rg, col)
+			idx, idxErr := pr.ReadColumnIndexWithContext(context.Background(), rg, col)
 			require.NoError(t, idxErr)
 			require.NotNil(t, idx)
 		}
 	}
 
-	found, err := pr.BloomFilterCheck("name", 0, "alpha")
+	found, err := pr.BloomFilterCheckWithContext(context.Background(), "name", 0, "alpha")
 	require.NoError(t, err)
 	require.True(t, found)
 
-	notFound, err := pr.BloomFilterCheck("name", 0, "nosuchvalue")
+	notFound, err := pr.BloomFilterCheckWithContext(context.Background(), "name", 0, "nosuchvalue")
 	require.NoError(t, err)
 	require.False(t, notFound)
 
 	// Without the name column key: the reader can open the file because
 	// the encrypted footer contains plaintext column metadata, but reading
 	// encrypted name-column modules still requires the name key.
-	prMissingNameKey, err := reader.NewParquetReader(
-		buffer.NewBufferReaderFromBytesNoAlloc(data),
+	prMissingNameKey, err := reader.NewParquetReaderWithContext(
+		context.Background(), buffer.NewBufferReaderFromBytesNoAlloc(data),
 		new(encryptedWriterRecord),
 		reader.WithFooterKey(footerKey),
 	)
 	require.NoError(t, err)
-	defer func() { require.NoError(t, prMissingNameKey.ReadStop()) }()
+	defer func() { require.NoError(t, prMissingNameKey.ReadStopWithContext(context.Background())) }()
 
-	_, err = prMissingNameKey.ReadColumnIndex(0, 1)
+	_, err = prMissingNameKey.ReadColumnIndexWithContext(context.Background(), 0, 1)
 	require.ErrorContains(t, err, "decryption key required for column "+common.ParGoRootExName+".name")
 
-	_, err = prMissingNameKey.BloomFilterCheck("name", 0, "alpha")
+	_, err = prMissingNameKey.BloomFilterCheckWithContext(context.Background(), "name", 0, "alpha")
 	require.ErrorContains(t, err, "decryption key required for column "+common.ParGoRootExName+".name")
 }
 
@@ -443,20 +444,20 @@ func TestEncryptedWriterPlaintextFooterSignatureVerification(t *testing.T) {
 	data := buf.Bytes()
 
 	// Correct key: footer signature verifies and rows are readable.
-	pr, err := reader.NewParquetReader(
-		buffer.NewBufferReaderFromBytesNoAlloc(data),
+	pr, err := reader.NewParquetReaderWithContext(
+		context.Background(), buffer.NewBufferReaderFromBytesNoAlloc(data),
 		new(encryptedWriterRecord),
 		reader.WithFooterKey(footerKey),
 	)
 	require.NoError(t, err)
 	rows := make([]encryptedWriterRecord, 1)
-	require.NoError(t, pr.Read(&rows))
+	require.NoError(t, pr.ReadWithContext(context.Background(), &rows))
 	require.Equal(t, int32(1), rows[0].ID)
-	require.NoError(t, pr.ReadStop())
+	require.NoError(t, pr.ReadStopWithContext(context.Background()))
 
 	// Wrong key: footer signature verification must fail.
-	_, err = reader.NewParquetReader(
-		buffer.NewBufferReaderFromBytesNoAlloc(data),
+	_, err = reader.NewParquetReaderWithContext(
+		context.Background(), buffer.NewBufferReaderFromBytesNoAlloc(data),
 		new(encryptedWriterRecord),
 		reader.WithFooterKey([]byte("abcdef0123456789")),
 	)
@@ -527,7 +528,7 @@ func TestEncryptPageUpdatesCompressedPageSize(t *testing.T) {
 			header.UncompressedPageSize = int32(tt.bodyLen)
 			header.CompressedPageSize = int32(tt.bodyLen)
 
-			headerBuf, err := serializeCompact(header)
+			headerBuf, err := serializeCompact(context.Background(), header)
 			require.NoError(t, err)
 
 			rawData := make([]byte, len(headerBuf)+tt.bodyLen)
@@ -571,7 +572,7 @@ func TestEncryptPageErrors(t *testing.T) {
 
 	t.Run("header re-serialization mismatch", func(t *testing.T) {
 		t.Parallel()
-		headerBuf, serErr := serializeCompact(header)
+		headerBuf, serErr := serializeCompact(context.Background(), header)
 		require.NoError(t, serErr)
 		rawData := bytes.Repeat([]byte{0xFF}, len(headerBuf)+10)
 		page := &layout.Page{

--- a/writer/index.go
+++ b/writer/index.go
@@ -1,7 +1,6 @@
 package writer
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/apache/thrift/lib/go/thrift"
@@ -24,7 +23,7 @@ func (pw *ParquetWriter) writeColumnIndexes(ts *thrift.TSerializer) error {
 			if columnIndex == nil {
 				continue
 			}
-			columnIndexBuf, err := ts.Write(context.TODO(), columnIndex)
+			columnIndexBuf, err := ts.Write(pw.context(), columnIndex)
 			if err != nil {
 				return fmt.Errorf("serialize column index: %w", err)
 			}
@@ -43,7 +42,7 @@ func (pw *ParquetWriter) writeColumnIndexes(ts *thrift.TSerializer) error {
 				}
 				columnIndexBuf = module
 			}
-			if _, err = pw.PFile.Write(columnIndexBuf); err != nil {
+			if _, err = pw.write(columnIndexBuf); err != nil {
 				return fmt.Errorf("write column index: %w", err)
 			}
 
@@ -65,7 +64,7 @@ func (pw *ParquetWriter) writeOffsetIndexes(ts *thrift.TSerializer) error {
 	idx := 0
 	for rowGroupIndex, rowGroup := range pw.Footer.RowGroups {
 		for columnOrdinal, columnChunk := range rowGroup.Columns {
-			offsetIndexBuf, err := ts.Write(context.TODO(), pw.offsetIndexes[idx])
+			offsetIndexBuf, err := ts.Write(pw.context(), pw.offsetIndexes[idx])
 			if err != nil {
 				return fmt.Errorf("serialize offset index: %w", err)
 			}
@@ -84,7 +83,7 @@ func (pw *ParquetWriter) writeOffsetIndexes(ts *thrift.TSerializer) error {
 				}
 				offsetIndexBuf = module
 			}
-			if _, err = pw.PFile.Write(offsetIndexBuf); err != nil {
+			if _, err = pw.write(offsetIndexBuf); err != nil {
 				return fmt.Errorf("write offset index: %w", err)
 			}
 

--- a/writer/json.go
+++ b/writer/json.go
@@ -1,6 +1,7 @@
 package writer
 
 import (
+	"context"
 	"fmt"
 	"io"
 
@@ -16,15 +17,29 @@ type JSONWriter struct {
 }
 
 // NewJSONWriterFromWriter creates a JSONWriter from an io.Writer.
+//
+// Deprecated: use NewJSONWriterFromWriterWithContext.
 func NewJSONWriterFromWriter(jsonSchema string, w io.Writer, opts ...WriterOption) (*JSONWriter, error) {
+	return NewJSONWriterFromWriterWithContext(context.Background(), jsonSchema, w, opts...)
+}
+
+// NewJSONWriterFromWriterWithContext creates a JSONWriter using ctx.
+func NewJSONWriterFromWriterWithContext(ctx context.Context, jsonSchema string, w io.Writer, opts ...WriterOption) (*JSONWriter, error) {
 	wf := writerfile.NewWriterFile(w)
-	return NewJSONWriter(jsonSchema, wf, opts...)
+	return NewJSONWriterWithContext(ctx, jsonSchema, wf, opts...)
 }
 
 // NewJSONWriter creates a JSONWriter from a JSON schema string and a ParquetFileWriter.
+//
+// Deprecated: use NewJSONWriterWithContext.
 func NewJSONWriter(jsonSchema string, pfile source.ParquetFileWriter, opts ...WriterOption) (*JSONWriter, error) {
+	return NewJSONWriterWithContext(context.Background(), jsonSchema, pfile, opts...)
+}
+
+// NewJSONWriterWithContext creates a JSONWriter using ctx.
+func NewJSONWriterWithContext(ctx context.Context, jsonSchema string, pfile source.ParquetFileWriter, opts ...WriterOption) (*JSONWriter, error) {
 	res := new(JSONWriter)
-	if err := res.initBase(pfile, opts...); err != nil {
+	if err := res.initBase(ctx, pfile, opts...); err != nil {
 		return nil, fmt.Errorf("init JSON writer base: %w", err)
 	}
 

--- a/writer/json_test.go
+++ b/writer/json_test.go
@@ -328,12 +328,14 @@ func TestJSONWriter(t *testing.T) {
 				// Verify row count if specified
 				if tt.expectRows != nil {
 					pf := buffer.NewBufferReaderFromBytesNoAlloc(buf.Bytes())
+					//nolint:staticcheck
 					pr, err := reader.NewParquetReader(pf, nil, reader.WithNP(1))
 					require.NoError(t, err)
 
 					numRows := pr.GetNumRows()
 					require.Equal(t, *tt.expectRows, numRows)
 
+					//nolint:staticcheck
 					_ = pr.ReadStop()
 					_ = pf.Close()
 				}

--- a/writer/mixed_encryption.go
+++ b/writer/mixed_encryption.go
@@ -239,7 +239,7 @@ func (pw *ParquetWriter) encryptColumnMetadata(rowGroupOrdinal, columnOrdinal in
 	if !plaintextFooter && footerKey {
 		return nil
 	}
-	plain, err := serializeCompact(column.MetaData)
+	plain, err := serializeCompact(pw.context(), column.MetaData)
 	if err != nil {
 		return fmt.Errorf("serialize column metadata: %w", err)
 	}

--- a/writer/mixed_encryption_test.go
+++ b/writer/mixed_encryption_test.go
@@ -145,6 +145,7 @@ func TestMixedEncryptedFooterRoundTrip(t *testing.T) {
 		WithColumnEncrypted("name", ColumnKey(nameKey)),
 	)
 
+	//nolint:staticcheck
 	pr, err := reader.NewParquetReader(
 		buffer.NewBufferReaderFromBytesNoAlloc(data),
 		new(mixedRecord),
@@ -152,9 +153,11 @@ func TestMixedEncryptedFooterRoundTrip(t *testing.T) {
 		reader.WithColumnKey("name", nameKey),
 	)
 	require.NoError(t, err)
+	//nolint:staticcheck
 	defer func() { require.NoError(t, pr.ReadStop()) }()
 
 	rows := make([]mixedRecord, 3)
+	//nolint:staticcheck
 	require.NoError(t, pr.Read(&rows))
 	require.Equal(t, []mixedRecord{
 		{ID: 1, Name: "alpha", Score: 1.1},
@@ -178,6 +181,7 @@ func TestMixedEncryptedFooterMetadata(t *testing.T) {
 		WithColumnEncrypted("name", ColumnKey(nameKey)),
 	)
 
+	//nolint:staticcheck
 	pr, err := reader.NewParquetReader(
 		buffer.NewBufferReaderFromBytesNoAlloc(data),
 		new(mixedRecord),
@@ -185,6 +189,7 @@ func TestMixedEncryptedFooterMetadata(t *testing.T) {
 		reader.WithColumnKey("name", nameKey),
 	)
 	require.NoError(t, err)
+	//nolint:staticcheck
 	defer func() { require.NoError(t, pr.ReadStop()) }()
 
 	require.NotEmpty(t, pr.Footer.RowGroups)
@@ -223,26 +228,33 @@ func TestMixedEncryptedFooterPartialRead(t *testing.T) {
 		WithColumnEncrypted("name", ColumnKey(nameKey)),
 	)
 
+	//nolint:staticcheck
 	pr, err := reader.NewParquetReader(
 		buffer.NewBufferReaderFromBytesNoAlloc(data),
 		new(mixedRecord),
 		reader.WithFooterKey(footerKey),
 	)
 	require.NoError(t, err)
+	//nolint:staticcheck
 	defer func() { _ = pr.ReadStop() }()
 
+	//nolint:staticcheck
 	idValues, _, _, err := pr.ReadColumnByPath(common.PathToStr([]string{"parquet_go_root", "id"}), 3)
 	require.NoError(t, err)
 	require.Equal(t, []any{int64(1), int64(2), int64(3)}, idValues)
 
+	//nolint:staticcheck
 	require.NoError(t, pr.Reset())
 
+	//nolint:staticcheck
 	scoreValues, _, _, err := pr.ReadColumnByPath(common.PathToStr([]string{"parquet_go_root", "score"}), 3)
 	require.NoError(t, err)
 	require.Equal(t, []any{1.1, 2.2, 3.3}, scoreValues)
 
+	//nolint:staticcheck
 	require.NoError(t, pr.Reset())
 
+	//nolint:staticcheck
 	_, _, _, err = pr.ReadColumnByPath(common.PathToStr([]string{"parquet_go_root", "name"}), 3)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "decryption key required for column")
@@ -261,15 +273,18 @@ func TestMixedAllColumnsPlaintextWithEncryptedFooter(t *testing.T) {
 		WithFooterKey(footerKey),
 	)
 
+	//nolint:staticcheck
 	pr, err := reader.NewParquetReader(
 		buffer.NewBufferReaderFromBytesNoAlloc(data),
 		new(mixedRecord),
 		reader.WithFooterKey(footerKey),
 	)
 	require.NoError(t, err)
+	//nolint:staticcheck
 	defer func() { require.NoError(t, pr.ReadStop()) }()
 
 	rows := make([]mixedRecord, 3)
+	//nolint:staticcheck
 	require.NoError(t, pr.Read(&rows))
 	require.Equal(t, []mixedRecord{
 		{ID: 1, Name: "alpha", Score: 1.1},
@@ -282,6 +297,7 @@ func TestMixedAllColumnsPlaintextWithEncryptedFooter(t *testing.T) {
 		require.Nilf(t, c.CryptoMetadata, "column %v should be plaintext", c.MetaData.PathInSchema)
 	}
 
+	//nolint:staticcheck
 	_, err = reader.NewParquetReader(
 		buffer.NewBufferReaderFromBytesNoAlloc(data),
 		new(mixedRecord),
@@ -305,15 +321,18 @@ func TestMixedFooterKeyColumn(t *testing.T) {
 		WithColumnEncrypted("name", ColumnFooterKey()),
 	)
 
+	//nolint:staticcheck
 	pr, err := reader.NewParquetReader(
 		buffer.NewBufferReaderFromBytesNoAlloc(data),
 		new(mixedRecord),
 		reader.WithFooterKey(footerKey),
 	)
 	require.NoError(t, err)
+	//nolint:staticcheck
 	defer func() { require.NoError(t, pr.ReadStop()) }()
 
 	rows := make([]mixedRecord, 3)
+	//nolint:staticcheck
 	require.NoError(t, pr.Read(&rows))
 	require.Equal(t, []mixedRecord{
 		{ID: 1, Name: "alpha", Score: 1.1},
@@ -347,6 +366,7 @@ func TestMixedPlaintextFooterRoundTrip(t *testing.T) {
 		WithColumnEncrypted("name", ColumnKey(nameKey)),
 	)
 
+	//nolint:staticcheck
 	pr, err := reader.NewParquetReader(
 		buffer.NewBufferReaderFromBytesNoAlloc(data),
 		new(mixedRecord),
@@ -354,9 +374,11 @@ func TestMixedPlaintextFooterRoundTrip(t *testing.T) {
 		reader.WithColumnKey("name", nameKey),
 	)
 	require.NoError(t, err)
+	//nolint:staticcheck
 	defer func() { require.NoError(t, pr.ReadStop()) }()
 
 	rows := make([]mixedRecord, 3)
+	//nolint:staticcheck
 	require.NoError(t, pr.Read(&rows))
 	require.Equal(t, []mixedRecord{
 		{ID: 1, Name: "alpha", Score: 1.1},
@@ -381,6 +403,7 @@ func TestMixedPlaintextFooterMetadataStripping(t *testing.T) {
 		WithColumnEncrypted("name", ColumnKey(nameKey)),
 	)
 
+	//nolint:staticcheck
 	pr, err := reader.NewParquetReader(
 		buffer.NewBufferReaderFromBytesNoAlloc(data),
 		new(mixedRecord),
@@ -388,6 +411,7 @@ func TestMixedPlaintextFooterMetadataStripping(t *testing.T) {
 		reader.WithColumnKey("name", nameKey),
 	)
 	require.NoError(t, err)
+	//nolint:staticcheck
 	defer func() { require.NoError(t, pr.ReadStop()) }()
 
 	rg := pr.Footer.RowGroups[0]
@@ -404,12 +428,14 @@ func TestMixedPlaintextFooterMetadataStripping(t *testing.T) {
 	// the plaintext copy. The reader rehydrates them from
 	// EncryptedColumnMetadata when the column key is available, so we
 	// inspect the raw footer instead (parse a fresh copy).
+	//nolint:staticcheck
 	prRaw, err := reader.NewParquetReader(
 		buffer.NewBufferReaderFromBytesNoAlloc(data),
 		new(mixedRecord),
 		reader.WithFooterKey(footerKey),
 	)
 	require.NoError(t, err)
+	//nolint:staticcheck
 	defer func() { _ = prRaw.ReadStop() }()
 	rgRaw := prRaw.Footer.RowGroups[0]
 	for _, c := range rgRaw.Columns {
@@ -459,6 +485,7 @@ func TestMixedPlaintextPageRawVerification(t *testing.T) {
 		WithColumnEncrypted("secret", ColumnKey(secretKey)),
 	)
 
+	//nolint:staticcheck
 	pr, err := reader.NewParquetReader(
 		buffer.NewBufferReaderFromBytesNoAlloc(data),
 		new(plaintextDictionaryRecord),
@@ -466,6 +493,7 @@ func TestMixedPlaintextPageRawVerification(t *testing.T) {
 		reader.WithColumnKey("secret", secretKey),
 	)
 	require.NoError(t, err)
+	//nolint:staticcheck
 	defer func() { _ = pr.ReadStop() }()
 
 	rg := pr.Footer.RowGroups[0]
@@ -501,13 +529,16 @@ func TestMixedPlaintextPageRawVerification(t *testing.T) {
 	_, err = readCompactStructFrom(data, secretCol.MetaData.DataPageOffset, encryptedHeader)
 	require.Error(t, err, "encrypted page bytes must not parse as a plaintext page header")
 
+	//nolint:staticcheck
 	prNoColumnKey, err := reader.NewParquetReader(
 		buffer.NewBufferReaderFromBytesNoAlloc(data),
 		new(plaintextDictionaryRecord),
 		reader.WithFooterKey(footerKey),
 	)
 	require.NoError(t, err)
+	//nolint:staticcheck
 	defer func() { _ = prNoColumnKey.ReadStop() }()
+	//nolint:staticcheck
 	values, _, _, err := prNoColumnKey.ReadColumnByPath(common.PathToStr([]string{"parquet_go_root", "category"}), 6)
 	require.NoError(t, err)
 	require.Equal(t, []any{"red", "blue", "red", "green", "blue", "red"}, values)
@@ -576,6 +607,7 @@ func TestThreeWayMixRoundTrip(t *testing.T) {
 		WithColumnEncrypted("secret_name", ColumnKey(nameKey)),
 	)
 
+	//nolint:staticcheck
 	pr, err := reader.NewParquetReader(
 		buffer.NewBufferReaderFromBytesNoAlloc(data),
 		new(threeWayRecord),
@@ -583,9 +615,11 @@ func TestThreeWayMixRoundTrip(t *testing.T) {
 		reader.WithColumnKey("secret_name", nameKey),
 	)
 	require.NoError(t, err)
+	//nolint:staticcheck
 	defer func() { require.NoError(t, pr.ReadStop()) }()
 
 	rows := make([]threeWayRecord, 5)
+	//nolint:staticcheck
 	require.NoError(t, pr.Read(&rows))
 	require.Equal(t, []threeWayRecord{
 		{PlainID: 1, FooterTag: "red", SecretName: "alpha", PlainScore: 1.1},
@@ -624,6 +658,7 @@ func TestThreeWayBloomFilterAccess(t *testing.T) {
 		WithColumnEncrypted("secret_name", ColumnKey(nameKey)),
 	)
 
+	//nolint:staticcheck
 	pr, err := reader.NewParquetReader(
 		buffer.NewBufferReaderFromBytesNoAlloc(data),
 		new(threeWayRecord),
@@ -631,20 +666,24 @@ func TestThreeWayBloomFilterAccess(t *testing.T) {
 		reader.WithColumnKey("secret_name", nameKey),
 	)
 	require.NoError(t, err)
+	//nolint:staticcheck
 	defer func() { require.NoError(t, pr.ReadStop()) }()
 
 	// Plaintext column bloom filter - accessible with no special key,
 	// but the reader still needs the footer key to open the file.
+	//nolint:staticcheck
 	found, err := pr.BloomFilterCheck("plain_score", 0, 1.1)
 	require.NoError(t, err)
 	require.True(t, found)
 
 	// Footer-key column bloom filter - decrypts with the footer key.
+	//nolint:staticcheck
 	found, err = pr.BloomFilterCheck("footer_tag", 0, "red")
 	require.NoError(t, err)
 	require.True(t, found)
 
 	// Column-key column bloom filter - decrypts with the column key.
+	//nolint:staticcheck
 	found, err = pr.BloomFilterCheck("secret_name", 0, "alpha")
 	require.NoError(t, err)
 	require.True(t, found)
@@ -666,6 +705,7 @@ func TestThreeWayColumnIndexAccess(t *testing.T) {
 		WithColumnEncrypted("secret_name", ColumnKey(nameKey)),
 	)
 
+	//nolint:staticcheck
 	pr, err := reader.NewParquetReader(
 		buffer.NewBufferReaderFromBytesNoAlloc(data),
 		new(threeWayRecord),
@@ -673,14 +713,17 @@ func TestThreeWayColumnIndexAccess(t *testing.T) {
 		reader.WithColumnKey("secret_name", nameKey),
 	)
 	require.NoError(t, err)
+	//nolint:staticcheck
 	defer func() { require.NoError(t, pr.ReadStop()) }()
 
 	rg := pr.Footer.RowGroups[0]
 	require.Len(t, rg.Columns, 4)
 	for i := range rg.Columns {
+		//nolint:staticcheck
 		idx, err := pr.ReadColumnIndex(0, i)
 		require.NoErrorf(t, err, "column %d ColumnIndex must decode under configured keys", i)
 		require.NotNil(t, idx)
+		//nolint:staticcheck
 		off, err := pr.ReadOffsetIndex(0, i)
 		require.NoErrorf(t, err, "column %d OffsetIndex must decode under configured keys", i)
 		require.NotNil(t, off)
@@ -703,14 +746,17 @@ func TestMixedPlaintextFooterNoKeyOpens(t *testing.T) {
 		WithColumnEncrypted("name", ColumnKey(nameKey)),
 	)
 
+	//nolint:staticcheck
 	pr, err := reader.NewParquetReader(
 		buffer.NewBufferReaderFromBytesNoAlloc(data),
 		new(mixedRecord),
 		// no keys at all
 	)
 	require.NoError(t, err)
+	//nolint:staticcheck
 	defer func() { _ = pr.ReadStop() }()
 
+	//nolint:staticcheck
 	idValues, _, _, err := pr.ReadColumnByPath(common.PathToStr([]string{"parquet_go_root", "id"}), 3)
 	require.NoError(t, err)
 	require.Equal(t, []any{int64(1), int64(2), int64(3)}, idValues)

--- a/writer/ops.go
+++ b/writer/ops.go
@@ -3,6 +3,7 @@ package writer
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"reflect"
 
@@ -13,14 +14,34 @@ import (
 	"github.com/hangxie/parquet-go/v3/parquet"
 )
 
+// WriteStop finalizes the parquet file.
+//
+// Deprecated: use WriteStopWithContext.
 func (pw *ParquetWriter) WriteStop() error {
+	return pw.WriteStopWithContext(pw.defaultContext())
+}
+
+// WriteStopWithContext flushes pending rows and writes the footer. Context
+// values are propagated, but cancellation does not interrupt finalization; a
+// cancellation error is returned after the file has been made valid.
+func (pw *ParquetWriter) WriteStopWithContext(ctx context.Context) (retErr error) {
 	if pw.stopped {
 		return nil
+	}
+	if ctx == nil {
+		return fmt.Errorf("context is nil")
+	}
+	defer func() {
+		retErr = errors.Join(ctx.Err(), retErr)
+	}()
+	finalizeCtx := context.WithoutCancel(ctx)
+	if err := pw.setContext(finalizeCtx); err != nil {
+		return err
 	}
 	pw.stopped = true
 
 	var err error
-	if err = pw.Flush(true); err != nil {
+	if err = pw.FlushWithContext(finalizeCtx, true); err != nil {
 		return fmt.Errorf("flush before stop: %w", err)
 	}
 	ts := thrift.NewTSerializer()
@@ -69,7 +90,7 @@ func (pw *ParquetWriter) WriteStop() error {
 		}
 	}
 
-	footerBuf, err := ts.Write(context.TODO(), pw.Footer)
+	footerBuf, err := ts.Write(finalizeCtx, pw.Footer)
 	if err != nil {
 		return fmt.Errorf("serialize footer: %w", err)
 	}
@@ -78,16 +99,16 @@ func (pw *ParquetWriter) WriteStop() error {
 		return fmt.Errorf("encrypt footer: %w", err)
 	}
 
-	if _, err = pw.PFile.Write(footerBuf); err != nil {
+	if _, err = pw.write(footerBuf); err != nil {
 		return fmt.Errorf("write footer: %w", err)
 	}
 	footerSizeBuf := make([]byte, 4)
 	binary.LittleEndian.PutUint32(footerSizeBuf, uint32(len(footerBuf)))
 
-	if _, err = pw.PFile.Write(footerSizeBuf); err != nil {
+	if _, err = pw.write(footerSizeBuf); err != nil {
 		return fmt.Errorf("write footer size: %w", err)
 	}
-	if _, err = pw.PFile.Write([]byte(tailMagic)); err != nil {
+	if _, err = pw.write([]byte(tailMagic)); err != nil {
 		return fmt.Errorf("write magic tail: %w", err)
 	}
 
@@ -95,7 +116,17 @@ func (pw *ParquetWriter) WriteStop() error {
 }
 
 // Write writes one object to the parquet file.
+//
+// Deprecated: use WriteWithContext.
 func (pw *ParquetWriter) Write(src any) error {
+	return pw.WriteWithContext(pw.defaultContext(), src)
+}
+
+// WriteWithContext writes one object using ctx.
+func (pw *ParquetWriter) WriteWithContext(ctx context.Context, src any) error {
+	if err := pw.setContext(ctx); err != nil {
+		return err
+	}
 	if pw.stopped {
 		return fmt.Errorf("writer stopped")
 	}
@@ -129,7 +160,7 @@ func (pw *ParquetWriter) Write(src any) error {
 	criSize := pw.np * pw.pageSize * pw.SchemaHandler.GetColumnNum()
 
 	if pw.objsSize >= criSize {
-		err = pw.Flush(false)
+		err = pw.FlushWithContext(ctx, false)
 	} else {
 		dln := (criSize - pw.objsSize + pw.objSize - 1) / pw.objSize / 2
 		pw.checkSizeCritical = dln + ln
@@ -157,6 +188,7 @@ func (pw *ParquetWriter) buildChunkMap() (map[string]*layout.Chunk, error) {
 			}
 			dictRec := v.(*layout.DictRecType)
 			dictPage, _, err := layout.DictRecToDictPageWithOption(dictRec, layout.PageWriteOption{
+				Context:      pw.context(),
 				PageSize:     int32(pw.pageSize),
 				CompressType: compressionType,
 				WriteCRC:     pw.writeCRC,
@@ -205,7 +237,17 @@ func (pw *ParquetWriter) buildRowGroup(chunkMap map[string]*layout.Chunk) *layou
 }
 
 // Flush the write buffer to parquet file
+//
+// Deprecated: use FlushWithContext.
 func (pw *ParquetWriter) Flush(flag bool) error {
+	return pw.FlushWithContext(pw.defaultContext(), flag)
+}
+
+// FlushWithContext flushes buffered rows using ctx.
+func (pw *ParquetWriter) FlushWithContext(ctx context.Context, flag bool) error {
+	if err := pw.setContext(ctx); err != nil {
+		return err
+	}
 	if err := pw.flushObjs(); err != nil {
 		return fmt.Errorf("flush objects during flush: %w", err)
 	}

--- a/writer/ops_test.go
+++ b/writer/ops_test.go
@@ -112,6 +112,7 @@ func TestColumnOrders(t *testing.T) {
 		defer func() {
 			require.NoError(t, pf.Close())
 		}()
+		//nolint:staticcheck
 		pr, err := reader.NewParquetReader(pf, nil, reader.WithNP(1))
 		require.NoError(t, err)
 
@@ -140,6 +141,7 @@ func TestColumnOrders(t *testing.T) {
 		defer func() {
 			require.NoError(t, pf.Close())
 		}()
+		//nolint:staticcheck
 		pr, err := reader.NewParquetReader(pf, nil, reader.WithNP(1))
 		require.NoError(t, err)
 

--- a/writer/pages.go
+++ b/writer/pages.go
@@ -28,6 +28,7 @@ func (pw *ParquetWriter) tableToDictPages(name string, table *layout.Table, comp
 
 	convMu.Lock()
 	pages, _, err := layout.TableToDictDataPagesWithOption(dictRec, table, 32, layout.PageWriteOption{
+		Context:      pw.context(),
 		PageSize:     int32(pw.pageSize),
 		CompressType: compressionType,
 		WriteCRC:     pw.writeCRC,
@@ -42,6 +43,7 @@ func (pw *ParquetWriter) tableToDictPages(name string, table *layout.Table, comp
 
 func (pw *ParquetWriter) tableToPlainPages(table *layout.Table, compressionType parquet.CompressionCodec, compressor *compress.Compressor) ([]*layout.Page, error) {
 	pages, _, err := layout.TableToDataPagesWithOption(table, layout.PageWriteOption{
+		Context:         pw.context(),
 		PageSize:        int32(pw.pageSize),
 		CompressType:    compressionType,
 		DataPageVersion: pw.dataPageVersion,
@@ -309,7 +311,7 @@ func (pw *ParquetWriter) writeChunkPages(chunk *layout.Chunk, rowGroupOrdinal, c
 			}
 			dataPageIdx++
 		}
-		if _, err := pw.PFile.Write(page.RawData); err != nil {
+		if _, err := pw.write(page.RawData); err != nil {
 			return fmt.Errorf("write page data: %w", err)
 		}
 		pw.offset += int64(len(page.RawData))

--- a/writer/pages_test.go
+++ b/writer/pages_test.go
@@ -103,6 +103,7 @@ func TestOffsetIndexFirstRowIndex(t *testing.T) {
 		pr, pf, err := createTestParquetReader(buf.Bytes(), new(ListStruct), reader.WithNP(1))
 		require.NoError(t, err)
 		defer func() { _ = pf.Close() }()
+		//nolint:staticcheck
 		defer func() { _ = pr.ReadStop() }()
 
 		require.Equal(t, int64(numRows), pr.GetNumRows())
@@ -111,6 +112,7 @@ func TestOffsetIndexFirstRowIndex(t *testing.T) {
 		// every page location advertises a row-based first_row_index.
 		var checkedMultiPage bool
 		for col := range pr.Footer.RowGroups[0].Columns {
+			//nolint:staticcheck
 			oi, err := pr.ReadOffsetIndex(0, col)
 			require.NoError(t, err)
 			if oi == nil {
@@ -172,9 +174,11 @@ func TestColumnIndex(t *testing.T) {
 		defer func() {
 			require.NoError(t, pf.Close())
 		}()
+		//nolint:staticcheck
 		pr, err := reader.NewParquetReader(pf, nil, reader.WithNP(1))
 		require.Nil(t, err)
 
+		//nolint:staticcheck
 		require.Nil(t, pr.ReadFooter())
 
 		require.Equal(t, 1, len(pr.Footer.RowGroups))
@@ -223,8 +227,10 @@ func TestColumnIndex(t *testing.T) {
 		defer func() {
 			require.NoError(t, pf.Close())
 		}()
+		//nolint:staticcheck
 		pr, err := reader.NewParquetReader(pf, nil, reader.WithNP(1))
 		require.NoError(t, err)
+		//nolint:staticcheck
 		require.NoError(t, pr.ReadFooter())
 
 		columns := pr.Footer.RowGroups[0].GetColumns()
@@ -273,9 +279,11 @@ func TestColumnIndex(t *testing.T) {
 		defer func() {
 			require.NoError(t, pf.Close())
 		}()
+		//nolint:staticcheck
 		pr, err := reader.NewParquetReader(pf, nil, reader.WithNP(1))
 		require.Nil(t, err)
 
+		//nolint:staticcheck
 		require.Nil(t, pr.ReadFooter())
 
 		require.Equal(t, 1, len(pr.Footer.RowGroups))
@@ -333,8 +341,10 @@ func TestColumnIndex(t *testing.T) {
 		defer func() {
 			require.NoError(t, pf.Close())
 		}()
+		//nolint:staticcheck
 		pr, err := reader.NewParquetReader(pf, nil, reader.WithNP(1))
 		require.NoError(t, err)
+		//nolint:staticcheck
 		require.NoError(t, pr.ReadFooter())
 
 		require.Equal(t, 1, len(pr.Footer.RowGroups))
@@ -376,8 +386,10 @@ func TestColumnIndex(t *testing.T) {
 		defer func() {
 			require.NoError(t, pf.Close())
 		}()
+		//nolint:staticcheck
 		pr, err := reader.NewParquetReader(pf, nil, reader.WithNP(1))
 		require.NoError(t, err)
+		//nolint:staticcheck
 		require.NoError(t, pr.ReadFooter())
 
 		columns := pr.Footer.RowGroups[0].GetColumns()
@@ -409,15 +421,17 @@ func TestColumnIndex(t *testing.T) {
 		defer func() {
 			require.NoError(t, pf.Close())
 		}()
+		//nolint:staticcheck
 		pr, err := reader.NewParquetReader(pf, nil, reader.WithNP(1))
 		require.NoError(t, err)
+		//nolint:staticcheck
 		require.NoError(t, pr.ReadFooter())
 
 		columns := pr.Footer.RowGroups[0].GetColumns()
 		colIdx, err := readColumnIndex(pr.PFile, *columns[0].ColumnIndexOffset)
 		require.NoError(t, err)
 
-		// Both maxDefLevel and maxRepLevel are 0 → no histograms
+		// Required field: maxDefLevel=0 → histogram would be trivial [0, values], so none
 		require.False(t, colIdx.IsSetDefinitionLevelHistograms())
 		require.False(t, colIdx.IsSetRepetitionLevelHistograms())
 	})
@@ -617,11 +631,13 @@ func TestDataPageVersion(t *testing.T) {
 		pr, pf, err := createTestParquetReader(buf.Bytes(), new(TestStruct), reader.WithNP(1))
 		require.NoError(t, err)
 		defer func() { _ = pf.Close() }()
+		//nolint:staticcheck
 		defer func() { _ = pr.ReadStop() }()
 
 		require.Equal(t, int64(4), pr.GetNumRows())
 
 		results := make([]TestStruct, 4)
+		//nolint:staticcheck
 		require.NoError(t, pr.Read(&results))
 
 		for i := range testData {
@@ -664,11 +680,13 @@ func TestDataPageVersion(t *testing.T) {
 		pr, pf, err := createTestParquetReader(buf.Bytes(), new(DictStruct), reader.WithNP(1))
 		require.NoError(t, err)
 		defer func() { _ = pf.Close() }()
+		//nolint:staticcheck
 		defer func() { _ = pr.ReadStop() }()
 
 		require.Equal(t, int64(6), pr.GetNumRows())
 
 		results := make([]DictStruct, 6)
+		//nolint:staticcheck
 		require.NoError(t, pr.Read(&results))
 
 		for i := range testData {
@@ -700,6 +718,7 @@ func TestDataPageVersion(t *testing.T) {
 		pr, pf, err := createTestParquetReader(buf.Bytes(), new(SimpleStruct), reader.WithNP(1))
 		require.NoError(t, err)
 		defer func() { _ = pf.Close() }()
+		//nolint:staticcheck
 		defer func() { _ = pr.ReadStop() }()
 
 		require.Equal(t, int64(2), pr.GetNumRows())
@@ -731,11 +750,13 @@ func TestDataPageVersion(t *testing.T) {
 		pr, pf, err := createTestParquetReader(buf.Bytes(), new(ValueStruct), reader.WithNP(1))
 		require.NoError(t, err)
 		defer func() { _ = pf.Close() }()
+		//nolint:staticcheck
 		defer func() { _ = pr.ReadStop() }()
 
 		require.Equal(t, int64(3), pr.GetNumRows())
 
 		results := make([]ValueStruct, 3)
+		//nolint:staticcheck
 		require.NoError(t, pr.Read(&results))
 
 		for i := range testData {
@@ -759,13 +780,16 @@ func TestDataPageVersion(t *testing.T) {
 		pf := buffer.NewBufferReaderFromBytesNoAlloc(buf.Bytes())
 		defer func() { _ = pf.Close() }()
 
+		//nolint:staticcheck
 		pr, err := reader.NewParquetReader(pf, new(ValueStruct), reader.WithNP(1))
 		require.NoError(t, err)
+		//nolint:staticcheck
 		defer func() { _ = pr.ReadStop() }()
 
 		require.Equal(t, int64(100), pr.GetNumRows())
 
 		results := make([]ValueStruct, 100)
+		//nolint:staticcheck
 		require.NoError(t, pr.Read(&results))
 
 		for i := range results {
@@ -800,9 +824,11 @@ func TestDataPageVersion(t *testing.T) {
 		pr, pf, err := createTestParquetReader(buf.Bytes(), new(MyStruct), reader.WithNP(1))
 		require.NoError(t, err)
 		defer func() { _ = pf.Close() }()
+		//nolint:staticcheck
 		defer func() { _ = pr.ReadStop() }()
 
 		res := make([]MyStruct, len(records))
+		//nolint:staticcheck
 		require.NoError(t, pr.Read(&res))
 
 		for i, rec := range res {
@@ -854,9 +880,11 @@ func TestDataPageVersion(t *testing.T) {
 		pr, pf, err := createTestParquetReader(buf.Bytes(), new(MyStruct), reader.WithNP(1))
 		require.NoError(t, err)
 		defer func() { _ = pf.Close() }()
+		//nolint:staticcheck
 		defer func() { _ = pr.ReadStop() }()
 
 		res := make([]MyStruct, 2)
+		//nolint:staticcheck
 		require.NoError(t, pr.Read(&res))
 
 		require.NotNil(t, res[0].Val)
@@ -954,11 +982,13 @@ func TestPerColumnCompression(t *testing.T) {
 		pr, pf, err := createTestParquetReader(buf.Bytes(), new(TestStruct), reader.WithNP(1))
 		require.NoError(t, err)
 		defer func() { _ = pf.Close() }()
+		//nolint:staticcheck
 		defer func() { _ = pr.ReadStop() }()
 
 		require.Equal(t, int64(3), pr.GetNumRows())
 
 		results := make([]TestStruct, 3)
+		//nolint:staticcheck
 		require.NoError(t, pr.Read(&results))
 
 		for i := range testData {
@@ -1005,11 +1035,13 @@ func TestPerColumnCompression(t *testing.T) {
 		pr, pf, err := createTestParquetReader(buf.Bytes(), new(DictStruct), reader.WithNP(1))
 		require.NoError(t, err)
 		defer func() { _ = pf.Close() }()
+		//nolint:staticcheck
 		defer func() { _ = pr.ReadStop() }()
 
 		require.Equal(t, int64(4), pr.GetNumRows())
 
 		results := make([]DictStruct, 4)
+		//nolint:staticcheck
 		require.NoError(t, pr.Read(&results))
 
 		for i := range testData {
@@ -1045,6 +1077,7 @@ func TestPerColumnCompression(t *testing.T) {
 		pr, pf, err := createTestParquetReader(buf.Bytes(), new(TestStruct), reader.WithNP(1))
 		require.NoError(t, err)
 		defer func() { _ = pf.Close() }()
+		//nolint:staticcheck
 		defer func() { _ = pr.ReadStop() }()
 
 		columns := pr.Footer.RowGroups[0].GetColumns()
@@ -1076,6 +1109,7 @@ func TestPerColumnCompression(t *testing.T) {
 		pr, pf, err := createTestParquetReader(buf.Bytes(), new(TestStruct), reader.WithNP(1))
 		require.NoError(t, err)
 		defer func() { _ = pf.Close() }()
+		//nolint:staticcheck
 		defer func() { _ = pr.ReadStop() }()
 
 		// All columns should use file-level compression (GZIP)
@@ -1087,6 +1121,7 @@ func TestPerColumnCompression(t *testing.T) {
 
 		// Verify data integrity
 		results := make([]TestStruct, 2)
+		//nolint:staticcheck
 		require.NoError(t, pr.Read(&results))
 		for i := range testData {
 			require.Equal(t, testData[i], results[i])
@@ -1115,6 +1150,7 @@ func TestPerColumnCompression(t *testing.T) {
 		pr, pf, err := createTestParquetReader(buf.Bytes(), new(TestStruct), reader.WithNP(1))
 		require.NoError(t, err)
 		defer func() { _ = pf.Close() }()
+		//nolint:staticcheck
 		defer func() { _ = pr.ReadStop() }()
 
 		// Verify compression codecs - map has key and value columns
@@ -1148,6 +1184,7 @@ func TestPerColumnCompression(t *testing.T) {
 		pr, pf, err := createTestParquetReader(buf.Bytes(), new(TestStruct), reader.WithNP(1))
 		require.NoError(t, err)
 		defer func() { _ = pf.Close() }()
+		//nolint:staticcheck
 		defer func() { _ = pr.ReadStop() }()
 
 		// Verify compression codec - list has one element column
@@ -1181,6 +1218,7 @@ func TestPerColumnCompression(t *testing.T) {
 		pr, pf, err := createTestParquetReader(buf.Bytes(), new(TestStruct), reader.WithNP(1))
 		require.NoError(t, err)
 		defer func() { _ = pf.Close() }()
+		//nolint:staticcheck
 		defer func() { _ = pr.ReadStop() }()
 
 		columns := pr.Footer.RowGroups[0].GetColumns()
@@ -1191,6 +1229,7 @@ func TestPerColumnCompression(t *testing.T) {
 
 		// Verify data is read correctly
 		results := make([]TestStruct, 2)
+		//nolint:staticcheck
 		require.NoError(t, pr.Read(&results))
 		for i := range testData {
 			require.Equal(t, testData[i], results[i])
@@ -1242,12 +1281,15 @@ func TestWriteCRC_RoundTrip(t *testing.T) {
 
 			// Read
 			pf := buffer.NewBufferReaderFromBytesNoAlloc(buf.Bytes())
+			//nolint:staticcheck
 			pr, err := reader.NewParquetReader(pf, new(testRecord),
 				reader.WithNP(1), reader.WithCRCMode(tc.crcMode))
 			require.NoError(t, err)
 
 			results := make([]testRecord, 10)
+			//nolint:staticcheck
 			require.NoError(t, pr.Read(&results))
+			//nolint:staticcheck
 			require.NoError(t, pr.ReadStop())
 			_ = pf.Close()
 
@@ -1278,12 +1320,15 @@ func TestWriteCRC_DictEncoding_RoundTrip(t *testing.T) {
 
 	// Read with strict CRC
 	pf := buffer.NewBufferReaderFromBytesNoAlloc(buf.Bytes())
+	//nolint:staticcheck
 	pr, err := reader.NewParquetReader(pf, new(testRecord),
 		reader.WithNP(1), reader.WithCRCMode(common.CRCStrict))
 	require.NoError(t, err)
 
 	results := make([]testRecord, 20)
+	//nolint:staticcheck
 	require.NoError(t, pr.Read(&results))
+	//nolint:staticcheck
 	require.NoError(t, pr.ReadStop())
 	_ = pf.Close()
 

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -1,6 +1,7 @@
 package writer
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"strings"
@@ -124,12 +125,22 @@ type ParquetWriter struct {
 
 	stopped            bool
 	encodingsValidated bool // tracks if encoding/version validation has been done
+	defaultCtx         context.Context
+	ctx                context.Context
 }
 
 // NewParquetWriterFromWriter creates a ParquetWriter from an io.Writer.
+//
+// Deprecated: use NewParquetWriterFromWriterWithContext.
 func NewParquetWriterFromWriter(w io.Writer, obj any, opts ...WriterOption) (*ParquetWriter, error) {
+	return NewParquetWriterFromWriterWithContext(context.Background(), w, obj, opts...)
+}
+
+// NewParquetWriterFromWriterWithContext creates a ParquetWriter from an
+// io.Writer and uses ctx for initialization.
+func NewParquetWriterFromWriterWithContext(ctx context.Context, w io.Writer, obj any, opts ...WriterOption) (*ParquetWriter, error) {
 	wf := writerfile.NewWriterFile(w)
-	return NewParquetWriter(wf, obj, opts...)
+	return NewParquetWriterWithContext(ctx, wf, obj, opts...)
 }
 
 // initBase sets up the ParquetWriter with defaults, applies and validates
@@ -139,7 +150,11 @@ func NewParquetWriterFromWriter(w io.Writer, obj any, opts ...WriterOption) (*Pa
 //
 // Callers must still set SchemaHandler, marshalFunc, call initBloomFilters,
 // and set stopped = false after successful schema init.
-func (pw *ParquetWriter) initBase(pFile source.ParquetFileWriter, opts ...WriterOption) error {
+func (pw *ParquetWriter) initBase(ctx context.Context, pFile source.ParquetFileWriter, opts ...WriterOption) error {
+	pw.defaultCtx = ctx
+	if err := pw.setContext(ctx); err != nil {
+		return err
+	}
 	pw.np = 4                                    // default parallel number
 	pw.pageSize = common.DefaultPageSize         // 8K
 	pw.rowGroupSize = common.DefaultRowGroupSize // 128M
@@ -214,7 +229,7 @@ func (pw *ParquetWriter) initBase(pFile source.ParquetFileWriter, opts ...Writer
 	if pw.encryptionState != nil && !pw.encryptionState.plaintextFooter {
 		magic = common.MagicBytesEncrypted
 	}
-	if _, err := pw.PFile.Write([]byte(magic)); err != nil {
+	if _, err := pw.write([]byte(magic)); err != nil {
 		return fmt.Errorf("write magic header: %w", err)
 	}
 	return nil
@@ -272,9 +287,17 @@ func formatOptionErrors(errs []error) string {
 }
 
 // NewParquetWriter creates a parquet writer. Obj is an object with tags or a JSON schema string.
+//
+// Deprecated: use NewParquetWriterWithContext.
 func NewParquetWriter(pFile source.ParquetFileWriter, obj any, opts ...WriterOption) (*ParquetWriter, error) {
+	return NewParquetWriterWithContext(context.Background(), pFile, obj, opts...)
+}
+
+// NewParquetWriterWithContext creates a parquet writer and uses ctx for
+// initialization, including writing the magic header.
+func NewParquetWriterWithContext(ctx context.Context, pFile source.ParquetFileWriter, obj any, opts ...WriterOption) (*ParquetWriter, error) {
 	res := new(ParquetWriter)
-	if err := res.initBase(pFile, opts...); err != nil {
+	if err := res.initBase(ctx, pFile, opts...); err != nil {
 		return nil, fmt.Errorf("init writer base: %w", err)
 	}
 	res.marshalFunc = marshal.Marshal
@@ -314,6 +337,35 @@ func NewParquetWriter(pFile source.ParquetFileWriter, obj any, opts ...WriterOpt
 	res.stopped = false
 
 	return res, nil
+}
+
+func (pw *ParquetWriter) context() context.Context {
+	if pw.ctx == nil {
+		return context.Background()
+	}
+	return pw.ctx
+}
+
+func (pw *ParquetWriter) defaultContext() context.Context {
+	if pw.defaultCtx == nil {
+		return context.Background()
+	}
+	return pw.defaultCtx
+}
+
+func (pw *ParquetWriter) setContext(ctx context.Context) error {
+	if ctx == nil {
+		return fmt.Errorf("context is nil")
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	pw.ctx = ctx
+	return nil
+}
+
+func (pw *ParquetWriter) write(p []byte) (int, error) {
+	return source.WriteWithContext(pw.context(), pw.PFile, p)
 }
 
 func (pw *ParquetWriter) SetSchemaHandlerFromJSON(jsonSchema string) error {

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -19,10 +19,164 @@ import (
 	"github.com/hangxie/parquet-go/v3/source/writerfile"
 )
 
+func TestParquetWriterContextCancellation(t *testing.T) {
+	type row struct {
+		Value int64 `parquet:"name=value, type=INT64"`
+	}
+
+	tests := []struct {
+		name string
+		run  func(context.Context, source.ParquetFileWriter) error
+	}{
+		{
+			name: "constructor",
+			run: func(ctx context.Context, file source.ParquetFileWriter) error {
+				_, err := NewParquetWriterWithContext(ctx, file, new(row), WithNP(1))
+				return err
+			},
+		},
+		{
+			name: "write",
+			run: func(ctx context.Context, file source.ParquetFileWriter) error {
+				pw, err := NewParquetWriter(file, new(row), WithNP(1))
+				require.NoError(t, err)
+				return pw.WriteWithContext(ctx, row{Value: 1})
+			},
+		},
+		{
+			name: "flush",
+			run: func(ctx context.Context, file source.ParquetFileWriter) error {
+				pw, err := NewParquetWriter(file, new(row), WithNP(1))
+				require.NoError(t, err)
+				return pw.FlushWithContext(ctx, true)
+			},
+		},
+		{
+			name: "stop",
+			run: func(ctx context.Context, file source.ParquetFileWriter) error {
+				pw, err := NewParquetWriter(file, new(row), WithNP(1))
+				require.NoError(t, err)
+				return pw.WriteStopWithContext(ctx)
+			},
+		},
+		{
+			name: "CSV constructor",
+			run: func(ctx context.Context, file source.ParquetFileWriter) error {
+				_, err := NewCSVWriterWithContext(ctx, nil, file)
+				return err
+			},
+		},
+		{
+			name: "JSON constructor",
+			run: func(ctx context.Context, file source.ParquetFileWriter) error {
+				_, err := NewJSONWriterWithContext(ctx, "", file)
+				return err
+			},
+		},
+		{
+			name: "Arrow constructor",
+			run: func(ctx context.Context, file source.ParquetFileWriter) error {
+				_, err := NewArrowWriterWithContext(ctx, nil, file)
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+			err := tt.run(ctx, writerfile.NewWriterFile(new(bytes.Buffer)))
+			require.ErrorIs(t, err, context.Canceled)
+		})
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := NewParquetWriterFromWriterWithContext(ctx, new(bytes.Buffer), new(row))
+	require.ErrorIs(t, err, context.Canceled)
+	_, err = NewCSVWriterFromWriterWithContext(ctx, nil, new(bytes.Buffer))
+	require.ErrorIs(t, err, context.Canceled)
+	_, err = NewJSONWriterFromWriterWithContext(ctx, "", new(bytes.Buffer))
+	require.ErrorIs(t, err, context.Canceled)
+	_, err = NewArrowWriterFromWriterWithContext(ctx, nil, new(bytes.Buffer))
+	require.ErrorIs(t, err, context.Canceled)
+	require.ErrorIs(t, new(CSVWriter).WriteStringWithContext(ctx, nil), context.Canceled)
+	require.ErrorIs(t, new(ArrowWriter).WriteArrowWithContext(ctx, nil), context.Canceled)
+	nilCtx := map[string]context.Context{}["missing"]
+	_, err = NewParquetWriterWithContext(nilCtx, writerfile.NewWriterFile(new(bytes.Buffer)), new(row))
+	require.ErrorContains(t, err, "context is nil")
+}
+
+func TestWriteStopWithContextCanceledFinalizesFile(t *testing.T) {
+	type row struct {
+		Value int64 `parquet:"name=value, type=INT64"`
+	}
+
+	file := buffer.NewBufferWriter()
+	pw, err := NewParquetWriter(file, new(row), WithNP(1))
+	require.NoError(t, err)
+	require.NoError(t, pw.Write(row{Value: 42}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.ErrorIs(t, pw.WriteStopWithContext(ctx), context.Canceled)
+
+	//nolint:staticcheck
+	pr, err := reader.NewParquetReader(buffer.NewBufferReaderFromBytes(file.Bytes()), new(row), reader.WithNP(1))
+	require.NoError(t, err)
+	//nolint:staticcheck
+	defer func() { require.NoError(t, pr.ReadStop()) }()
+	rows := make([]row, 1)
+	//nolint:staticcheck
+	require.NoError(t, pr.Read(&rows))
+	require.Equal(t, int64(42), rows[0].Value)
+}
+
+type contextTrackingWriter struct {
+	bytes.Buffer
+	contexts []context.Context
+}
+
+func (w *contextTrackingWriter) WriteContext(ctx context.Context, p []byte) (int, error) {
+	w.contexts = append(w.contexts, ctx)
+	return w.Write(p)
+}
+
+func (w *contextTrackingWriter) Close() error { return nil }
+
+func (w *contextTrackingWriter) Create(string) (source.ParquetFileWriter, error) { return w, nil }
+
+func TestParquetWriterWithContext(t *testing.T) {
+	type row struct {
+		Value int64 `parquet:"name=value, type=INT64"`
+	}
+	type contextKey struct{}
+
+	file := new(contextTrackingWriter)
+	constructorCtx := context.WithValue(context.Background(), contextKey{}, "constructor")
+	pw, err := NewParquetWriterWithContext(constructorCtx, file, new(row), WithNP(1))
+	require.NoError(t, err)
+	require.NotEmpty(t, file.contexts)
+	require.Equal(t, "constructor", file.contexts[0].Value(contextKey{}))
+
+	file.contexts = nil
+	require.NoError(t, pw.Write(row{Value: 1}))
+	require.Equal(t, "constructor", pw.context().Value(contextKey{}))
+
+	file.contexts = nil
+	stopCtx := context.WithValue(context.Background(), contextKey{}, "stop")
+	require.NoError(t, pw.WriteStopWithContext(stopCtx))
+	require.NotEmpty(t, file.contexts)
+	for _, got := range file.contexts {
+		require.Equal(t, "stop", got.Value(contextKey{}))
+	}
+}
+
 func readColumnIndex(pf source.ParquetFileReader, offset int64) (*parquet.ColumnIndex, error) {
 	colIdx := parquet.NewColumnIndex()
 	tpf := thrift.NewTCompactProtocolFactoryConf(nil)
-	triftReader, err := source.ConvertToThriftReader(pf, offset)
+	triftReader, err := source.ConvertToThriftReaderWithContext(context.Background(), pf, offset)
 	if err != nil {
 		return nil, err
 	}
@@ -45,6 +199,7 @@ func createTestParquetWriter(schema any, opts ...WriterOption) (*ParquetWriter, 
 // Helper function to create a parquet reader from buffer
 func createTestParquetReader(buf []byte, schema any, opts ...reader.ReaderOption) (*reader.ParquetReader, source.ParquetFileReader, error) {
 	pf := buffer.NewBufferReaderFromBytesNoAlloc(buf)
+	//nolint:staticcheck
 	pr, err := reader.NewParquetReader(pf, schema, opts...)
 	return pr, pf, err
 }
@@ -114,9 +269,11 @@ func TestParquetWriter(t *testing.T) {
 		require.Equal(t, len(testData), numRows)
 
 		actualRows := make([]test, numRows)
+		//nolint:staticcheck
 		err = pr.Read(&actualRows)
 		require.NoError(t, err)
 
+		//nolint:staticcheck
 		_ = pr.ReadStop()
 	})
 
@@ -459,6 +616,7 @@ func TestWriterCompressionLevel(t *testing.T) {
 	}()
 
 	got := make([]Entry, len(want))
+	//nolint:staticcheck
 	require.NoError(t, pr.Read(&got))
 	require.Equal(t, want, got)
 	require.Equal(t, parquet.CompressionCodec_GZIP, pr.Footer.RowGroups[0].Columns[0].MetaData.GetCodec())
@@ -505,6 +663,7 @@ func TestParquetWriter_PerColumnCompressionLevel(t *testing.T) {
 
 	// Round-trip validation
 	got := make([]Row, len(want))
+	//nolint:staticcheck
 	require.NoError(t, pr.Read(&got))
 	require.Equal(t, want, got)
 }
@@ -554,6 +713,7 @@ func TestParquetWriter_UnknownLogicalType(t *testing.T) {
 
 	// Round-trip: read rows back and confirm all values are nil.
 	rows := make([]Row, int(pr.GetNumRows()))
+	//nolint:staticcheck
 	require.NoError(t, pr.Read(&rows))
 	for _, row := range rows {
 		require.Nil(t, row.NullCol)


### PR DESCRIPTION
## Summary

- add context-aware reader and writer constructors and operations while preserving existing APIs
- add optional source context capabilities with legacy fallbacks
- propagate cancellation through Thrift, page, index, bloom-filter, encryption, and supported remote-backend paths
- ensure canceled cleanup still closes handles and canceled writer finalization still emits a valid footer
- preserve constructor contexts for calls through plain methods and avoid unnecessary GCS reader recreation
- pass contexts directly through unexported helper signatures without duplicate internal `WithContext` overlays
- deprecate context-free APIs that have direct `WithContext` replacements while retaining their behavior
- document and test cancellation, propagation, fallback, cleanup, deprecation, and compatibility

## Compatibility

Existing `ParquetFileReader` and `ParquetFileWriter` interfaces and all legacy API signatures remain unchanged. Context-free entry points with direct replacements are deprecated but remain available. Legacy constructors use `context.Background()`, and their plain methods retain that behavior; objects created with a context-aware constructor use that constructor context for plain methods.

## Validation

- `make all`
- coverage: 95.1822% (main: 95.1554%)

Closes #335