### PR TITLE
feat(writer): cap and compact dictionaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ Encoding notes:
 
 - For maximum compatibility, use `PLAIN` and `PLAIN_DICTIONARY`.
 - Dictionary indices use the minimum bit width required by the completed row-group dictionary. Encoded dictionary value bytes are capped at 1 MiB by default, after which the writer uses `PLAIN` encoding for subsequent pages; tune the cap with `writer.WithMaxDictionarySize`.
+- `writer.WithDataPageVersion(2)` applies to both dictionary-encoded and plain data pages.
 - Use `omitstats=true` in a field tag to skip statistics for large array fields.
 - Whenever min/max statistics are available, the current `min_value`/`max_value` fields are written. The deprecated `min`/`max` fields (PARQUET-251) are limited to signed sort orders; for unsigned-ordered columns (e.g. `BYTE_ARRAY`/UTF8 and unsigned integer logical types) they are omitted so legacy readers do not misinterpret them.
 

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Common writer options:
 - `writer.WithNP`
 - `writer.WithPageSize`
 - `writer.WithRowGroupSize`
+- `writer.WithMaxDictionarySize`
 - `writer.WithCompressionCodec`
 - `writer.WithCompressionLevel`
 - `writer.WithDataPageVersion`
@@ -300,7 +301,7 @@ LIST and REPEATED are different in the Parquet format. Prefer LIST for list data
 Encoding notes:
 
 - For maximum compatibility, use `PLAIN` and `PLAIN_DICTIONARY`.
-- Avoid dictionary encoding for high-cardinality fields because dictionaries can consume significant memory.
+- Dictionary indices use the minimum bit width required by the completed row-group dictionary. Encoded dictionary value bytes are capped at 1 MiB by default, after which the writer uses `PLAIN` encoding for subsequent pages; tune the cap with `writer.WithMaxDictionarySize`.
 - Use `omitstats=true` in a field tag to skip statistics for large array fields.
 - Whenever min/max statistics are available, the current `min_value`/`max_value` fields are written. The deprecated `min`/`max` fields (PARQUET-251) are limited to signed sort orders; for unsigned-ordered columns (e.g. `BYTE_ARRAY`/UTF8 and unsigned integer logical types) they are omitted so legacy readers do not misinterpret them.
 

--- a/internal/layout/dictpage.go
+++ b/internal/layout/dictpage.go
@@ -276,12 +276,8 @@ func TableToDictDataPagesWithOption(dictRec *DictRecType, table *Table, opt Page
 		if len(dictRec.DictSlice) > 1 {
 			bitWidth = int32(bits.Len(uint(len(dictRec.DictSlice) - 1)))
 		}
-		compressedData, compressErr := page.dictDataPageCompress(opt.CompressType, bitWidth, scan.values, opt.Compressor)
-		if compressErr != nil {
-			return nil, 0, fmt.Errorf("compress dict data page: %w", compressErr)
-		}
-		if err = serializePage(page, opt, compressedData); err != nil {
-			return nil, 0, fmt.Errorf("serialize dict data page: %w", err)
+		if err = compressAndSerializeDictDataPage(page, bitWidth, scan.values, opt); err != nil {
+			return nil, 0, fmt.Errorf("compress and serialize dict data page: %w", err)
 		}
 		page.dictionaryIndices = append([]int32{}, scan.values...)
 
@@ -298,17 +294,28 @@ func FinalizeDictDataPagesWithOption(pages []*Page, bitWidth int32, opt PageWrit
 		if page == nil || page.dictionaryIndices == nil {
 			continue
 		}
-		compressedData, err := page.dictDataPageCompress(opt.CompressType, bitWidth, page.dictionaryIndices, opt.Compressor)
-		if err != nil {
-			return fmt.Errorf("compress dict data page %d: %w", i, err)
-		}
-		if err := serializePage(page, opt, compressedData); err != nil {
-			return fmt.Errorf("serialize dict data page %d: %w", i, err)
+		if err := compressAndSerializeDictDataPage(page, bitWidth, page.dictionaryIndices, opt); err != nil {
+			return fmt.Errorf("finalize dict data page %d: %w", i, err)
 		}
 		page.dictionaryIndices = nil
 		page.DataTable = nil
 	}
 	return nil
+}
+
+func compressAndSerializeDictDataPage(page *Page, bitWidth int32, values []int32, opt PageWriteOption) error {
+	if opt.DataPageVersion == 2 {
+		repLevels, defLevels, compressedValues, err := page.dictDataPageV2Compress(opt.CompressType, bitWidth, values, opt.Compressor)
+		if err != nil {
+			return fmt.Errorf("compress dict data page v2: %w", err)
+		}
+		return serializePage(page, opt, repLevels, defLevels, compressedValues)
+	}
+	compressedData, err := page.dictDataPageCompress(opt.CompressType, bitWidth, values, opt.Compressor)
+	if err != nil {
+		return fmt.Errorf("compress dict data page: %w", err)
+	}
+	return serializePage(page, opt, compressedData)
 }
 
 func (page *Page) dictDataPageCompress(compressType parquet.CompressionCodec, bitWidth int32, values []int32, c *compress.Compressor) ([]byte, error) {
@@ -365,4 +372,60 @@ func (page *Page) dictDataPageCompress(compressType parquet.CompressionCodec, bi
 	}
 
 	return dataEncodeBuf, nil
+}
+
+func (page *Page) dictDataPageV2Compress(compressType parquet.CompressionCodec, bitWidth int32, values []int32, c *compress.Compressor) ([]byte, []byte, []byte, error) {
+	valuesRawBuf := append([]byte{byte(bitWidth)}, encoding.WriteRLEInt32(values, bitWidth)...)
+
+	var definitionLevelBuf []byte
+	if page.DataTable.MaxDefinitionLevel > 0 {
+		definitionLevelBuf = encoding.WriteRLEInt32(
+			page.DataTable.DefinitionLevels,
+			int32(bits.Len32(uint32(page.DataTable.MaxDefinitionLevel))),
+		)
+	}
+
+	var repetitionLevelBuf []byte
+	var numRows int32
+	if page.DataTable.MaxRepetitionLevel > 0 {
+		repetitionLevelBuf = encoding.WriteRLEInt32(
+			page.DataTable.RepetitionLevels,
+			int32(bits.Len32(uint32(page.DataTable.MaxRepetitionLevel))),
+		)
+		for _, level := range page.DataTable.RepetitionLevels {
+			if level == 0 {
+				numRows++
+			}
+		}
+	} else {
+		numRows = int32(len(page.DataTable.DefinitionLevels))
+	}
+
+	compressedValues, err := resolveCompressor(c).Compress(valuesRawBuf, compressType)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("compress dict data: %w", err)
+	}
+	isCompressed := len(compressedValues) < len(valuesRawBuf)
+	if !isCompressed {
+		compressedValues = valuesRawBuf
+	}
+
+	page.Header = parquet.NewPageHeader()
+	page.Header.Type = parquet.PageType_DATA_PAGE_V2
+	page.Header.CompressedPageSize = int32(len(repetitionLevelBuf) + len(definitionLevelBuf) + len(compressedValues))
+	page.Header.UncompressedPageSize = int32(len(repetitionLevelBuf) + len(definitionLevelBuf) + len(valuesRawBuf))
+	page.Header.DataPageHeaderV2 = parquet.NewDataPageHeaderV2()
+	page.Header.DataPageHeaderV2.NumValues = int32(len(page.DataTable.DefinitionLevels))
+	page.Header.DataPageHeaderV2.NumNulls = page.Header.DataPageHeaderV2.NumValues - int32(len(values))
+	page.Header.DataPageHeaderV2.NumRows = numRows
+	page.Header.DataPageHeaderV2.Encoding = parquet.Encoding_RLE_DICTIONARY
+	page.Header.DataPageHeaderV2.DefinitionLevelsByteLength = int32(len(definitionLevelBuf))
+	page.Header.DataPageHeaderV2.RepetitionLevelsByteLength = int32(len(repetitionLevelBuf))
+	page.Header.DataPageHeaderV2.IsCompressed = isCompressed
+	page.Header.DataPageHeaderV2.Statistics = parquet.NewStatistics()
+	if err := page.setPageStatistics(page.Header.DataPageHeaderV2.Statistics); err != nil {
+		return nil, nil, nil, fmt.Errorf("set dict page statistics: %w", err)
+	}
+
+	return repetitionLevelBuf, definitionLevelBuf, compressedValues, nil
 }

--- a/internal/layout/dictpage.go
+++ b/internal/layout/dictpage.go
@@ -14,12 +14,22 @@ type DictRecType struct {
 	DictMap   map[any]int32
 	DictSlice []any
 	Type      parquet.Type
+	size      int64
+	maxSize   int64
+	full      bool
 }
 
 func NewDictRec(pT parquet.Type) *DictRecType {
 	res := new(DictRecType)
 	res.DictMap = make(map[any]int32)
 	res.Type = pT
+	return res
+}
+
+// NewDictRecWithLimit creates a size-limited dictionary recorder.
+func NewDictRecWithLimit(pT parquet.Type, maxSize int64) *DictRecType {
+	res := NewDictRec(pT)
+	res.maxSize = maxSize
 	return res
 }
 
@@ -74,13 +84,14 @@ func (page *Page) dictPageCompress(compressType parquet.CompressionCodec, pT par
 
 // dictPageValueResult holds the results from scanning one page's worth of values for dictionary encoding.
 type dictPageValueResult struct {
-	endIdx    int
-	numValues int32
-	size      int32
-	minVal    any
-	maxVal    any
-	nullCount int64
-	values    []int32
+	endIdx         int
+	numValues      int32
+	size           int32
+	minVal         any
+	maxVal         any
+	nullCount      int64
+	values         []int32
+	dictionaryFull bool
 }
 
 // scanDictPageValues scans table values from startIdx to build one page, collecting dictionary indices and stats.
@@ -121,7 +132,15 @@ func scanDictPageValues(table *Table, dictRec *DictRecType, startIdx int, pageSi
 				r.minVal, r.maxVal, elSize = funcTable.MinMaxSize(r.minVal, r.maxVal, table.Values[r.endIdx])
 			}
 			r.size += elSize
-			r.values = append(r.values, dictRec.lookupOrInsert(table.Values[r.endIdx]))
+			index, ok, err := dictRec.tryLookupOrInsert(table.Values[r.endIdx])
+			if err != nil {
+				return r, fmt.Errorf("measure dictionary value: %w", err)
+			}
+			if !ok {
+				r.dictionaryFull = true
+				return r, nil
+			}
+			r.values = append(r.values, index)
 		}
 		r.endIdx++
 	}
@@ -139,6 +158,42 @@ func (d *DictRecType) lookupOrInsert(val any) int32 {
 	return idx
 }
 
+func (d *DictRecType) tryLookupOrInsert(val any) (int32, bool, error) {
+	if idx, ok := d.DictMap[val]; ok {
+		return idx, true, nil
+	}
+	encoded, err := encoding.WritePlain([]any{val}, d.Type)
+	if err != nil {
+		return 0, false, err
+	}
+	if d.maxSize > 0 && d.size+int64(len(encoded)) > d.maxSize {
+		d.full = true
+		return 0, false, nil
+	}
+	idx := d.lookupOrInsert(val)
+	d.size += int64(len(encoded))
+	return idx, true, nil
+}
+
+func (d *DictRecType) rollback(length int, size int64) {
+	for _, value := range d.DictSlice[length:] {
+		delete(d.DictMap, value)
+	}
+	d.DictSlice = d.DictSlice[:length]
+	d.size = size
+}
+
+func tableToPlainFallback(table *Table, start int, opt PageWriteOption) ([]*Page, int64, error) {
+	plainTable := *table
+	plainTable.Values = table.Values[start:]
+	plainTable.DefinitionLevels = table.DefinitionLevels[start:]
+	plainTable.RepetitionLevels = table.RepetitionLevels[start:]
+	plainInfo := *table.Info
+	plainInfo.Encoding = parquet.Encoding_PLAIN
+	plainTable.Info = &plainInfo
+	return TableToDataPagesWithOption(&plainTable, opt)
+}
+
 // checkRequiredNil returns an error if a nil value appears at a position where a REQUIRED field should have a value.
 func checkRequiredNil(table *Table, idx int) error {
 	if table.Schema.GetRepetitionType() == parquet.FieldRepetitionType_REQUIRED &&
@@ -149,11 +204,18 @@ func checkRequiredNil(table *Table, idx int) error {
 }
 
 // TableToDictDataPagesWithOption converts a table to dictionary-encoded data pages using the provided options.
-func TableToDictDataPagesWithOption(dictRec *DictRecType, table *Table, bitWidth int32, opt PageWriteOption) ([]*Page, int64, error) {
+func TableToDictDataPagesWithOption(dictRec *DictRecType, table *Table, opt PageWriteOption) ([]*Page, int64, error) {
 	var totSize int64 = 0
 	totalLn := len(table.Values)
 	if totalLn == 0 {
 		return []*Page{}, 0, nil
+	}
+	if dictRec.full {
+		pages, size, err := tableToPlainFallback(table, 0, opt)
+		if err != nil {
+			return nil, 0, fmt.Errorf("build plain fallback pages: %w", err)
+		}
+		return pages, size, nil
 	}
 	res := make([]*Page, 0)
 	i := 0
@@ -166,9 +228,20 @@ func TableToDictDataPagesWithOption(dictRec *DictRecType, table *Table, bitWidth
 			return nil, 0, fmt.Errorf("find func table for given types [%v, %v, %v]: %w", pT, cT, logT, err)
 		}
 
+		dictLength, dictSize := len(dictRec.DictSlice), dictRec.size
 		scan, err := scanDictPageValues(table, dictRec, i, opt.PageSize, omitStats, funcTable)
 		if err != nil {
 			return nil, 0, fmt.Errorf("scan dict page values at %d: %w", i, err)
+		}
+		if scan.dictionaryFull {
+			dictRec.rollback(dictLength, dictSize)
+			plainPages, plainSize, plainErr := tableToPlainFallback(table, i, opt)
+			if plainErr != nil {
+				return nil, 0, fmt.Errorf("build plain fallback pages at %d: %w", i, plainErr)
+			}
+			res = append(res, plainPages...)
+			totSize += plainSize
+			break
 		}
 
 		page := NewDataPage()
@@ -199,6 +272,10 @@ func TableToDictDataPagesWithOption(dictRec *DictRecType, table *Table, bitWidth
 
 		page.computeLevelHistograms()
 
+		bitWidth := int32(0)
+		if len(dictRec.DictSlice) > 1 {
+			bitWidth = int32(bits.Len(uint(len(dictRec.DictSlice) - 1)))
+		}
 		compressedData, compressErr := page.dictDataPageCompress(opt.CompressType, bitWidth, scan.values, opt.Compressor)
 		if compressErr != nil {
 			return nil, 0, fmt.Errorf("compress dict data page: %w", compressErr)
@@ -206,12 +283,32 @@ func TableToDictDataPagesWithOption(dictRec *DictRecType, table *Table, bitWidth
 		if err = serializePage(page, opt, compressedData); err != nil {
 			return nil, 0, fmt.Errorf("serialize dict data page: %w", err)
 		}
+		page.dictionaryIndices = append([]int32{}, scan.values...)
 
 		totSize += int64(len(page.RawData))
 		res = append(res, page)
 		i = scan.endIdx
 	}
 	return res, totSize, nil
+}
+
+// FinalizeDictDataPagesWithOption rewrites buffered pages with bitWidth.
+func FinalizeDictDataPagesWithOption(pages []*Page, bitWidth int32, opt PageWriteOption) error {
+	for i, page := range pages {
+		if page == nil || page.dictionaryIndices == nil {
+			continue
+		}
+		compressedData, err := page.dictDataPageCompress(opt.CompressType, bitWidth, page.dictionaryIndices, opt.Compressor)
+		if err != nil {
+			return fmt.Errorf("compress dict data page %d: %w", i, err)
+		}
+		if err := serializePage(page, opt, compressedData); err != nil {
+			return fmt.Errorf("serialize dict data page %d: %w", i, err)
+		}
+		page.dictionaryIndices = nil
+		page.DataTable = nil
+	}
+	return nil
 }
 
 func (page *Page) dictDataPageCompress(compressType parquet.CompressionCodec, bitWidth int32, values []int32, c *compress.Compressor) ([]byte, error) {

--- a/internal/layout/dictpage_test.go
+++ b/internal/layout/dictpage_test.go
@@ -99,7 +99,7 @@ func TestTableToDictDataPagesWithOption(t *testing.T) {
 				WriteCRC:     tc.writeCRC,
 			}
 
-			pages, totalSize, err := TableToDictDataPagesWithOption(dictRec, table, 2, opt)
+			pages, totalSize, err := TableToDictDataPagesWithOption(dictRec, table, opt)
 			require.NoError(t, err)
 			require.NotEmpty(t, pages)
 			require.Positive(t, totalSize)
@@ -152,6 +152,17 @@ func TestDictRecToDictPageWithOption(t *testing.T) {
 	}
 }
 
+func TestDictRecToDictPageWithOption_EncodeError(t *testing.T) {
+	dictRec := NewDictRec(parquet.Type_INT32)
+	dictRec.DictSlice = []any{"wrong type"}
+
+	_, _, err := DictRecToDictPageWithOption(dictRec, PageWriteOption{
+		CompressType: parquet.CompressionCodec_UNCOMPRESSED,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "compress dictionary page")
+}
+
 func TestScanDictPageValues_RequiredNil(t *testing.T) {
 	table := &Table{
 		Schema: &parquet.SchemaElement{
@@ -175,6 +186,15 @@ func TestLookupOrInsert_ExistingValue(t *testing.T) {
 	idx2 := dictRec.lookupOrInsert(int32(42)) // already present
 	require.Equal(t, idx1, idx2)
 	require.Len(t, dictRec.DictSlice, 1)
+
+	idx3, ok, err := dictRec.tryLookupOrInsert(int32(42))
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, idx1, idx3)
+
+	_, ok, err = NewDictRec(parquet.Type_INT32).tryLookupOrInsert("wrong type")
+	require.Error(t, err)
+	require.False(t, ok)
 }
 
 func TestScanDictPageValues_OptionalNull(t *testing.T) {
@@ -202,7 +222,7 @@ func TestTableToDictDataPagesWithOption_EmptyTable(t *testing.T) {
 		Schema: &parquet.SchemaElement{Type: common.ToPtr(parquet.Type_INT32)},
 		Values: []any{},
 	}
-	pages, totalSize, err := TableToDictDataPagesWithOption(NewDictRec(parquet.Type_INT32), table, 2, PageWriteOption{PageSize: 1024})
+	pages, totalSize, err := TableToDictDataPagesWithOption(NewDictRec(parquet.Type_INT32), table, PageWriteOption{PageSize: 1024})
 	require.NoError(t, err)
 	require.Empty(t, pages)
 	require.Zero(t, totalSize)
@@ -219,12 +239,162 @@ func TestTableToDictDataPagesWithOption_ScanError(t *testing.T) {
 		MaxDefinitionLevel: 0,
 		Info:               &common.Tag{},
 	}
-	_, _, err := TableToDictDataPagesWithOption(NewDictRec(parquet.Type_INT32), table, 2, PageWriteOption{
+	_, _, err := TableToDictDataPagesWithOption(NewDictRec(parquet.Type_INT32), table, PageWriteOption{
 		PageSize:     1024,
 		CompressType: parquet.CompressionCodec_UNCOMPRESSED,
 	})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "scan dict page values")
+}
+
+func TestTableToDictDataPagesWithOption_PlainFallback(t *testing.T) {
+	dictTag, err := common.StringToTag("name=value, type=BYTE_ARRAY, encoding=PLAIN_DICTIONARY")
+	require.NoError(t, err)
+	newTable := func() *Table {
+		return &Table{
+			Schema: &parquet.SchemaElement{
+				Type:           common.ToPtr(parquet.Type_BYTE_ARRAY),
+				RepetitionType: common.ToPtr(parquet.FieldRepetitionType_REQUIRED),
+			},
+			Values:             []any{"alpha", "bravo", "charlie"},
+			DefinitionLevels:   []int32{0, 0, 0},
+			RepetitionLevels:   []int32{0, 0, 0},
+			MaxDefinitionLevel: 0,
+			Info:               dictTag,
+		}
+	}
+
+	tests := []struct {
+		name          string
+		pageSize      int32
+		wantDictSize  int
+		wantEncodings []parquet.Encoding
+	}{
+		{
+			name:          "fallback_at_page_boundary",
+			pageSize:      5,
+			wantDictSize:  1,
+			wantEncodings: []parquet.Encoding{parquet.Encoding_RLE_DICTIONARY, parquet.Encoding_PLAIN, parquet.Encoding_PLAIN},
+		},
+		{
+			name:          "rollback_partial_dictionary_page",
+			pageSize:      1024,
+			wantDictSize:  0,
+			wantEncodings: []parquet.Encoding{parquet.Encoding_PLAIN},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dictRec := NewDictRecWithLimit(parquet.Type_BYTE_ARRAY, 10)
+			pages, totalSize, err := TableToDictDataPagesWithOption(dictRec, newTable(), PageWriteOption{
+				PageSize:     tt.pageSize,
+				CompressType: parquet.CompressionCodec_UNCOMPRESSED,
+			})
+			require.NoError(t, err)
+			require.Positive(t, totalSize)
+			require.Len(t, dictRec.DictSlice, tt.wantDictSize)
+			require.Len(t, pages, len(tt.wantEncodings))
+			for i, encoding := range tt.wantEncodings {
+				require.Equal(t, encoding, pages[i].Header.DataPageHeader.Encoding)
+			}
+
+			morePages, _, err := TableToDictDataPagesWithOption(dictRec, newTable(), PageWriteOption{
+				PageSize:     tt.pageSize,
+				CompressType: parquet.CompressionCodec_UNCOMPRESSED,
+			})
+			require.NoError(t, err)
+			for _, page := range morePages {
+				require.Equal(t, parquet.Encoding_PLAIN, page.Header.DataPageHeader.Encoding)
+			}
+
+			_, _, err = TableToDictDataPagesWithOption(dictRec, newTable(), PageWriteOption{
+				PageSize:     tt.pageSize,
+				CompressType: parquet.CompressionCodec(9999),
+			})
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "build plain fallback pages")
+		})
+	}
+}
+
+func TestFinalizeDictDataPagesWithOption(t *testing.T) {
+	dictTag, err := common.StringToTag("name=value, type=INT32, encoding=PLAIN_DICTIONARY")
+	require.NoError(t, err)
+	tests := []struct {
+		name   string
+		values []any
+		defs   []int32
+		maxDef int32
+		width  int32
+	}{
+		{
+			name:   "values",
+			values: []any{int32(1), int32(2)},
+			defs:   []int32{0, 0},
+			width:  1,
+		},
+		{
+			name:   "all_null",
+			values: []any{nil},
+			defs:   []int32{0},
+			maxDef: 1,
+			width:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			table := &Table{
+				Schema: &parquet.SchemaElement{
+					Type:           common.ToPtr(parquet.Type_INT32),
+					RepetitionType: common.ToPtr(parquet.FieldRepetitionType_OPTIONAL),
+				},
+				Values:             tt.values,
+				DefinitionLevels:   tt.defs,
+				RepetitionLevels:   make([]int32, len(tt.values)),
+				MaxDefinitionLevel: tt.maxDef,
+				Info:               dictTag,
+			}
+			pages, _, err := TableToDictDataPagesWithOption(NewDictRec(parquet.Type_INT32), table, PageWriteOption{
+				PageSize:     1024,
+				CompressType: parquet.CompressionCodec_UNCOMPRESSED,
+			})
+			require.NoError(t, err)
+			require.NotNil(t, pages[0].DataTable)
+
+			err = FinalizeDictDataPagesWithOption(
+				append([]*Page{nil}, pages...),
+				tt.width,
+				PageWriteOption{CompressType: parquet.CompressionCodec_UNCOMPRESSED},
+			)
+			require.NoError(t, err)
+			require.Nil(t, pages[0].DataTable)
+			require.Nil(t, pages[0].dictionaryIndices)
+		})
+	}
+}
+
+func TestFinalizeDictDataPagesWithOption_CompressError(t *testing.T) {
+	table := &Table{
+		Schema:             &parquet.SchemaElement{Type: common.ToPtr(parquet.Type_INT32)},
+		Values:             []any{int32(1)},
+		DefinitionLevels:   []int32{0},
+		RepetitionLevels:   []int32{0},
+		MaxDefinitionLevel: 0,
+		MaxRepetitionLevel: 0,
+		Info:               &common.Tag{},
+		RepetitionType:     parquet.FieldRepetitionType_REQUIRED,
+	}
+	pages, _, err := TableToDictDataPagesWithOption(NewDictRec(parquet.Type_INT32), table, PageWriteOption{
+		PageSize:     1024,
+		CompressType: parquet.CompressionCodec_UNCOMPRESSED,
+	})
+	require.NoError(t, err)
+
+	err = FinalizeDictDataPagesWithOption(pages, 1, PageWriteOption{CompressType: parquet.CompressionCodec(9999)})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "compress dict data page")
 }
 
 func TestDictDataPageCompress_RepetitionLevels(t *testing.T) {

--- a/internal/layout/dictpage_test.go
+++ b/internal/layout/dictpage_test.go
@@ -1,6 +1,7 @@
 package layout
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -62,19 +63,33 @@ func TestNewDictRec(t *testing.T) {
 
 func TestTableToDictDataPagesWithOption(t *testing.T) {
 	testCases := []struct {
-		name      string
-		writeCRC  bool
-		expectCRC bool
+		name            string
+		dataPageVersion int32
+		writeCRC        bool
+		expectCRC       bool
+		expectedType    parquet.PageType
 	}{
 		{
-			name:      "without_crc",
-			writeCRC:  false,
-			expectCRC: false,
+			name:         "v1_without_crc",
+			expectedType: parquet.PageType_DATA_PAGE,
 		},
 		{
-			name:      "with_crc",
-			writeCRC:  true,
-			expectCRC: true,
+			name:         "v1_with_crc",
+			writeCRC:     true,
+			expectCRC:    true,
+			expectedType: parquet.PageType_DATA_PAGE,
+		},
+		{
+			name:            "v2_without_crc",
+			dataPageVersion: 2,
+			expectedType:    parquet.PageType_DATA_PAGE_V2,
+		},
+		{
+			name:            "v2_with_crc",
+			dataPageVersion: 2,
+			writeCRC:        true,
+			expectCRC:       true,
+			expectedType:    parquet.PageType_DATA_PAGE_V2,
 		},
 	}
 
@@ -94,9 +109,10 @@ func TestTableToDictDataPagesWithOption(t *testing.T) {
 			dictRec := NewDictRec(parquet.Type_INT32)
 
 			opt := PageWriteOption{
-				PageSize:     1024,
-				CompressType: parquet.CompressionCodec_UNCOMPRESSED,
-				WriteCRC:     tc.writeCRC,
+				PageSize:        1024,
+				CompressType:    parquet.CompressionCodec_UNCOMPRESSED,
+				DataPageVersion: tc.dataPageVersion,
+				WriteCRC:        tc.writeCRC,
 			}
 
 			pages, totalSize, err := TableToDictDataPagesWithOption(dictRec, table, opt)
@@ -106,6 +122,16 @@ func TestTableToDictDataPagesWithOption(t *testing.T) {
 
 			for _, page := range pages {
 				require.NotEmpty(t, page.RawData)
+				require.Equal(t, tc.expectedType, page.Header.Type)
+				if tc.dataPageVersion == 2 {
+					require.Equal(t, parquet.Encoding_RLE_DICTIONARY, page.Header.DataPageHeaderV2.Encoding)
+					require.Equal(t, int32(3), page.Header.DataPageHeaderV2.NumValues)
+					require.Zero(t, page.Header.DataPageHeaderV2.NumNulls)
+					require.Equal(t, int32(3), page.Header.DataPageHeaderV2.NumRows)
+					require.Positive(t, page.Header.DataPageHeaderV2.DefinitionLevelsByteLength)
+				} else {
+					require.Equal(t, parquet.Encoding_RLE_DICTIONARY, page.Header.DataPageHeader.Encoding)
+				}
 				if tc.expectCRC {
 					require.True(t, page.Header.IsSetCrc(), "expected CRC to be set")
 				} else {
@@ -376,25 +402,33 @@ func TestFinalizeDictDataPagesWithOption(t *testing.T) {
 }
 
 func TestFinalizeDictDataPagesWithOption_CompressError(t *testing.T) {
-	table := &Table{
-		Schema:             &parquet.SchemaElement{Type: common.ToPtr(parquet.Type_INT32)},
-		Values:             []any{int32(1)},
-		DefinitionLevels:   []int32{0},
-		RepetitionLevels:   []int32{0},
-		MaxDefinitionLevel: 0,
-		MaxRepetitionLevel: 0,
-		Info:               &common.Tag{},
-		RepetitionType:     parquet.FieldRepetitionType_REQUIRED,
-	}
-	pages, _, err := TableToDictDataPagesWithOption(NewDictRec(parquet.Type_INT32), table, PageWriteOption{
-		PageSize:     1024,
-		CompressType: parquet.CompressionCodec_UNCOMPRESSED,
-	})
-	require.NoError(t, err)
+	for _, version := range []int32{1, 2} {
+		t.Run(fmt.Sprintf("v%d", version), func(t *testing.T) {
+			table := &Table{
+				Schema:             &parquet.SchemaElement{Type: common.ToPtr(parquet.Type_INT32)},
+				Values:             []any{int32(1)},
+				DefinitionLevels:   []int32{0},
+				RepetitionLevels:   []int32{0},
+				MaxDefinitionLevel: 0,
+				MaxRepetitionLevel: 0,
+				Info:               &common.Tag{},
+				RepetitionType:     parquet.FieldRepetitionType_REQUIRED,
+			}
+			pages, _, err := TableToDictDataPagesWithOption(NewDictRec(parquet.Type_INT32), table, PageWriteOption{
+				PageSize:        1024,
+				CompressType:    parquet.CompressionCodec_UNCOMPRESSED,
+				DataPageVersion: version,
+			})
+			require.NoError(t, err)
 
-	err = FinalizeDictDataPagesWithOption(pages, 1, PageWriteOption{CompressType: parquet.CompressionCodec(9999)})
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "compress dict data page")
+			err = FinalizeDictDataPagesWithOption(pages, 1, PageWriteOption{
+				CompressType:    parquet.CompressionCodec(9999),
+				DataPageVersion: version,
+			})
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "compress dict data page")
+		})
+	}
 }
 
 func TestDictDataPageCompress_RepetitionLevels(t *testing.T) {

--- a/internal/layout/page.go
+++ b/internal/layout/page.go
@@ -66,6 +66,9 @@ type Page struct {
 	// Only set for BYTE_ARRAY physical type columns; nil otherwise.
 	UnencodedByteArrayDataBytes *int64
 
+	// dictionaryIndices are retained until row-group finalization.
+	dictionaryIndices []int32
+
 	// compressor is set during page reading so that subsequent operations
 	// (GetRLDLFromRawData, GetValueFromRawData) can decompress using
 	// the same per-instance compressor. Nil means use DefaultCompressor.

--- a/internal/layout/page_write_test.go
+++ b/internal/layout/page_write_test.go
@@ -609,7 +609,7 @@ func TestTableToDataPagesRowAligned(t *testing.T) {
 			Info:               &common.Tag{},
 		}
 
-		pages, _, err := TableToDictDataPagesWithOption(NewDictRec(parquet.Type_INT32), table, 32, PageWriteOption{
+		pages, _, err := TableToDictDataPagesWithOption(NewDictRec(parquet.Type_INT32), table, PageWriteOption{
 			PageSize:     6,
 			CompressType: parquet.CompressionCodec_UNCOMPRESSED,
 		})

--- a/writer/dictionary.go
+++ b/writer/dictionary.go
@@ -14,6 +14,19 @@ func usesDictionaryEncoding(table *layout.Table) bool {
 		table.Info.Encoding == parquet.Encoding_RLE_DICTIONARY
 }
 
+func isDictionaryDataPage(page *layout.Page) bool {
+	if page == nil || page.Header == nil {
+		return false
+	}
+	if page.Header.DataPageHeader != nil {
+		return page.Header.DataPageHeader.Encoding == parquet.Encoding_RLE_DICTIONARY
+	}
+	if page.Header.DataPageHeaderV2 != nil {
+		return page.Header.DataPageHeaderV2.Encoding == parquet.Encoding_RLE_DICTIONARY
+	}
+	return false
+}
+
 func (pw *ParquetWriter) tableToDictPages(name string, table *layout.Table, compressionType parquet.CompressionCodec, compressor *compress.Compressor) ([]*layout.Page, error) {
 	var dictRec *layout.DictRecType
 	if v, ok := pw.DictRecs.Load(name); ok {
@@ -43,8 +56,7 @@ func hasDictionaryDataPage(pages []*layout.Page) bool {
 		if page == nil {
 			continue
 		}
-		if page.Header != nil && page.Header.DataPageHeader != nil &&
-			page.Header.DataPageHeader.Encoding == parquet.Encoding_RLE_DICTIONARY {
+		if isDictionaryDataPage(page) {
 			return true
 		}
 		if page.Header == nil && page.Info != nil &&
@@ -67,10 +79,11 @@ func (pw *ParquetWriter) buildDictionaryChunk(name string, pages []*layout.Page,
 		bitWidth = int32(bits.Len(uint(len(dictRec.DictSlice) - 1)))
 	}
 	if err := layout.FinalizeDictDataPagesWithOption(pages, bitWidth, layout.PageWriteOption{
-		Context:      pw.context(),
-		CompressType: compressionType,
-		WriteCRC:     pw.writeCRC,
-		Compressor:   pw.compressorForColumn(name),
+		Context:         pw.context(),
+		CompressType:    compressionType,
+		DataPageVersion: pw.dataPageVersion,
+		WriteCRC:        pw.writeCRC,
+		Compressor:      pw.compressorForColumn(name),
 	}); err != nil {
 		return nil, fmt.Errorf("finalize dict data pages for column %s: %w", name, err)
 	}

--- a/writer/dictionary.go
+++ b/writer/dictionary.go
@@ -1,0 +1,92 @@
+package writer
+
+import (
+	"fmt"
+	"math/bits"
+
+	"github.com/hangxie/parquet-go/v3/internal/compress"
+	"github.com/hangxie/parquet-go/v3/internal/layout"
+	"github.com/hangxie/parquet-go/v3/parquet"
+)
+
+func usesDictionaryEncoding(table *layout.Table) bool {
+	return table.Info.Encoding == parquet.Encoding_PLAIN_DICTIONARY ||
+		table.Info.Encoding == parquet.Encoding_RLE_DICTIONARY
+}
+
+func (pw *ParquetWriter) tableToDictPages(name string, table *layout.Table, compressionType parquet.CompressionCodec, compressor *compress.Compressor) ([]*layout.Page, error) {
+	var dictRec *layout.DictRecType
+	if v, ok := pw.DictRecs.Load(name); ok {
+		dictRec = v.(*layout.DictRecType)
+	} else {
+		newRec := layout.NewDictRecWithLimit(*table.Schema.Type, pw.maxDictionarySize)
+		actual, _ := pw.DictRecs.LoadOrStore(name, newRec)
+		dictRec = actual.(*layout.DictRecType)
+	}
+
+	pages, _, err := layout.TableToDictDataPagesWithOption(dictRec, table, layout.PageWriteOption{
+		Context:         pw.context(),
+		PageSize:        int32(pw.pageSize),
+		CompressType:    compressionType,
+		WriteCRC:        pw.writeCRC,
+		Compressor:      compressor,
+		DataPageVersion: pw.dataPageVersion,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("build dict pages: %w", err)
+	}
+	return pages, nil
+}
+
+func hasDictionaryDataPage(pages []*layout.Page) bool {
+	for _, page := range pages {
+		if page == nil {
+			continue
+		}
+		if page.Header != nil && page.Header.DataPageHeader != nil &&
+			page.Header.DataPageHeader.Encoding == parquet.Encoding_RLE_DICTIONARY {
+			return true
+		}
+		if page.Header == nil && page.Info != nil &&
+			(page.Info.Encoding == parquet.Encoding_PLAIN_DICTIONARY ||
+				page.Info.Encoding == parquet.Encoding_RLE_DICTIONARY) {
+			return true
+		}
+	}
+	return false
+}
+
+func (pw *ParquetWriter) buildDictionaryChunk(name string, pages []*layout.Page, compressionType parquet.CompressionCodec) (*layout.Chunk, error) {
+	v, ok := pw.DictRecs.Load(name)
+	if !ok {
+		return nil, fmt.Errorf("missing dictionary recorder for column %s", name)
+	}
+	dictRec := v.(*layout.DictRecType)
+	bitWidth := int32(0)
+	if len(dictRec.DictSlice) > 1 {
+		bitWidth = int32(bits.Len(uint(len(dictRec.DictSlice) - 1)))
+	}
+	if err := layout.FinalizeDictDataPagesWithOption(pages, bitWidth, layout.PageWriteOption{
+		Context:      pw.context(),
+		CompressType: compressionType,
+		WriteCRC:     pw.writeCRC,
+		Compressor:   pw.compressorForColumn(name),
+	}); err != nil {
+		return nil, fmt.Errorf("finalize dict data pages for column %s: %w", name, err)
+	}
+	dictPage, _, err := layout.DictRecToDictPageWithOption(dictRec, layout.PageWriteOption{
+		Context:      pw.context(),
+		PageSize:     int32(pw.pageSize),
+		CompressType: compressionType,
+		WriteCRC:     pw.writeCRC,
+		Compressor:   pw.compressorForColumn(name),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("convert dict rec to dict page for column %s: %w", name, err)
+	}
+	chunk, err := layout.PagesToDictChunk(append([]*layout.Page{dictPage}, pages...))
+	if err != nil {
+		return nil, fmt.Errorf("convert pages to dict chunk for column %s: %w", name, err)
+	}
+	return chunk, nil
+}

--- a/writer/dictionary_test.go
+++ b/writer/dictionary_test.go
@@ -1,0 +1,75 @@
+package writer
+
+import (
+	"context"
+	"math/bits"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hangxie/parquet-go/v3/parquet"
+	"github.com/hangxie/parquet-go/v3/reader"
+)
+
+func TestDictionaryEncodingBitWidthAndFallback(t *testing.T) {
+	type Entry struct {
+		Value string `parquet:"name=value, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+	}
+
+	t.Run("uses_completed_dictionary_width", func(t *testing.T) {
+		pw, buf, err := createTestParquetWriter(
+			new(Entry),
+			WithNP(4),
+			WithCompressionCodec(parquet.CompressionCodec_UNCOMPRESSED),
+		)
+		require.NoError(t, err)
+
+		values := []string{"alpha", "beta", "gamma", "delta", "epsilon", "alpha"}
+		for _, value := range values {
+			require.NoError(t, pw.Write(Entry{Value: value}))
+		}
+		require.NoError(t, pw.WriteStop())
+
+		column := pw.Footer.RowGroups[0].Columns[0]
+		header, headerLen := rawPageHeaderAt(t, buf.Bytes(), column.MetaData.DataPageOffset)
+		require.Equal(t, parquet.Encoding_RLE_DICTIONARY, header.DataPageHeader.Encoding)
+		bodyOffset := column.MetaData.DataPageOffset + int64(headerLen)
+		require.Equal(t, byte(bits.Len(uint(5-1))), buf.Bytes()[bodyOffset])
+	})
+
+	t.Run("falls_back_to_plain", func(t *testing.T) {
+		pw, buf, err := createTestParquetWriter(
+			new(Entry),
+			WithNP(4),
+			WithPageSize(5),
+			WithMaxDictionarySize(10),
+			WithCompressionCodec(parquet.CompressionCodec_UNCOMPRESSED),
+		)
+		require.NoError(t, err)
+
+		values := []string{"alpha", "bravo", "charlie", "delta"}
+		for _, value := range values {
+			require.NoError(t, pw.Write(Entry{Value: value}))
+		}
+		require.NoError(t, pw.WriteStop())
+
+		column := pw.Footer.RowGroups[0].Columns[0]
+		require.Contains(t, column.MetaData.Encodings, parquet.Encoding_RLE_DICTIONARY)
+		require.Contains(t, column.MetaData.Encodings, parquet.Encoding_PLAIN)
+
+		dictHeader, _ := rawPageHeaderAt(t, buf.Bytes(), *column.MetaData.DictionaryPageOffset)
+		require.Equal(t, int32(1), dictHeader.DictionaryPageHeader.NumValues)
+
+		pr, pf, err := createTestParquetReader(buf.Bytes(), new(Entry), reader.WithNP(1))
+		require.NoError(t, err)
+		defer func() { require.NoError(t, pf.Close()) }()
+		//nolint:staticcheck
+		defer func() { require.NoError(t, pr.ReadStop()) }()
+
+		got := make([]Entry, len(values))
+		require.NoError(t, pr.ReadWithContext(context.Background(), &got))
+		for i := range values {
+			require.Equal(t, values[i], got[i].Value)
+		}
+	})
+}

--- a/writer/dictionary_test.go
+++ b/writer/dictionary_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestDictionaryEncodingBitWidthAndFallback(t *testing.T) {
 	type Entry struct {
-		Value string `parquet:"name=value, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+		Value string `parquet:"name=value, type=BYTE_ARRAY, convertedtype=UTF8, encoding=RLE_DICTIONARY"`
 	}
 
 	t.Run("uses_completed_dictionary_width", func(t *testing.T) {
@@ -43,6 +43,7 @@ func TestDictionaryEncodingBitWidthAndFallback(t *testing.T) {
 			WithNP(4),
 			WithPageSize(5),
 			WithMaxDictionarySize(10),
+			WithDataPageVersion(2),
 			WithCompressionCodec(parquet.CompressionCodec_UNCOMPRESSED),
 		)
 		require.NoError(t, err)
@@ -59,6 +60,14 @@ func TestDictionaryEncodingBitWidthAndFallback(t *testing.T) {
 
 		dictHeader, _ := rawPageHeaderAt(t, buf.Bytes(), *column.MetaData.DictionaryPageOffset)
 		require.Equal(t, int32(1), dictHeader.DictionaryPageHeader.NumValues)
+
+		offset := column.MetaData.DataPageOffset
+		chunkEnd := *column.MetaData.DictionaryPageOffset + column.MetaData.TotalCompressedSize
+		for offset < chunkEnd {
+			header, headerLen := rawPageHeaderAt(t, buf.Bytes(), offset)
+			require.Equal(t, parquet.PageType_DATA_PAGE_V2, header.Type)
+			offset += int64(headerLen) + int64(header.CompressedPageSize)
+		}
 
 		pr, pf, err := createTestParquetReader(buf.Bytes(), new(Entry), reader.WithNP(1))
 		require.NoError(t, err)

--- a/writer/ops.go
+++ b/writer/ops.go
@@ -189,27 +189,11 @@ func (pw *ParquetWriter) buildChunkMap() (map[string]*layout.Chunk, error) {
 			}
 		}
 
-		if len(pages) > 0 && (pages[0].Info.Encoding == parquet.Encoding_PLAIN_DICTIONARY || pages[0].Info.Encoding == parquet.Encoding_RLE_DICTIONARY) {
-			v, ok := pw.DictRecs.Load(name)
-			if !ok {
-				return nil, fmt.Errorf("missing dictionary recorder for column %s", name)
-			}
-			dictRec := v.(*layout.DictRecType)
-			dictPage, _, err := layout.DictRecToDictPageWithOption(dictRec, layout.PageWriteOption{
-				Context:      pw.context(),
-				PageSize:     int32(pw.pageSize),
-				CompressType: compressionType,
-				WriteCRC:     pw.writeCRC,
-				Compressor:   pw.compressorForColumn(name),
-			})
+		if hasDictionaryDataPage(pages) {
+			var err error
+			chunkMap[name], err = pw.buildDictionaryChunk(name, pages, compressionType)
 			if err != nil {
-				return nil, fmt.Errorf("convert dict rec to dict page for column %s: %w", name, err)
-			}
-			tmp := append([]*layout.Page{dictPage}, pages...)
-			var chunkErr error
-			chunkMap[name], chunkErr = layout.PagesToDictChunk(tmp)
-			if chunkErr != nil {
-				return nil, fmt.Errorf("convert pages to dict chunk for column %s: %w", name, chunkErr)
+				return nil, err
 			}
 		} else {
 			var err error

--- a/writer/pages.go
+++ b/writer/pages.go
@@ -16,31 +16,6 @@ func (pw *ParquetWriter) tableCompressionCodec(table *layout.Table) parquet.Comp
 	return pw.compressionType
 }
 
-func (pw *ParquetWriter) tableToDictPages(name string, table *layout.Table, compressionType parquet.CompressionCodec, compressor *compress.Compressor, convMu *sync.Mutex) ([]*layout.Page, error) {
-	var dictRec *layout.DictRecType
-	if v, ok := pw.DictRecs.Load(name); ok {
-		dictRec = v.(*layout.DictRecType)
-	} else {
-		newRec := layout.NewDictRec(*table.Schema.Type)
-		actual, _ := pw.DictRecs.LoadOrStore(name, newRec)
-		dictRec = actual.(*layout.DictRecType)
-	}
-
-	convMu.Lock()
-	pages, _, err := layout.TableToDictDataPagesWithOption(dictRec, table, 32, layout.PageWriteOption{
-		Context:      pw.context(),
-		PageSize:     int32(pw.pageSize),
-		CompressType: compressionType,
-		WriteCRC:     pw.writeCRC,
-		Compressor:   compressor,
-	})
-	convMu.Unlock()
-	if err != nil {
-		return nil, fmt.Errorf("build dict pages: %w", err)
-	}
-	return pages, nil
-}
-
 func (pw *ParquetWriter) tableToPlainPages(table *layout.Table, compressionType parquet.CompressionCodec, compressor *compress.Compressor) ([]*layout.Page, error) {
 	pages, _, err := layout.TableToDataPagesWithOption(table, layout.PageWriteOption{
 		Context:         pw.context(),
@@ -56,12 +31,11 @@ func (pw *ParquetWriter) tableToPlainPages(table *layout.Table, compressionType 
 	return pages, nil
 }
 
-func (pw *ParquetWriter) convertTableToPages(name string, table *layout.Table, convMu *sync.Mutex) ([]*layout.Page, error) {
+func (pw *ParquetWriter) convertTableToPages(name string, table *layout.Table) ([]*layout.Page, error) {
 	compressionType := pw.tableCompressionCodec(table)
 	compressor := pw.compressorForColumn(name)
-	if table.Info.Encoding == parquet.Encoding_PLAIN_DICTIONARY ||
-		table.Info.Encoding == parquet.Encoding_RLE_DICTIONARY {
-		return pw.tableToDictPages(name, table, compressionType, compressor, convMu)
+	if usesDictionaryEncoding(table) {
+		return pw.tableToDictPages(name, table, compressionType, compressor)
 	}
 	return pw.tableToPlainPages(table, compressionType, compressor)
 }
@@ -76,10 +50,60 @@ func (pw *ParquetWriter) mergePageResults(pagesMapList []map[string][]*layout.Pa
 			}
 			for _, page := range pages {
 				pw.size += int64(len(page.RawData))
-				page.DataTable = nil // release memory
+				if page.Header.DataPageHeader == nil ||
+					page.Header.DataPageHeader.Encoding != parquet.Encoding_RLE_DICTIONARY {
+					page.DataTable = nil // release memory
+				}
 			}
 		}
 	}
+}
+
+func (pw *ParquetWriter) marshalAndConvertPlain(b, e int, pagesMap map[string][]*layout.Page, bloomMu *sync.Mutex) (map[string]*layout.Table, error) {
+	if e <= b {
+		return nil, nil
+	}
+	tableMap, err := pw.marshalFunc(pw.objs[b:e], pw.SchemaHandler)
+	if err != nil {
+		return nil, err
+	}
+	for name, table := range *tableMap {
+		pw.insertBloomValues(name, table, bloomMu)
+		if usesDictionaryEncoding(table) {
+			continue
+		}
+		pages, err := pw.convertTableToPages(name, table)
+		if err != nil {
+			return nil, err
+		}
+		pagesMap[name] = pages
+	}
+	return *tableMap, nil
+}
+
+func firstPageConversionError(errs []error) error {
+	for _, err := range errs {
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (pw *ParquetWriter) convertDictionaryTables(tableMaps []map[string]*layout.Table, pagesMaps []map[string][]*layout.Page) error {
+	for index, tableMap := range tableMaps {
+		for name, table := range tableMap {
+			if !usesDictionaryEncoding(table) {
+				continue
+			}
+			pages, err := pw.convertTableToPages(name, table)
+			if err != nil {
+				return err
+			}
+			pagesMaps[index][name] = pages
+		}
+	}
+	return nil
 }
 
 func (pw *ParquetWriter) flushObjs() error {
@@ -88,12 +112,12 @@ func (pw *ParquetWriter) flushObjs() error {
 		return nil
 	}
 	pagesMapList := make([]map[string][]*layout.Page, pw.np)
+	tableMapList := make([]map[string]*layout.Table, pw.np)
 	for i := range pw.np {
 		pagesMapList[i] = make(map[string][]*layout.Page)
 	}
 
 	delta := (l + pw.np - 1) / pw.np
-	var convMu sync.Mutex
 	var bloomMu sync.Mutex
 	var wg sync.WaitGroup
 	errs := make([]error, pw.np)
@@ -111,37 +135,15 @@ func (pw *ParquetWriter) flushObjs() error {
 		wg.Add(1)
 		go func(b, e int, index int64) {
 			defer wg.Done()
-
-			if e <= b {
-				return
-			}
-
-			tableMap, err2 := pw.marshalFunc(pw.objs[b:e], pw.SchemaHandler)
-			if err2 != nil {
-				errs[index] = err2
-				return
-			}
-
-			for name, table := range *tableMap {
-				pw.insertBloomValues(name, table, &bloomMu)
-				pages, localErr := pw.convertTableToPages(name, table, &convMu)
-				if localErr != nil {
-					errs[index] = localErr
-					return
-				}
-				pagesMapList[index][name] = pages
-			}
+			tableMapList[index], errs[index] = pw.marshalAndConvertPlain(b, e, pagesMapList[index], &bloomMu)
 		}(int(bgn), int(end), c)
 	}
 
 	wg.Wait()
 
-	var err error
-	for _, err2 := range errs {
-		if err2 != nil {
-			err = err2
-			break
-		}
+	err := firstPageConversionError(errs)
+	if err == nil {
+		err = pw.convertDictionaryTables(tableMapList, pagesMapList)
 	}
 
 	pw.mergePageResults(pagesMapList)

--- a/writer/pages.go
+++ b/writer/pages.go
@@ -50,8 +50,7 @@ func (pw *ParquetWriter) mergePageResults(pagesMapList []map[string][]*layout.Pa
 			}
 			for _, page := range pages {
 				pw.size += int64(len(page.RawData))
-				if page.Header.DataPageHeader == nil ||
-					page.Header.DataPageHeader.Encoding != parquet.Encoding_RLE_DICTIONARY {
+				if !isDictionaryDataPage(page) {
 					page.DataTable = nil // release memory
 				}
 			}

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -18,6 +18,9 @@ import (
 	"github.com/hangxie/parquet-go/v3/source/writerfile"
 )
 
+// DefaultMaxDictionarySize is the default encoded dictionary value-byte limit.
+const DefaultMaxDictionarySize = 1024 * 1024
+
 // columnCompressorKey uniquely identifies a (codec, level) combination for sharing compressor instances.
 type columnCompressorKey struct {
 	codec parquet.CompressionCodec
@@ -50,6 +53,11 @@ func WithPageSize(size int64) WriterOption {
 // WithRowGroupSize sets the row group size in bytes. Default is 128MB.
 func WithRowGroupSize(size int64) WriterOption {
 	return writerOptionFunc(func(pw *ParquetWriter) { pw.rowGroupSize = size })
+}
+
+// WithMaxDictionarySize limits encoded dictionary value bytes per column and row group.
+func WithMaxDictionarySize(size int64) WriterOption {
+	return writerOptionFunc(func(pw *ParquetWriter) { pw.maxDictionarySize = size })
 }
 
 // WithCompressionCodec sets the compression codec. Default is SNAPPY.
@@ -88,6 +96,7 @@ type ParquetWriter struct {
 	np                int64 // parallel number
 	pageSize          int64
 	rowGroupSize      int64
+	maxDictionarySize int64
 	compressionType   parquet.CompressionCodec
 	compressionLevels map[parquet.CompressionCodec]int
 	compressor        *compress.Compressor
@@ -159,6 +168,7 @@ func (pw *ParquetWriter) initBase(ctx context.Context, pFile source.ParquetFileW
 	pw.np = 4                                    // default parallel number
 	pw.pageSize = common.DefaultPageSize         // 8K
 	pw.rowGroupSize = common.DefaultRowGroupSize // 128M
+	pw.maxDictionarySize = DefaultMaxDictionarySize
 	pw.compressionType = parquet.CompressionCodec_SNAPPY
 	pw.compressionLevels = nil
 	pw.compressor = nil
@@ -203,6 +213,9 @@ func (pw *ParquetWriter) initBase(ctx context.Context, pFile source.ParquetFileW
 	}
 	if pw.rowGroupSize <= 0 {
 		return fmt.Errorf("WithRowGroupSize: value must be positive, got %d", pw.rowGroupSize)
+	}
+	if pw.maxDictionarySize <= 0 {
+		return fmt.Errorf("WithMaxDictionarySize: value must be positive, got %d", pw.maxDictionarySize)
 	}
 	if pw.dataPageVersion != 1 && pw.dataPageVersion != 2 {
 		return fmt.Errorf("WithDataPageVersion: value must be 1 or 2, got %d", pw.dataPageVersion)

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -465,6 +465,11 @@ func TestOptionValidation(t *testing.T) {
 		"page_size_zero":       {[]WriterOption{WithPageSize(0)}, "WithPageSize: value must be positive"},
 		"page_size_negative":   {[]WriterOption{WithPageSize(-100)}, "WithPageSize: value must be positive"},
 		"row_group_size_zero":  {[]WriterOption{WithRowGroupSize(0)}, "WithRowGroupSize: value must be positive"},
+		"dictionary_size_zero": {[]WriterOption{WithMaxDictionarySize(0)}, "WithMaxDictionarySize: value must be positive"},
+		"dictionary_size_negative": {
+			[]WriterOption{WithMaxDictionarySize(-1)},
+			"WithMaxDictionarySize: value must be positive",
+		},
 		"data_page_version_0":  {[]WriterOption{WithDataPageVersion(0)}, "WithDataPageVersion: value must be 1 or 2"},
 		"data_page_version_3":  {[]WriterOption{WithDataPageVersion(3)}, "WithDataPageVersion: value must be 1 or 2"},
 		"data_page_version_-1": {[]WriterOption{WithDataPageVersion(-1)}, "WithDataPageVersion: value must be 1 or 2"},
@@ -475,7 +480,10 @@ func TestOptionValidation(t *testing.T) {
 			WithCompressionLevel(parquet.CompressionCodec_GZIP, 100),
 		}, "WithCompressionLevel: set compression level for GZIP"},
 		"valid_defaults": {nil, ""},
-		"valid_custom":   {[]WriterOption{WithNP(2), WithPageSize(4096), WithRowGroupSize(1024), WithDataPageVersion(2)}, ""},
+		"valid_custom": {
+			[]WriterOption{WithNP(2), WithPageSize(4096), WithRowGroupSize(1024), WithMaxDictionarySize(512), WithDataPageVersion(2)},
+			"",
+		},
 		"valid_compression_level": {[]WriterOption{
 			WithCompressionCodec(parquet.CompressionCodec_GZIP),
 			WithCompressionLevel(parquet.CompressionCodec_GZIP, 1),


### PR DESCRIPTION
## Summary

- compute dictionary index bit widths from the completed row-group dictionary
- cap encoded dictionaries at 1 MiB by default and fall back to PLAIN pages at page boundaries
- add `WithMaxDictionarySize` for per-writer tuning
- preserve input ordering for dictionary conversion with parallel writers
- document the dictionary behavior and add round-trip and edge-case coverage

## Validation

- `make all`
- statement coverage: 95.212867% (main: 95.178998%)

Closes #332