### PR TITLE
docs: clarify reader and writer concurrency contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -632,6 +632,42 @@ Other WKB types fall back to raw WKB. If WKB parsing fails, the converter also f
 
 Use `WithNP(n)` to set the number of parallel goroutines. The default is 4.
 
+`WithNP` controls parallel work performed inside a single operation. It does not make concurrent method calls on one reader or writer safe. Callers must serialize all operations on each `ParquetReader`, `ParquetWriter`, `CSVWriter`, `JSONWriter`, or `ArrowWriter` instance. In particular, writes must not overlap other writes, flushes, or finalization, and reads must not overlap other reads, skips, inspection operations, resets, or closing.
+
+Separate reader or writer instances do not share mutable library state and may be used concurrently when each has an independent file handle. A `ParquetFileReader` implementation must provide independent cursors from `Clone` and `Open`, as required by the source interface; any shared backend client must support the concurrency performed by those independent handles.
+
+`Clone` creates another low-level reader with an independent cursor. `NewParquetReader` also clones its supplied file reader internally for column-level work controlled by `WithNP`, but those internal handles belong to one high-level reader and do not make concurrent calls on that `ParquetReader` safe. To read the same file concurrently, clone the file reader and construct a separate `ParquetReader` for each goroutine:
+
+```go
+file1, err := source.CloneWithContext(ctx, file)
+if err != nil {
+    return err
+}
+file2, err := source.CloneWithContext(ctx, file)
+if err != nil {
+    _ = file1.Close()
+    return err
+}
+
+reader1, err := reader.NewParquetReaderWithContext(ctx, file1, new(Row))
+if err != nil {
+    _ = file1.Close()
+    _ = file2.Close()
+    return err
+}
+reader2, err := reader.NewParquetReaderWithContext(ctx, file2, new(Row))
+if err != nil {
+    _ = reader1.ReadStopWithContext(context.WithoutCancel(ctx))
+    _ = file1.Close()
+    _ = file2.Close()
+    return err
+}
+
+// reader1 and reader2 may now be used by separate goroutines.
+```
+
+Each `ParquetReader` has its own logical position; reads through one do not advance the other. `ReadStop` closes the reader's internal column handles, while the cloned file handles passed to the constructors remain the caller's responsibility to close.
+
 ```go
 func NewParquetReader(pFile source.ParquetFileReader, obj any, opts ...ReaderOption) (*ParquetReader, error)
 func NewParquetWriter(pFile source.ParquetFileWriter, obj any, opts ...WriterOption) (*ParquetWriter, error)

--- a/reader/reader.go
+++ b/reader/reader.go
@@ -18,7 +18,13 @@ import (
 	"github.com/hangxie/parquet-go/v3/source"
 )
 
-// ParquetReader is a reader for parquet files.
+// ParquetReader reads parquet files.
+//
+// A ParquetReader must not be used by multiple goroutines concurrently.
+// Callers must serialize all operations on an instance, including row reads,
+// column reads, skips, inspection methods, Reset, ReadStop, and their
+// context-aware variants. WithNP controls internal parallelism and does not
+// make concurrent method calls safe.
 type ParquetReader struct {
 	SchemaHandler *schema.SchemaHandler
 	// Footer is loaded once by ReadFooter and then treated as immutable for the

--- a/writer/arrow.go
+++ b/writer/arrow.go
@@ -15,7 +15,11 @@ import (
 	"github.com/hangxie/parquet-go/v3/source/writerfile"
 )
 
-// ArrowWriter is a writer for Arrow record batches to parquet files.
+// ArrowWriter writes Arrow record batches to parquet files.
+//
+// An ArrowWriter must not be used by multiple goroutines concurrently. Callers
+// must serialize all operations on an instance. WithNP controls internal
+// parallelism and does not make concurrent method calls safe.
 type ArrowWriter struct {
 	ParquetWriter
 }

--- a/writer/csv.go
+++ b/writer/csv.go
@@ -12,7 +12,11 @@ import (
 	"github.com/hangxie/parquet-go/v3/types"
 )
 
-// CSVWriter is a writer for CSV-style data to parquet files.
+// CSVWriter writes CSV-style data to parquet files.
+//
+// A CSVWriter must not be used by multiple goroutines concurrently. Callers
+// must serialize all operations on an instance. WithNP controls internal
+// parallelism and does not make concurrent method calls safe.
 type CSVWriter struct {
 	ParquetWriter
 }

--- a/writer/json.go
+++ b/writer/json.go
@@ -11,7 +11,11 @@ import (
 	"github.com/hangxie/parquet-go/v3/source/writerfile"
 )
 
-// JSONWriter is a writer for JSON-schema-defined data to parquet files.
+// JSONWriter writes JSON-schema-defined data to parquet files.
+//
+// A JSONWriter must not be used by multiple goroutines concurrently. Callers
+// must serialize all operations on an instance. WithNP controls internal
+// parallelism and does not make concurrent method calls safe.
 type JSONWriter struct {
 	ParquetWriter
 }

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -87,7 +87,12 @@ func WithWriteCRC(enabled bool) WriterOption {
 	return writerOptionFunc(func(pw *ParquetWriter) { pw.writeCRC = enabled })
 }
 
-// ParquetWriter is a writer  parquet file
+// ParquetWriter writes parquet files.
+//
+// A ParquetWriter must not be used by multiple goroutines concurrently.
+// Callers must serialize all operations on an instance, including Write,
+// Flush, WriteStop, and their context-aware variants. WithNP controls internal
+// parallelism and does not make concurrent method calls safe.
 type ParquetWriter struct {
 	SchemaHandler *schema.SchemaHandler
 	Footer        *parquet.FileMetaData


### PR DESCRIPTION
## Summary

- document that public operations on one `ParquetReader` or writer instance must be serialized
- clarify that `WithNP` controls internal parallelism rather than concurrent public calls
- explain how independent `ParquetFileReader` clones support concurrent reads through separate `ParquetReader` instances
- document the file-handle and backend requirements for independent instances

## Evidence

Temporary same-instance probes run with `go test -race` reproduced data races for both concurrent `WriteWithContext` calls and concurrent `Read` calls using the in-memory backend. Writer calls raced on context and buffered writer state; reader calls raced on context and column cursor/buffer state.

The probes were diagnostic only and are not included because tests that intentionally contain races would make race-enabled test runs fail.

## Validation

- `make all`

Closes #358.
