### PR TITLE
feat(encoding): emit bit-packed hybrid runs

### DIFF
--- a/internal/encoding/encodingread.go
+++ b/internal/encoding/encodingread.go
@@ -207,7 +207,11 @@ func ReadRLEBitPackedHybrid(bytesReader *bytes.Reader, bitWidth, length, maxCoun
 			return res, err
 		}
 		if header&1 == 0 {
-			buf, err := ReadRLE(newReader, header, bitWidth, maxCount)
+			remainingCount := maxCount
+			if maxCount > 0 {
+				remainingCount -= uint64(len(res))
+			}
+			buf, err := ReadRLE(newReader, header, bitWidth, remainingCount)
 			if err != nil {
 				return res, err
 			}
@@ -219,6 +223,9 @@ func ReadRLEBitPackedHybrid(bytesReader *bytes.Reader, bitWidth, length, maxCoun
 				return res, err
 			}
 			res = append(res, buf...)
+		}
+		if maxCount > 0 && uint64(len(res)) >= maxCount {
+			return res[:maxCount], nil
 		}
 	}
 	return res, nil

--- a/internal/encoding/encodingread_test.go
+++ b/internal/encoding/encodingread_test.go
@@ -398,7 +398,7 @@ func TestReadRLEBitPackedHybrid(t *testing.T) {
 			maxVal := uint64(data[len(data)-1].(int64))
 			buf, err := WriteRLEBitPackedHybrid(data, int32(bits.Len64(maxVal)), parquet.Type_INT64)
 			require.NoError(t, err)
-			res, err := ReadRLEBitPackedHybrid(bytes.NewReader(buf), uint64(bits.Len64(maxVal)), 0, 0)
+			res, err := ReadRLEBitPackedHybrid(bytes.NewReader(buf), uint64(bits.Len64(maxVal)), 0, uint64(len(data)))
 			require.NoError(t, err)
 			require.Equal(t, fmt.Sprintf("%v", data), fmt.Sprintf("%v", res))
 		}

--- a/internal/encoding/encodingwrite.go
+++ b/internal/encoding/encodingwrite.go
@@ -11,31 +11,34 @@ import (
 )
 
 func WriteRLE(vals []any, bitWidth int32, pt parquet.Type) ([]byte, error) {
-	ln := len(vals)
-	i := 0
-	res := make([]byte, 0)
-	for i < ln {
-		j := i + 1
-		for j < ln && vals[j] == vals[i] {
-			j++
+	intVals := make([]int64, len(vals))
+	for i, val := range vals {
+		switch pt {
+		case parquet.Type_BOOLEAN:
+			boolVal, ok := val.(bool)
+			if !ok {
+				return nil, fmt.Errorf("WriteRLE: value %d has type %T, expected bool", i, val)
+			}
+			if boolVal {
+				intVals[i] = 1
+			}
+		case parquet.Type_INT32:
+			intVal, ok := val.(int32)
+			if !ok {
+				return nil, fmt.Errorf("WriteRLE: value %d has type %T, expected int32", i, val)
+			}
+			intVals[i] = int64(intVal)
+		case parquet.Type_INT64:
+			intVal, ok := val.(int64)
+			if !ok {
+				return nil, fmt.Errorf("WriteRLE: value %d has type %T, expected int64", i, val)
+			}
+			intVals[i] = intVal
+		default:
+			return nil, fmt.Errorf("WriteRLE: unsupported parquet type %v", pt)
 		}
-		num := j - i
-		header := num << 1
-		byteNum := (bitWidth + 7) / 8
-		headerBuf := WriteUnsignedVarInt(uint64(header))
-
-		valBuf, err := WritePlain([]any{vals[i]}, pt)
-		if err != nil {
-			return nil, err
-		}
-
-		rleBuf := make([]byte, int64(len(headerBuf))+int64(byteNum))
-		copy(rleBuf[0:], headerBuf)
-		copy(rleBuf[len(headerBuf):], valBuf[0:byteNum])
-		res = append(res, rleBuf...)
-		i = j
 	}
-	return res, nil
+	return writeRLEInt64(intVals, bitWidth), nil
 }
 
 func WriteRLEBitPackedHybrid(vals []any, bitWidths int32, pt parquet.Type) ([]byte, error) {
@@ -54,27 +57,11 @@ func WriteRLEBitPackedHybrid(vals []any, bitWidths int32, pt parquet.Type) ([]by
 }
 
 func WriteRLEInt32(vals []int32, bitWidth int32) []byte {
-	ln := len(vals)
-	i := 0
-	res := make([]byte, 0)
-	for i < ln {
-		j := i + 1
-		for j < ln && vals[j] == vals[i] {
-			j++
-		}
-		num := j - i
-		header := num << 1
-		byteNum := (bitWidth + 7) / 8
-		headerBuf := WriteUnsignedVarInt(uint64(header))
-
-		var valBuf [4]byte
-		binary.LittleEndian.PutUint32(valBuf[:], uint32(vals[i]))
-
-		res = append(res, headerBuf...)
-		res = append(res, valBuf[:byteNum]...)
-		i = j
+	intVals := make([]int64, len(vals))
+	for i := range vals {
+		intVals[i] = int64(vals[i])
 	}
-	return res
+	return writeRLEInt64(intVals, bitWidth)
 }
 
 func WriteRLEBitPackedHybridInt32(vals []int32, bitWidths int32) ([]byte, error) {
@@ -94,55 +81,91 @@ func WriteBitPacked(vals []any, bitWidth int64, ifHeader bool) []byte {
 	if ln <= 0 {
 		return nil
 	}
-	valsInt := ToInt64(vals)
+	return writeBitPackedInt64(ToInt64(vals), bitWidth, ifHeader)
+}
 
-	header := ((ln/8)<<1 | 1)
-	headerBuf := WriteUnsignedVarInt(uint64(header))
+const (
+	rleRunThreshold = 8
+	bitPackedGroup  = 8
+)
 
-	valBuf := make([]byte, 0)
+func writeRLEInt64(vals []int64, bitWidth int32) []byte {
+	res := make([]byte, 0)
+	literalStart := 0
 
-	i := 0
-	var resCur int64 = 0
-	var resCurNeedBits int64 = 8
-	var used int64 = 0
-	left := bitWidth - used
-	val := int64(valsInt[i])
-	for i < ln {
-		if left >= resCurNeedBits {
-			resCur |= ((val >> uint64(used)) & ((1 << uint64(resCurNeedBits)) - 1)) << uint64(8-resCurNeedBits)
-			valBuf = append(valBuf, byte(resCur))
-			left -= resCurNeedBits
-			used += resCurNeedBits
+	for i := 0; i < len(vals); {
+		runEnd := i + 1
+		for runEnd < len(vals) && vals[runEnd] == vals[i] {
+			runEnd++
+		}
 
-			resCurNeedBits = 8
-			resCur = 0
-
-			if left <= 0 && (i+1) < ln {
-				i += 1
-				val = int64(valsInt[i])
-				left = bitWidth
-				used = 0
+		runStart := i
+		runLength := runEnd - runStart
+		if runLength >= rleRunThreshold {
+			literalLength := runStart - literalStart
+			alignment := (bitPackedGroup - literalLength%bitPackedGroup) % bitPackedGroup
+			if runLength-alignment >= rleRunThreshold {
+				if alignment > 0 {
+					runStart += alignment
+					runLength -= alignment
+				}
+				res = appendBitPackedRun(res, vals[literalStart:runStart], bitWidth)
+				res = appendRLERun(res, vals[runStart], runLength, bitWidth)
+				literalStart = runEnd
 			}
-		} else {
-			resCur |= (val >> uint64(used)) << uint64(8-resCurNeedBits)
-			i += 1
+		}
+		i = runEnd
+	}
 
-			if i < ln {
-				val = int64(valsInt[i])
-			}
-			resCurNeedBits -= left
+	return appendBitPackedRun(res, vals[literalStart:], bitWidth)
+}
 
-			left = bitWidth
-			used = 0
+func appendBitPackedRun(dst []byte, vals []int64, bitWidth int32) []byte {
+	if len(vals) == 0 {
+		return dst
+	}
+
+	paddedLength := (len(vals) + bitPackedGroup - 1) / bitPackedGroup * bitPackedGroup
+	padded := make([]int64, paddedLength)
+	copy(padded, vals)
+	return append(dst, writeBitPackedInt64(padded, int64(bitWidth), true)...)
+}
+
+func appendRLERun(dst []byte, val int64, runLength int, bitWidth int32) []byte {
+	dst = append(dst, WriteUnsignedVarInt(uint64(runLength<<1))...)
+
+	var valBuf [8]byte
+	binary.LittleEndian.PutUint64(valBuf[:], uint64(val))
+	byteCount := (bitWidth + 7) / 8
+	return append(dst, valBuf[:byteCount]...)
+}
+
+func writeBitPackedInt64(vals []int64, bitWidth int64, withHeader bool) []byte {
+	res := make([]byte, 0, (len(vals)*int(bitWidth)+7)/8+1)
+	if withHeader {
+		header := (len(vals)/bitPackedGroup)<<1 | 1
+		res = append(res, WriteUnsignedVarInt(uint64(header))...)
+	}
+	if bitWidth == 0 {
+		return res
+	}
+
+	packed := make([]byte, (len(vals)*int(bitWidth)+7)/8)
+	for i, val := range vals {
+		value := uint64(val)
+		bitOffset := i * int(bitWidth)
+		for valueBits := int(bitWidth); valueBits > 0; {
+			byteOffset := bitOffset / 8
+			offsetInByte := bitOffset % 8
+			bitsToWrite := min(8-offsetInByte, valueBits)
+			mask := uint64(1<<bitsToWrite) - 1
+			valueOffset := int(bitWidth) - valueBits
+			packed[byteOffset] |= byte((value>>valueOffset)&mask) << offsetInByte
+			bitOffset += bitsToWrite
+			valueBits -= bitsToWrite
 		}
 	}
-
-	res := make([]byte, 0)
-	if ifHeader {
-		res = append(res, headerBuf...)
-	}
-	res = append(res, valBuf...)
-	return res
+	return append(res, packed...)
 }
 
 func WriteDelta(nums []any) ([]byte, error) {

--- a/internal/encoding/encodingwrite_test.go
+++ b/internal/encoding/encodingwrite_test.go
@@ -1,7 +1,10 @@
 package encoding
 
 import (
+	"bytes"
+	"fmt"
 	"math/bits"
+	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -10,6 +13,10 @@ import (
 )
 
 func TestWriteBitPacked(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		require.Nil(t, WriteBitPacked(nil, 1, true))
+	})
+
 	t.Run("standard", func(t *testing.T) {
 		testData := []struct {
 			nums     []any
@@ -22,6 +29,37 @@ func TestWriteBitPacked(t *testing.T) {
 		for _, data := range testData {
 			res := WriteBitPacked(data.nums, int64(bits.Len64(uint64(data.nums[len(data.nums)-1].(int)))), true)
 			require.Equal(t, string(data.expected), string(res))
+		}
+	})
+
+	t.Run("round_trip_bit_widths", func(t *testing.T) {
+		testCases := []struct {
+			name     string
+			bitWidth uint64
+			vals     []int64
+		}{
+			{name: "zero", bitWidth: 0, vals: []int64{0, 0, 0, 0, 0, 0, 0, 0}},
+			{name: "one", bitWidth: 1, vals: []int64{0, 1, 0, 1, 1, 0, 1, 0}},
+			{name: "seven", bitWidth: 7, vals: []int64{0, 1, 63, 64, 65, 126, 127, 42}},
+			{name: "eight", bitWidth: 8, vals: []int64{0, 1, 127, 128, 129, 254, 255, 42}},
+			{name: "nine", bitWidth: 9, vals: []int64{0, 1, 255, 256, 257, 510, 511, 42}},
+			{name: "thirty_one", bitWidth: 31, vals: []int64{0, 1, 1<<30 - 1, 1 << 30, 1<<30 + 1, 1<<31 - 2, 1<<31 - 1, 42}},
+			{name: "thirty_two", bitWidth: 32, vals: []int64{0, 1, 1<<31 - 1, 1 << 31, 1<<31 + 1, 1<<32 - 2, 1<<32 - 1, 42}},
+			{name: "sixty_three", bitWidth: 63, vals: []int64{0, 1, 1<<62 - 1, 1 << 62, 1<<62 + 1, 1<<63 - 2, 1<<63 - 1, 42}},
+			{name: "sixty_four", bitWidth: 64, vals: []int64{0, 1, 1<<62 - 1, 1 << 62, 1<<62 + 1, 1<<63 - 2, 1<<63 - 1, 42}},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				vals := make([]any, len(tc.vals))
+				for i := range tc.vals {
+					vals[i] = tc.vals[i]
+				}
+				encoded := WriteBitPacked(vals, int64(tc.bitWidth), true)
+				decoded, err := ReadBitPacked(bytes.NewReader(encoded[1:]), uint64(encoded[0]), tc.bitWidth)
+				require.NoError(t, err)
+				require.Equal(t, vals, decoded)
+			})
 		}
 	})
 }
@@ -270,30 +308,152 @@ func TestWriteDelta(t *testing.T) {
 	})
 }
 
-func TestWriteRLE(t *testing.T) {
-	t.Run("basic", func(t *testing.T) {
-		testData := []struct {
-			nums     []any
-			expected []byte
-		}{
-			{[]any{int64(0), int64(0), int64(0)}, []byte{byte(3 << 1)}},
-			{[]any{int64(3)}, []byte{byte(1 << 1), byte(3)}},
-			{[]any{int64(1), int64(2), int64(3), int64(3)}, []byte{byte(1 << 1), byte(1), byte(1 << 1), byte(2), byte(2 << 1), byte(3)}},
-		}
+func TestWriteRLEHybridRunSelection(t *testing.T) {
+	testCases := []struct {
+		name       string
+		vals       []int32
+		bitWidth   int32
+		expected   []byte
+		valueCount uint64
+	}{
+		{
+			name:       "bit_packed_literals",
+			vals:       []int32{0, 1, 2, 3, 4, 5, 6, 7},
+			bitWidth:   3,
+			expected:   []byte{3, 0x88, 0xC6, 0xFA},
+			valueCount: 8,
+		},
+		{
+			name:       "rle_at_eight_repeats",
+			vals:       []int32{5, 5, 5, 5, 5, 5, 5, 5},
+			bitWidth:   3,
+			expected:   []byte{16, 5},
+			valueCount: 8,
+		},
+		{
+			name:       "literal_alignment_before_rle",
+			vals:       []int32{0, 1, 2, 3, 4, 5, 6, 7, 7, 7, 7, 7, 7, 7, 7, 7},
+			bitWidth:   3,
+			expected:   []byte{3, 0x88, 0xC6, 0xFA, 16, 7},
+			valueCount: 16,
+		},
+		{
+			name:       "padded_literal_tail",
+			vals:       []int32{1, 2, 3},
+			bitWidth:   2,
+			expected:   []byte{3, 0x39, 0},
+			valueCount: 3,
+		},
+		{
+			name:       "zero_bit_width",
+			vals:       []int32{0, 0, 0},
+			bitWidth:   0,
+			expected:   []byte{3},
+			valueCount: 3,
+		},
+	}
 
-		for _, data := range testData {
-			res, err := WriteRLE(data.nums, int32(bits.Len64(uint64(data.nums[len(data.nums)-1].(int64)))), parquet.Type_INT64)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			vals := make([]any, len(tc.vals))
+			for i := range tc.vals {
+				vals[i] = int32(tc.vals[i])
+			}
+
+			res, err := WriteRLE(vals, tc.bitWidth, parquet.Type_INT32)
 			require.NoError(t, err)
-			require.Equal(t, string(data.expected), string(res))
-		}
-	})
+			require.Equal(t, tc.expected, res)
+			require.Equal(t, tc.expected, WriteRLEInt32(tc.vals, tc.bitWidth))
 
+			decoded, err := ReadRLEBitPackedHybrid(bytes.NewReader(res), uint64(tc.bitWidth), uint64(len(res)), tc.valueCount)
+			require.NoError(t, err)
+			expectedDecoded := make([]any, len(tc.vals))
+			for i := range tc.vals {
+				expectedDecoded[i] = int64(tc.vals[i])
+			}
+			require.Equal(t, expectedDecoded, decoded[:tc.valueCount])
+		})
+	}
+}
+
+func TestWriteRLEHybridRoundTripRandomized(t *testing.T) {
+	const (
+		bitWidth       = 5
+		casesPerOffset = 64
+	)
+
+	random := rand.New(rand.NewSource(0))
+	for alignment := range bitPackedGroup {
+		t.Run(fmt.Sprintf("literal_alignment_%d", alignment), func(t *testing.T) {
+			for testCase := range casesPerOffset {
+				vals := make([]int32, 0, 128)
+				vals = appendRepeatedInt32(vals, int32(random.Intn(32)), 8+random.Intn(24))
+				vals = appendLiteralInt32(vals, alignment, random)
+				vals = appendRepeatedInt32(vals, differentInt32(vals[len(vals)-1], random), 8+random.Intn(24))
+
+				for range 2 + random.Intn(6) {
+					if random.Intn(2) == 0 {
+						vals = appendRepeatedInt32(vals, differentInt32(vals[len(vals)-1], random), 8+random.Intn(24))
+					} else {
+						vals = appendLiteralInt32(vals, 1+random.Intn(23), random)
+					}
+				}
+
+				expected := make([]any, len(vals))
+				genericVals := make([]any, len(vals))
+				for i := range vals {
+					expected[i] = int64(vals[i])
+					genericVals[i] = vals[i]
+				}
+
+				genericEncoded, err := WriteRLE(genericVals, bitWidth, parquet.Type_INT32)
+				require.NoError(t, err)
+				int32Encoded := WriteRLEInt32(vals, bitWidth)
+				require.Equal(t, genericEncoded, int32Encoded)
+
+				decoded, err := ReadRLEBitPackedHybrid(
+					bytes.NewReader(genericEncoded),
+					bitWidth,
+					uint64(len(genericEncoded)),
+					uint64(len(vals)),
+				)
+				require.NoError(t, err, "case %d", testCase)
+				require.Equal(t, expected, decoded, "case %d", testCase)
+			}
+		})
+	}
+}
+
+func appendRepeatedInt32(dst []int32, val int32, count int) []int32 {
+	for range count {
+		dst = append(dst, val)
+	}
+	return dst
+}
+
+func appendLiteralInt32(dst []int32, count int, random *rand.Rand) []int32 {
+	for range count {
+		dst = append(dst, differentInt32(dst[len(dst)-1], random))
+	}
+	return dst
+}
+
+func differentInt32(previous int32, random *rand.Rand) int32 {
+	val := int32(random.Intn(31))
+	if val >= previous {
+		val++
+	}
+	return val
+}
+
+func TestWriteRLE(t *testing.T) {
 	t.Run("bit_packed_hybrid", func(t *testing.T) {
 		testCases := []struct {
-			name      string
-			vals      []any
-			bitWidths int32
-			pt        parquet.Type
+			name        string
+			vals        []any
+			bitWidths   int32
+			pt          parquet.Type
+			expectError bool
 		}{
 			{
 				name:      "valid_int64",
@@ -308,22 +468,54 @@ func TestWriteRLE(t *testing.T) {
 				pt:        parquet.Type_INT32,
 			},
 			{
+				name:      "valid_boolean",
+				vals:      []any{false, true, false},
+				bitWidths: 1,
+				pt:        parquet.Type_BOOLEAN,
+			},
+			{
 				name:      "empty_input",
 				vals:      []any{},
 				bitWidths: 1,
 				pt:        parquet.Type_INT64,
 			},
 			{
-				name:      "unsupported_type",
-				vals:      []any{"string1", "string2"},
-				bitWidths: 2,
-				pt:        parquet.Type_BYTE_ARRAY,
+				name:        "invalid_boolean_value",
+				vals:        []any{int32(1)},
+				bitWidths:   1,
+				pt:          parquet.Type_BOOLEAN,
+				expectError: true,
+			},
+			{
+				name:        "invalid_int32_value",
+				vals:        []any{int64(1)},
+				bitWidths:   1,
+				pt:          parquet.Type_INT32,
+				expectError: true,
+			},
+			{
+				name:        "invalid_int64_value",
+				vals:        []any{int32(1)},
+				bitWidths:   1,
+				pt:          parquet.Type_INT64,
+				expectError: true,
+			},
+			{
+				name:        "unsupported_type",
+				vals:        []any{"string1", "string2"},
+				bitWidths:   2,
+				pt:          parquet.Type_BYTE_ARRAY,
+				expectError: true,
 			},
 		}
 
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
 				result, err := WriteRLEBitPackedHybrid(tc.vals, tc.bitWidths, tc.pt)
+				if tc.expectError {
+					require.Error(t, err)
+					return
+				}
 				require.NoError(t, err)
 
 				// Result should have at least 4 bytes for the length header

--- a/internal/layout/page_read_values_test.go
+++ b/internal/layout/page_read_values_test.go
@@ -415,15 +415,10 @@ func TestReadDataPageValues_BoundsChecking(t *testing.T) {
 			cnt:            21, // Request 21 values
 			bitWidth:       4,
 			setupData: func() []byte {
-				// Create RLE data that only contains 1 value (repeated once)
-				// Bit width byte
-				data := []byte{4} // bitWidth = 4
-				// Write RLE/bit-packed hybrid data for just 1 value
-				rleBuf, _ := encoding.WriteRLEBitPackedHybrid([]any{int64(0)}, 4, parquet.Type_INT64)
-				data = append(data, rleBuf...)
-				return data
+				// Dictionary data has no length prefix: bit width 4, then one RLE value.
+				return []byte{4, 2, 0}
 			},
-			expectedError: "expected 21 values but got 2 from RLE/bit-packed hybrid decoder",
+			expectedError: "expected 21 values but got 1 from RLE/bit-packed hybrid decoder",
 		},
 		{
 			name:           "rle_fewer_values_than_expected",
@@ -432,9 +427,8 @@ func TestReadDataPageValues_BoundsChecking(t *testing.T) {
 			cnt:            21, // Request 21 values
 			bitWidth:       4,
 			setupData: func() []byte {
-				// Create RLE data that only contains 1 value
-				rleBuf, _ := encoding.WriteRLEBitPackedHybrid([]any{int64(0)}, 4, parquet.Type_INT64)
-				return rleBuf
+				// Length-prefixed RLE data containing one value.
+				return []byte{2, 0, 0, 0, 2, 0}
 			},
 			expectedError: "expected 21 values but got 1 from RLE/bit-packed hybrid decoder",
 		},
@@ -445,19 +439,10 @@ func TestReadDataPageValues_BoundsChecking(t *testing.T) {
 			cnt:            10,
 			bitWidth:       3,
 			setupData: func() []byte {
-				// Create dictionary-encoded data with fewer values than requested
-				data := []byte{3} // bitWidth = 3
-				// RLE data with only 3 values - create minimal data
-				// We manually construct this to have fewer values than cnt
-				rleBuf, _ := encoding.WriteRLEBitPackedHybrid(
-					[]any{int64(0), int64(1), int64(0)},
-					3,
-					parquet.Type_INT64,
-				)
-				data = append(data, rleBuf...)
-				return data
+				// Dictionary data has no length prefix: bit width 3, then three RLE values.
+				return []byte{3, 6, 0}
 			},
-			expectedError: "expected 10 values but got",
+			expectedError: "expected 10 values but got 3",
 		},
 	}
 


### PR DESCRIPTION
## Summary

- emit bit-packed runs for short and non-repeating hybrid-encoded values
- retain RLE runs for eight or more repeats while preserving eight-value literal alignment
- trim final bit-packed padding using the caller-provided value count
- add exact encoding, boundary, error-path, and bit-width round-trip coverage

## Validation

- `make all`
- overall coverage: 95.2% (matches `main`)
- `internal/encoding` coverage: 96.2% (up from 95.9% on `main`)

Closes #331