### PR TITLE
fix(writer): preserve WriteStop failure on retry

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ func main() {
 }
 ```
 
+`WriteStop` is idempotent after successful finalization. If finalization fails, the writer remains stopped and later `WriteStop` calls return an error stating that the file is incomplete instead of retrying non-idempotent footer writes.
+
 ### Read a File
 
 ```go

--- a/writer/ops.go
+++ b/writer/ops.go
@@ -23,16 +23,17 @@ func (pw *ParquetWriter) WriteStop() error {
 
 // WriteStopWithContext flushes pending rows and writes the footer. Context
 // values are propagated, but cancellation does not interrupt finalization; a
-// cancellation error is returned after the file has been made valid.
+// cancellation error is returned after the file has been made valid. Calls
+// after a finalization failure return an error indicating the file is incomplete.
 func (pw *ParquetWriter) WriteStopWithContext(ctx context.Context) (retErr error) {
 	if pw.stopped {
-		return nil
+		return pw.stopErr
 	}
 	if ctx == nil {
 		return fmt.Errorf("context is nil")
 	}
 	defer func() {
-		retErr = errors.Join(ctx.Err(), retErr)
+		retErr = pw.finishWriteStop(ctx, retErr)
 	}()
 	finalizeCtx := context.WithoutCancel(ctx)
 	if err := pw.setContext(finalizeCtx); err != nil {
@@ -113,6 +114,13 @@ func (pw *ParquetWriter) WriteStopWithContext(ctx context.Context) (retErr error
 	}
 
 	return nil
+}
+
+func (pw *ParquetWriter) finishWriteStop(ctx context.Context, err error) error {
+	if pw.stopped && err != nil {
+		pw.stopErr = fmt.Errorf("previous WriteStop failed; file is incomplete: %w", err)
+	}
+	return errors.Join(ctx.Err(), err)
 }
 
 // Write writes one object to the parquet file.

--- a/writer/ops_test.go
+++ b/writer/ops_test.go
@@ -405,3 +405,49 @@ func TestWriteStopTailWriteErrors(t *testing.T) {
 		})
 	}
 }
+
+func TestWriteStopAfterFailure(t *testing.T) {
+	tests := []struct {
+		name        string
+		failOnWrite int
+		want        string
+	}{
+		{
+			name:        "footer",
+			failOnWrite: 2,
+			want:        "write footer",
+		},
+		{
+			name:        "footer_size",
+			failOnWrite: 3,
+			want:        "write footer size",
+		},
+		{
+			name:        "magic_tail",
+			failOnWrite: 4,
+			want:        "write magic tail",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			type Entry struct {
+				ID int32 `parquet:"name=id, type=INT32"`
+			}
+
+			fw := &failOnWriteN{failOn: tt.failOnWrite}
+			pw, err := NewParquetWriter(fw, new(Entry), WithNP(1))
+			require.NoError(t, err)
+
+			err = pw.WriteStop()
+			require.ErrorIs(t, err, errWrite)
+			require.Contains(t, err.Error(), tt.want)
+			writeCount := fw.count
+
+			err = pw.WriteStop()
+			require.ErrorIs(t, err, errWrite)
+			require.Contains(t, err.Error(), "previous WriteStop failed; file is incomplete")
+			require.Equal(t, writeCount, fw.count)
+		})
+	}
+}

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -124,6 +124,7 @@ type ParquetWriter struct {
 	marshalFunc func(src []any, sh *schema.SchemaHandler) (*map[string]*layout.Table, error)
 
 	stopped            bool
+	stopErr            error
 	encodingsValidated bool // tracks if encoding/version validation has been done
 	defaultCtx         context.Context
 	ctx                context.Context

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -121,6 +121,7 @@ func TestWriteStopWithContextCanceledFinalizesFile(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	require.ErrorIs(t, pw.WriteStopWithContext(ctx), context.Canceled)
+	require.NoError(t, pw.WriteStop())
 
 	//nolint:staticcheck
 	pr, err := reader.NewParquetReader(buffer.NewBufferReaderFromBytes(file.Bytes()), new(row), reader.WithNP(1))
@@ -373,6 +374,10 @@ func TestParquetWriter(t *testing.T) {
 		stopErr := pw.WriteStop()
 		require.Error(t, stopErr)
 		require.Contains(t, stopErr.Error(), "nil value encountered for REQUIRED field")
+
+		stopErr = pw.WriteStop()
+		require.Error(t, stopErr)
+		require.Contains(t, stopErr.Error(), "previous WriteStop failed; file is incomplete")
 	})
 
 	t.Run("zero_rows", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- latch `WriteStop` finalization failures on the writer
- return an explicit incomplete-file error from subsequent stop calls without retrying non-idempotent footer writes
- preserve idempotent behavior after successful finalization, including finalization completed under a canceled context
- document the finalization retry contract

## Testing

- added regression coverage for flush, footer, footer-size, and magic-tail failures
- verified the original error remains available through `errors.Is`
- verified failed retries perform no additional writes
- `make all`

Closes #328