### PR TITLE
feat(writer): truncate binary min-max bounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Common writer options:
 - `writer.WithPageSize`
 - `writer.WithRowGroupSize`
 - `writer.WithMaxDictionarySize`
+- `writer.WithBinaryMinMaxTruncateLength`
 - `writer.WithCompressionCodec`
 - `writer.WithCompressionLevel`
 - `writer.WithDataPageVersion`
@@ -305,6 +306,17 @@ Encoding notes:
 - `writer.WithDataPageVersion(2)` applies to both dictionary-encoded and plain data pages.
 - Use `omitstats=true` in a field tag to skip statistics for large array fields.
 - Whenever min/max statistics are available, the current `min_value`/`max_value` fields are written. The deprecated `min`/`max` fields (PARQUET-251) are limited to signed sort orders; for unsigned-ordered columns (e.g. `BYTE_ARRAY`/UTF8 and unsigned integer logical types) they are omitted so legacy readers do not misinterpret them.
+
+### Binary statistics bound truncation
+
+Binary footer statistics and column-index bounds target a 64-byte maximum by default; tune it with `writer.WithBinaryMinMaxTruncateLength`. Unlike parquet-java, which leaves row-group statistics effectively untruncated by default, parquet-go intentionally applies the same default truncation policy to both footer statistics and column-index bounds.
+
+The maximum length applies only to these column types:
+
+- Unannotated `BYTE_ARRAY` and unannotated `FIXED_LEN_BYTE_ARRAY`: bounds are truncated as raw bytes. The configured length is a target rather than a hard cap; if an all-`0xFF` maximum prefix cannot be incremented, the original exact maximum is retained.
+- `BYTE_ARRAY` annotated with logical type `STRING` or converted type `UTF8`: minimum bounds are shortened at a UTF-8 character boundary and maximum bounds are rounded up to a valid UTF-8 upper bound. The configured length is a target rather than a hard cap for these columns; for example, with a target of 64 bytes, a stored bound may exceed 64 bytes when retaining the original value is necessary to keep a valid UTF-8 bound.
+
+The maximum length does not apply to any other logical or converted type, including annotated `FIXED_LEN_BYTE_ARRAY`, `ENUM`, `JSON`, `BSON`, `UUID`, `DECIMAL`, `FLOAT16`, `INTERVAL`, `GEOMETRY`, and `GEOGRAPHY`. Compact Parquet bounds must remain valid values of their logical type, which arbitrary prefix truncation cannot guarantee for those annotations.
 
 ## Compression Support
 

--- a/internal/layout/chunk.go
+++ b/internal/layout/chunk.go
@@ -110,6 +110,8 @@ func populateStatistics(metaData *parquet.ColumnMetaData, schema *parquet.Schema
 	}
 	metaData.Statistics.MaxValue = tmpBufMax
 	metaData.Statistics.MinValue = tmpBufMin
+	metaData.Statistics.IsMaxValueExact = common.ToPtr(true)
+	metaData.Statistics.IsMinValueExact = common.ToPtr(true)
 	// Deprecated Min/Max (PARQUET-251) only for signed sort orders.
 	if common.IsSignedSortOrder(pT, schema.ConvertedType, schema.LogicalType) {
 		metaData.Statistics.Max = tmpBufMax

--- a/internal/layout/page_write_encode.go
+++ b/internal/layout/page_write_encode.go
@@ -135,6 +135,7 @@ func (page *Page) setPageStatistics(stats *parquet.Statistics) error {
 			tmpBuf = tmpBuf[4:]
 		}
 		stats.MaxValue = tmpBuf
+		stats.IsMaxValueExact = common.ToPtr(true)
 		if signed {
 			stats.Max = tmpBuf
 		}
@@ -148,6 +149,7 @@ func (page *Page) setPageStatistics(stats *parquet.Statistics) error {
 			tmpBuf = tmpBuf[4:]
 		}
 		stats.MinValue = tmpBuf
+		stats.IsMinValueExact = common.ToPtr(true)
 		if signed {
 			stats.Min = tmpBuf
 		}

--- a/internal/layout/statistics.go
+++ b/internal/layout/statistics.go
@@ -1,0 +1,183 @@
+package layout
+
+import (
+	"unicode/utf8"
+
+	"github.com/hangxie/parquet-go/v3/common"
+	"github.com/hangxie/parquet-go/v3/parquet"
+)
+
+func truncateBinaryBounds(minValue, maxValue []byte, length int) (min, max []byte, minExact, maxExact bool) {
+	if length <= 0 {
+		return minValue, maxValue, true, true
+	}
+	min, minExact = truncateBinaryMin(minValue, length)
+	max, maxExact = truncateBinaryMax(maxValue, length)
+	return min, max, minExact, maxExact
+}
+
+func truncateRawBinaryBounds(minValue, maxValue []byte, length int) (min, max []byte, minExact, maxExact bool) {
+	if length <= 0 {
+		return minValue, maxValue, true, true
+	}
+	min, minExact = minValue, true
+	if len(minValue) > length {
+		min = append([]byte(nil), minValue[:length]...)
+		minExact = false
+	}
+	max, maxExact = maxValue, true
+	if len(maxValue) > length {
+		if incremented := incrementBinary(append([]byte(nil), maxValue[:length]...)); incremented != nil {
+			max = incremented
+			maxExact = false
+		}
+	}
+	return min, max, minExact, maxExact
+}
+
+func truncateBinaryMin(value []byte, length int) ([]byte, bool) {
+	if len(value) <= length {
+		return value, true
+	}
+	if !utf8.Valid(value) {
+		return value, true
+	}
+	truncated := append([]byte(nil), value[:length]...)
+	for len(truncated) > 0 && !utf8.Valid(truncated) {
+		truncated = truncated[:len(truncated)-1]
+	}
+	if len(truncated) == 0 {
+		return value, true
+	}
+	return truncated, false
+}
+
+func truncateBinaryMax(value []byte, length int) ([]byte, bool) {
+	if len(value) <= length {
+		return value, true
+	}
+	if !utf8.Valid(value) {
+		return value, true
+	}
+	truncated := append([]byte(nil), value[:length]...)
+	for len(truncated) > 0 && !utf8.Valid(truncated) {
+		truncated = truncated[:len(truncated)-1]
+	}
+	if len(truncated) == 0 {
+		return value, true
+	}
+	if incremented := incrementUTF8(truncated); incremented != nil {
+		return incremented, false
+	}
+	return value, true
+}
+
+func incrementBinary(value []byte) []byte {
+	for i := len(value) - 1; i >= 0; i-- {
+		value[i]++
+		if value[i] != 0 {
+			return value
+		}
+	}
+	return nil
+}
+
+func incrementUTF8(value []byte) []byte {
+	for i := len(value) - 1; i >= 0; i-- {
+		original := value[i]
+		for candidate := int(original) + 1; candidate <= 0xff; candidate++ {
+			value[i] = byte(candidate)
+			if utf8.Valid(value) {
+				return value
+			}
+		}
+		value[i] = original
+	}
+	return nil
+}
+
+type binaryTruncationMode uint8
+
+const (
+	binaryTruncationDisabled binaryTruncationMode = iota
+	binaryTruncationRaw
+	binaryTruncationUTF8
+)
+
+func binaryStatisticsTruncationMode(schema *parquet.SchemaElement) binaryTruncationMode {
+	if schema == nil || schema.Type == nil ||
+		(*schema.Type != parquet.Type_BYTE_ARRAY && *schema.Type != parquet.Type_FIXED_LEN_BYTE_ARRAY) {
+		return binaryTruncationDisabled
+	}
+	if schema.LogicalType != nil {
+		if *schema.Type == parquet.Type_BYTE_ARRAY && schema.LogicalType.STRING != nil &&
+			(schema.ConvertedType == nil || *schema.ConvertedType == parquet.ConvertedType_UTF8) {
+			return binaryTruncationUTF8
+		}
+		return binaryTruncationDisabled
+	}
+	if schema.ConvertedType != nil {
+		if *schema.Type == parquet.Type_BYTE_ARRAY && *schema.ConvertedType == parquet.ConvertedType_UTF8 {
+			return binaryTruncationUTF8
+		}
+		return binaryTruncationDisabled
+	}
+	return binaryTruncationRaw
+}
+
+// TruncateBinaryStatistics shortens eligible binary min/max values while
+// preserving safe lower and upper bounds. Unsupported logical values and
+// bounds without a valid shortened representation are left intact.
+func TruncateBinaryStatistics(stats *parquet.Statistics, schema *parquet.SchemaElement, length int) {
+	if stats == nil {
+		return
+	}
+	mode := binaryStatisticsTruncationMode(schema)
+	if mode == binaryTruncationDisabled {
+		if stats.MinValue != nil {
+			stats.IsMinValueExact = common.ToPtr(true)
+		}
+		if stats.MaxValue != nil {
+			stats.IsMaxValueExact = common.ToPtr(true)
+		}
+		return
+	}
+
+	hasMin, hasMax := stats.MinValue != nil, stats.MaxValue != nil
+	var min, max []byte
+	var minExact, maxExact bool
+	if mode == binaryTruncationUTF8 {
+		min, max, minExact, maxExact = truncateBinaryBounds(stats.MinValue, stats.MaxValue, length)
+	} else {
+		min, max, minExact, maxExact = truncateRawBinaryBounds(stats.MinValue, stats.MaxValue, length)
+	}
+	stats.MinValue = min
+	stats.MaxValue = max
+	if hasMin {
+		stats.IsMinValueExact = common.ToPtr(minExact)
+	}
+	if hasMax {
+		stats.IsMaxValueExact = common.ToPtr(maxExact)
+	}
+	if stats.Min != nil {
+		stats.Min = min
+	}
+	if stats.Max != nil {
+		stats.Max = max
+	}
+}
+
+// TruncateBinaryBounds shortens eligible binary bounds for a column. Bounds
+// that cannot be safely shortened are returned unchanged.
+func TruncateBinaryBounds(schema *parquet.SchemaElement, minValue, maxValue []byte, length int) (min, max []byte) {
+	switch binaryStatisticsTruncationMode(schema) {
+	case binaryTruncationRaw:
+		min, max, _, _ = truncateRawBinaryBounds(minValue, maxValue, length)
+		return min, max
+	case binaryTruncationUTF8:
+		min, max, _, _ = truncateBinaryBounds(minValue, maxValue, length)
+		return min, max
+	default:
+		return minValue, maxValue
+	}
+}

--- a/internal/layout/statistics_test.go
+++ b/internal/layout/statistics_test.go
@@ -1,0 +1,278 @@
+package layout
+
+import (
+	"testing"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hangxie/parquet-go/v3/common"
+	"github.com/hangxie/parquet-go/v3/parquet"
+)
+
+func TestTruncateBinaryBounds(t *testing.T) {
+	tests := []struct {
+		name     string
+		min      []byte
+		max      []byte
+		length   int
+		wantMin  []byte
+		wantMax  []byte
+		minExact bool
+		maxExact bool
+	}{
+		{"within limit", []byte("abc"), []byte("xyz"), 3, []byte("abc"), []byte("xyz"), true, true},
+		{"truncate and round upper bound", []byte("abcdef"), []byte("xyz123"), 3, []byte("abc"), []byte("xy{"), false, false},
+		{"disabled", []byte("abcdef"), []byte("xyz123"), 0, []byte("abcdef"), []byte("xyz123"), true, true},
+		{"first rune exceeds limit", []byte("ár"), []byte("ár"), 1, []byte("ár"), []byte("ár"), true, true},
+		{
+			"largest UTF-8 rune cannot be incremented",
+			[]byte("\U0010ffffx"),
+			[]byte("\U0010ffffx"),
+			4,
+			[]byte("\U0010ffff"),
+			[]byte("\U0010ffffx"),
+			false,
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			min, max, minExact, maxExact := truncateBinaryBounds(tt.min, tt.max, tt.length)
+			require.Equal(t, tt.wantMin, min)
+			require.Equal(t, tt.wantMax, max)
+			require.Equal(t, tt.minExact, minExact)
+			require.Equal(t, tt.maxExact, maxExact)
+		})
+	}
+}
+
+func TestPublicTruncateBinaryBounds(t *testing.T) {
+	byteArray := &parquet.SchemaElement{Type: common.ToPtr(parquet.Type_BYTE_ARRAY)}
+	min, max := TruncateBinaryBounds(byteArray, []byte("abcdef"), []byte("xyz123"), 3)
+	require.Equal(t, []byte("abc"), min)
+	require.Equal(t, []byte("xy{"), max)
+
+	int32Type := &parquet.SchemaElement{Type: common.ToPtr(parquet.Type_INT32)}
+	min, max = TruncateBinaryBounds(int32Type, []byte("abcdef"), []byte("xyz123"), 3)
+	require.Equal(t, []byte("abcdef"), min)
+	require.Equal(t, []byte("xyz123"), max)
+
+	min, max = TruncateBinaryBounds(byteArray, []byte("abcdef"), []byte("xyz123"), 0)
+	require.Equal(t, []byte("abcdef"), min)
+	require.Equal(t, []byte("xyz123"), max)
+
+	min, max = TruncateBinaryBounds(byteArray, []byte("abc"), []byte("xyz"), 3)
+	require.Equal(t, []byte("abc"), min)
+	require.Equal(t, []byte("xyz"), max)
+}
+
+func TestTruncateBinaryStatistics(t *testing.T) {
+	tests := []struct {
+		name         string
+		schema       *parquet.SchemaElement
+		wantMin      []byte
+		wantMax      []byte
+		wantMinExact bool
+		wantMaxExact bool
+	}{
+		{
+			name: "raw byte array",
+			schema: &parquet.SchemaElement{
+				Type: common.ToPtr(parquet.Type_BYTE_ARRAY),
+			},
+			wantMin:      []byte("abc"),
+			wantMax:      []byte("xy{"),
+			wantMinExact: false,
+			wantMaxExact: false,
+		},
+		{
+			name: "converted UTF8",
+			schema: &parquet.SchemaElement{
+				Type:          common.ToPtr(parquet.Type_BYTE_ARRAY),
+				ConvertedType: common.ToPtr(parquet.ConvertedType_UTF8),
+			},
+			wantMin:      []byte("abc"),
+			wantMax:      []byte("xy{"),
+			wantMinExact: false,
+			wantMaxExact: false,
+		},
+		{
+			name: "raw fixed length byte array",
+			schema: &parquet.SchemaElement{
+				Type: common.ToPtr(parquet.Type_FIXED_LEN_BYTE_ARRAY),
+			},
+			wantMin:      []byte("abc"),
+			wantMax:      []byte("xy{"),
+			wantMinExact: false,
+			wantMaxExact: false,
+		},
+		{
+			name: "decimal keeps signed-order bytes",
+			schema: &parquet.SchemaElement{
+				Type:          common.ToPtr(parquet.Type_BYTE_ARRAY),
+				ConvertedType: common.ToPtr(parquet.ConvertedType_DECIMAL),
+			},
+			wantMin:      []byte("abcdef"),
+			wantMax:      []byte("xyz123"),
+			wantMinExact: true,
+			wantMaxExact: true,
+		},
+		{
+			name: "uuid keeps fixed-width value",
+			schema: &parquet.SchemaElement{
+				Type:        common.ToPtr(parquet.Type_FIXED_LEN_BYTE_ARRAY),
+				LogicalType: &parquet.LogicalType{UUID: &parquet.UUIDType{}},
+			},
+			wantMin:      []byte("abcdef"),
+			wantMax:      []byte("xyz123"),
+			wantMinExact: true,
+			wantMaxExact: true,
+		},
+		{
+			name: "json remains a valid document",
+			schema: &parquet.SchemaElement{
+				Type:        common.ToPtr(parquet.Type_BYTE_ARRAY),
+				LogicalType: &parquet.LogicalType{JSON: &parquet.JsonType{}},
+			},
+			wantMin:      []byte("abcdef"),
+			wantMax:      []byte("xyz123"),
+			wantMinExact: true,
+			wantMaxExact: true,
+		},
+		{
+			name: "logical JSON overrides inconsistent UTF8 converted type",
+			schema: &parquet.SchemaElement{
+				Type:          common.ToPtr(parquet.Type_BYTE_ARRAY),
+				ConvertedType: common.ToPtr(parquet.ConvertedType_UTF8),
+				LogicalType:   &parquet.LogicalType{JSON: &parquet.JsonType{}},
+			},
+			wantMin:      []byte("abcdef"),
+			wantMax:      []byte("xyz123"),
+			wantMinExact: true,
+			wantMaxExact: true,
+		},
+		{
+			name: "bson remains a valid document",
+			schema: &parquet.SchemaElement{
+				Type:          common.ToPtr(parquet.Type_BYTE_ARRAY),
+				ConvertedType: common.ToPtr(parquet.ConvertedType_BSON),
+			},
+			wantMin:      []byte("abcdef"),
+			wantMax:      []byte("xyz123"),
+			wantMinExact: true,
+			wantMaxExact: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stats := &parquet.Statistics{
+				MinValue: []byte("abcdef"),
+				MaxValue: []byte("xyz123"),
+				Min:      []byte("abcdef"),
+				Max:      []byte("xyz123"),
+			}
+			TruncateBinaryStatistics(stats, tt.schema, 3)
+			require.Equal(t, tt.wantMin, stats.MinValue)
+			require.Equal(t, tt.wantMax, stats.MaxValue)
+			require.Equal(t, tt.wantMinExact, stats.GetIsMinValueExact())
+			require.Equal(t, tt.wantMaxExact, stats.GetIsMaxValueExact())
+			require.Equal(t, tt.wantMin, stats.Min)
+			require.Equal(t, tt.wantMax, stats.Max)
+		})
+	}
+
+	TruncateBinaryStatistics(nil, nil, 3)
+	empty := parquet.NewStatistics()
+	TruncateBinaryStatistics(empty, &parquet.SchemaElement{Type: common.ToPtr(parquet.Type_BYTE_ARRAY)}, 3)
+	require.False(t, empty.IsSetIsMinValueExact())
+	require.False(t, empty.IsSetIsMaxValueExact())
+}
+
+func TestTruncateUTF8Bounds(t *testing.T) {
+	tests := []struct {
+		name   string
+		schema *parquet.SchemaElement
+	}{
+		{
+			name: "converted UTF8",
+			schema: &parquet.SchemaElement{
+				Type:          common.ToPtr(parquet.Type_BYTE_ARRAY),
+				ConvertedType: common.ToPtr(parquet.ConvertedType_UTF8),
+			},
+		},
+		{
+			name: "logical STRING",
+			schema: &parquet.SchemaElement{
+				Type:        common.ToPtr(parquet.Type_BYTE_ARRAY),
+				LogicalType: &parquet.LogicalType{STRING: &parquet.StringType{}},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			min, max := TruncateBinaryBounds(tt.schema, []byte("árvíztűrő"), []byte("árvíztűrő"), 9)
+			require.Equal(t, []byte("árvízt"), min)
+			require.Equal(t, []byte("árvízu"), max)
+			require.True(t, utf8.Valid(min))
+			require.True(t, utf8.Valid(max))
+		})
+	}
+}
+
+func TestInvalidUTF8BoundsRemainUntruncated(t *testing.T) {
+	schema := &parquet.SchemaElement{
+		Type:          common.ToPtr(parquet.Type_BYTE_ARRAY),
+		ConvertedType: common.ToPtr(parquet.ConvertedType_UTF8),
+	}
+	value := []byte{0xff, 0x01, 0x02}
+	min, max := TruncateBinaryBounds(schema, value, value, 2)
+	require.Equal(t, value, min)
+	require.Equal(t, value, max)
+}
+
+func TestTruncateRawMalformedUTF8Bounds(t *testing.T) {
+	tests := []struct {
+		name         string
+		physicalType parquet.Type
+		value        []byte
+		wantMin      []byte
+		wantMax      []byte
+	}{
+		{"increment", parquet.Type_BYTE_ARRAY, []byte{0xff, 0x01, 0x02}, []byte{0xff, 0x01}, []byte{0xff, 0x02}},
+		{"carry", parquet.Type_BYTE_ARRAY, []byte{0x01, 0xff, 0x03}, []byte{0x01, 0xff}, []byte{0x02, 0x00}},
+		{"byte array overflow", parquet.Type_BYTE_ARRAY, []byte{0xff, 0xff, 0x03}, []byte{0xff, 0xff}, []byte{0xff, 0xff, 0x03}},
+		{"fixed length overflow", parquet.Type_FIXED_LEN_BYTE_ARRAY, []byte{0xff, 0xff, 0x03}, []byte{0xff, 0xff}, []byte{0xff, 0xff, 0x03}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			schema := &parquet.SchemaElement{Type: common.ToPtr(tt.physicalType)}
+			min, max := TruncateBinaryBounds(schema, tt.value, tt.value, 2)
+			require.Equal(t, tt.wantMin, min)
+			require.Equal(t, tt.wantMax, max)
+		})
+	}
+}
+
+func TestTruncateRawOverflowStatistics(t *testing.T) {
+	for _, physicalType := range []parquet.Type{parquet.Type_BYTE_ARRAY, parquet.Type_FIXED_LEN_BYTE_ARRAY} {
+		t.Run(physicalType.String(), func(t *testing.T) {
+			value := []byte{0xff, 0xff, 0x03}
+			stats := &parquet.Statistics{MinValue: value, MaxValue: value}
+			TruncateBinaryStatistics(stats, &parquet.SchemaElement{Type: common.ToPtr(physicalType)}, 2)
+			require.Equal(t, []byte{0xff, 0xff}, stats.MinValue)
+			require.Equal(t, value, stats.MaxValue)
+			require.False(t, stats.GetIsMinValueExact())
+			require.True(t, stats.GetIsMaxValueExact())
+		})
+	}
+}
+
+func TestTruncateRawByteArrayDoesNotApplyUTF8Rules(t *testing.T) {
+	schema := &parquet.SchemaElement{Type: common.ToPtr(parquet.Type_BYTE_ARRAY)}
+	min, max := TruncateBinaryBounds(schema, []byte("ár"), []byte("ár"), 1)
+	require.Equal(t, []byte{0xc3}, min)
+	require.Equal(t, []byte{0xc4}, max)
+}

--- a/writer/ops.go
+++ b/writer/ops.go
@@ -202,6 +202,10 @@ func (pw *ParquetWriter) buildChunkMap() (map[string]*layout.Chunk, error) {
 				return nil, fmt.Errorf("convert pages to chunk for column %s: %w", name, err)
 			}
 		}
+		chunk := chunkMap[name]
+		if chunk != nil && len(chunk.Pages) > 0 {
+			layout.TruncateBinaryStatistics(chunk.ChunkHeader.MetaData.Statistics, chunk.Pages[len(chunk.Pages)-1].Schema, pw.binaryMinMaxTruncateLength)
+		}
 	}
 	return chunkMap, nil
 }

--- a/writer/pages.go
+++ b/writer/pages.go
@@ -218,8 +218,12 @@ func (pw *ParquetWriter) recordDataPage(page *layout.Page, columnIndex *parquet.
 		if stats.minVal == nil || stats.maxVal == nil {
 			hasValidBounds = false
 		}
-		columnIndex.MinValues[dataPageIdx] = stats.minVal
-		columnIndex.MaxValues[dataPageIdx] = stats.maxVal
+		minValue, maxValue := layout.TruncateBinaryBounds(page.Schema, stats.minVal, stats.maxVal, pw.binaryMinMaxTruncateLength)
+		if minValue == nil || maxValue == nil {
+			hasValidBounds = false
+		}
+		columnIndex.MinValues[dataPageIdx] = minValue
+		columnIndex.MaxValues[dataPageIdx] = maxValue
 	}
 	if stats.nullCount != nil {
 		if columnIndex.NullCounts == nil {

--- a/writer/pages_test.go
+++ b/writer/pages_test.go
@@ -3,6 +3,7 @@ package writer
 import (
 	"bytes"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -146,6 +147,183 @@ func TestOffsetIndexFirstRowIndex(t *testing.T) {
 }
 
 func TestColumnIndex(t *testing.T) {
+	t.Run("raw_fixed_length_bounds", func(t *testing.T) {
+		type Entry struct {
+			Value string `parquet:"name=value, type=FIXED_LEN_BYTE_ARRAY, length=6"`
+		}
+
+		pw, buf, err := createTestParquetWriter(new(Entry), WithNP(1), WithBinaryMinMaxTruncateLength(3))
+		require.NoError(t, err)
+		for _, value := range []string{"aaaaaa", "zzzzzz"} {
+			require.NoError(t, pw.Write(Entry{Value: value}))
+		}
+		require.NoError(t, pw.WriteStop())
+
+		pf := buffer.NewBufferReaderFromBytesNoAlloc(buf.Bytes())
+		defer func() { require.NoError(t, pf.Close()) }()
+		pr, err := reader.NewParquetReader(pf, nil, reader.WithNP(1)) //nolint:staticcheck
+		require.NoError(t, err)
+		require.NoError(t, pr.ReadFooter()) //nolint:staticcheck
+
+		chunk := pr.Footer.RowGroups[0].Columns[0]
+		require.Equal(t, []byte("aaa"), chunk.MetaData.Statistics.MinValue)
+		require.Equal(t, []byte("zz{"), chunk.MetaData.Statistics.MaxValue)
+		require.False(t, chunk.MetaData.Statistics.GetIsMinValueExact())
+		require.False(t, chunk.MetaData.Statistics.GetIsMaxValueExact())
+		index, err := readColumnIndex(pr.PFile, *chunk.ColumnIndexOffset)
+		require.NoError(t, err)
+		require.Equal(t, [][]byte{[]byte("aaa")}, index.MinValues)
+		require.Equal(t, [][]byte{[]byte("zz{")}, index.MaxValues)
+	})
+
+	t.Run("annotated_documents_are_not_truncated", func(t *testing.T) {
+		type Entry struct {
+			Value string `parquet:"name=value, type=BYTE_ARRAY, convertedtype=JSON"`
+		}
+
+		pw, buf, err := createTestParquetWriter(new(Entry), WithNP(1), WithBinaryMinMaxTruncateLength(3))
+		require.NoError(t, err)
+		for _, value := range []string{`{"a":1}`, `{"z":9}`} {
+			require.NoError(t, pw.Write(Entry{Value: value}))
+		}
+		require.NoError(t, pw.WriteStop())
+
+		pf := buffer.NewBufferReaderFromBytesNoAlloc(buf.Bytes())
+		defer func() { require.NoError(t, pf.Close()) }()
+		pr, err := reader.NewParquetReader(pf, nil, reader.WithNP(1)) //nolint:staticcheck
+		require.NoError(t, err)
+		require.NoError(t, pr.ReadFooter()) //nolint:staticcheck
+
+		chunk := pr.Footer.RowGroups[0].Columns[0]
+		require.Equal(t, []byte(`{"a":1}`), chunk.MetaData.Statistics.MinValue)
+		require.Equal(t, []byte(`{"z":9}`), chunk.MetaData.Statistics.MaxValue)
+		require.True(t, chunk.MetaData.Statistics.GetIsMinValueExact())
+		require.True(t, chunk.MetaData.Statistics.GetIsMaxValueExact())
+		index, err := readColumnIndex(pr.PFile, *chunk.ColumnIndexOffset)
+		require.NoError(t, err)
+		require.Equal(t, [][]byte{[]byte(`{"a":1}`)}, index.MinValues)
+		require.Equal(t, [][]byte{[]byte(`{"z":9}`)}, index.MaxValues)
+	})
+
+	t.Run("default_binary_bound_length", func(t *testing.T) {
+		type Entry struct {
+			Value string `parquet:"name=value, type=BYTE_ARRAY, convertedtype=UTF8"`
+		}
+
+		pw, buf, err := createTestParquetWriter(new(Entry), WithNP(1))
+		require.NoError(t, err)
+		require.NoError(t, pw.Write(Entry{Value: strings.Repeat("a", DefaultBinaryMinMaxTruncateLength+6)}))
+		require.NoError(t, pw.WriteStop())
+
+		pf := buffer.NewBufferReaderFromBytesNoAlloc(buf.Bytes())
+		defer func() { require.NoError(t, pf.Close()) }()
+		pr, err := reader.NewParquetReader(pf, nil, reader.WithNP(1)) //nolint:staticcheck
+		require.NoError(t, err)
+		require.NoError(t, pr.ReadFooter()) //nolint:staticcheck
+
+		chunk := pr.Footer.RowGroups[0].Columns[0]
+		require.Len(t, chunk.MetaData.Statistics.MinValue, DefaultBinaryMinMaxTruncateLength)
+		require.Len(t, chunk.MetaData.Statistics.MaxValue, DefaultBinaryMinMaxTruncateLength)
+		index, err := readColumnIndex(pr.PFile, *chunk.ColumnIndexOffset)
+		require.NoError(t, err)
+		require.Len(t, index.MinValues[0], DefaultBinaryMinMaxTruncateLength)
+		require.Len(t, index.MaxValues[0], DefaultBinaryMinMaxTruncateLength)
+	})
+
+	t.Run("truncated_binary_bounds", func(t *testing.T) {
+		tests := []struct {
+			name string
+			obj  any
+			rows []any
+		}{
+			{
+				name: "plain",
+				obj: new(struct {
+					Value string `parquet:"name=value, type=BYTE_ARRAY, convertedtype=UTF8"`
+				}),
+				rows: []any{
+					struct {
+						Value string `parquet:"name=value, type=BYTE_ARRAY, convertedtype=UTF8"`
+					}{Value: "aaaaaa"},
+					struct {
+						Value string `parquet:"name=value, type=BYTE_ARRAY, convertedtype=UTF8"`
+					}{Value: "zzzzzz"},
+				},
+			},
+			{
+				name: "dictionary",
+				obj: new(struct {
+					Value string `parquet:"name=value, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+				}),
+				rows: []any{
+					struct {
+						Value string `parquet:"name=value, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+					}{Value: "aaaaaa"},
+					struct {
+						Value string `parquet:"name=value, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+					}{Value: "zzzzzz"},
+				},
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				pw, buf, err := createTestParquetWriter(tt.obj, WithNP(1), WithBinaryMinMaxTruncateLength(3))
+				require.NoError(t, err)
+				for _, row := range tt.rows {
+					require.NoError(t, pw.Write(row))
+				}
+				require.NoError(t, pw.WriteStop())
+
+				pf := buffer.NewBufferReaderFromBytesNoAlloc(buf.Bytes())
+				defer func() { require.NoError(t, pf.Close()) }()
+				pr, err := reader.NewParquetReader(pf, nil, reader.WithNP(1)) //nolint:staticcheck
+				require.NoError(t, err)
+				require.NoError(t, pr.ReadFooter()) //nolint:staticcheck
+
+				chunk := pr.Footer.RowGroups[0].Columns[0]
+				stats := chunk.MetaData.Statistics
+				require.Equal(t, []byte("aaa"), stats.MinValue)
+				require.Equal(t, []byte("zz{"), stats.MaxValue)
+				require.False(t, stats.GetIsMinValueExact())
+				require.False(t, stats.GetIsMaxValueExact())
+
+				index, err := readColumnIndex(pr.PFile, *chunk.ColumnIndexOffset)
+				require.NoError(t, err)
+				require.Equal(t, [][]byte{[]byte("aaa")}, index.MinValues)
+				require.Equal(t, [][]byte{[]byte("zz{")}, index.MaxValues)
+			})
+		}
+	})
+
+	t.Run("raw_overflow_preserves_exact_max_and_index", func(t *testing.T) {
+		type Entry struct {
+			Value string `parquet:"name=value, type=BYTE_ARRAY"`
+		}
+
+		pw, buf, err := createTestParquetWriter(new(Entry), WithNP(1), WithBinaryMinMaxTruncateLength(2))
+		require.NoError(t, err)
+		require.NoError(t, pw.Write(Entry{Value: string([]byte{0xff, 0xff, 0x01})}))
+		require.NoError(t, pw.WriteStop())
+
+		pf := buffer.NewBufferReaderFromBytesNoAlloc(buf.Bytes())
+		defer func() { require.NoError(t, pf.Close()) }()
+		pr, err := reader.NewParquetReader(pf, nil, reader.WithNP(1)) //nolint:staticcheck
+		require.NoError(t, err)
+		require.NoError(t, pr.ReadFooter()) //nolint:staticcheck
+
+		chunk := pr.Footer.RowGroups[0].Columns[0]
+		require.True(t, chunk.IsSetColumnIndexOffset())
+		require.Equal(t, []byte{0xff, 0xff}, chunk.MetaData.Statistics.MinValue)
+		require.Equal(t, []byte{0xff, 0xff, 0x01}, chunk.MetaData.Statistics.MaxValue)
+		require.False(t, chunk.MetaData.Statistics.GetIsMinValueExact())
+		require.True(t, chunk.MetaData.Statistics.GetIsMaxValueExact())
+		index, err := readColumnIndex(pr.PFile, *chunk.ColumnIndexOffset)
+		require.NoError(t, err)
+		require.Equal(t, [][]byte{{0xff, 0xff}}, index.MinValues)
+		require.Equal(t, [][]byte{{0xff, 0xff, 0x01}}, index.MaxValues)
+	})
+
 	t.Run("all_null_counts", func(t *testing.T) {
 		type Entry struct {
 			X *int64 `parquet:"name=x, type=INT64"`

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -18,8 +18,13 @@ import (
 	"github.com/hangxie/parquet-go/v3/source/writerfile"
 )
 
-// DefaultMaxDictionarySize is the default encoded dictionary value-byte limit.
-const DefaultMaxDictionarySize = 1024 * 1024
+const (
+	// DefaultMaxDictionarySize is the default encoded dictionary value-byte limit.
+	DefaultMaxDictionarySize = 1024 * 1024
+	// DefaultBinaryMinMaxTruncateLength is the default byte-length target for binary
+	// footer statistics and column-index bounds.
+	DefaultBinaryMinMaxTruncateLength = 64
+)
 
 // columnCompressorKey uniquely identifies a (codec, level) combination for sharing compressor instances.
 type columnCompressorKey struct {
@@ -60,6 +65,15 @@ func WithMaxDictionarySize(size int64) WriterOption {
 	return writerOptionFunc(func(pw *ParquetWriter) { pw.maxDictionarySize = size })
 }
 
+// WithBinaryMinMaxTruncateLength sets the target byte limit for unannotated
+// BYTE_ARRAY/FIXED_LEN_BYTE_ARRAY and STRING/UTF8 statistics and column-index
+// bounds. Default is 64. STRING/UTF8 bounds may exceed the target when they
+// cannot be shortened to a valid UTF-8 bound. Other annotated types remain
+// untruncated.
+func WithBinaryMinMaxTruncateLength(length int) WriterOption {
+	return writerOptionFunc(func(pw *ParquetWriter) { pw.binaryMinMaxTruncateLength = length })
+}
+
 // WithCompressionCodec sets the compression codec. Default is SNAPPY.
 func WithCompressionCodec(ct parquet.CompressionCodec) WriterOption {
 	return writerOptionFunc(func(pw *ParquetWriter) { pw.compressionType = ct })
@@ -98,20 +112,21 @@ type ParquetWriter struct {
 	Footer        *parquet.FileMetaData
 	PFile         source.ParquetFileWriter
 
-	np                int64 // parallel number
-	pageSize          int64
-	rowGroupSize      int64
-	maxDictionarySize int64
-	compressionType   parquet.CompressionCodec
-	compressionLevels map[parquet.CompressionCodec]int
-	compressor        *compress.Compressor
-	columnCompressors map[string]*compress.Compressor
-	dataPageVersion   int32 // 1 for DATA_PAGE (default), 2 for DATA_PAGE_V2
-	writeCRC          bool  // compute and write CRC32 checksums on pages (default false)
-	encryptionConfig  *EncryptionConfig
-	encryptionState   *encryptionState
-	optionErrors      []error
-	offset            int64
+	np                         int64 // parallel number
+	pageSize                   int64
+	rowGroupSize               int64
+	maxDictionarySize          int64
+	binaryMinMaxTruncateLength int
+	compressionType            parquet.CompressionCodec
+	compressionLevels          map[parquet.CompressionCodec]int
+	compressor                 *compress.Compressor
+	columnCompressors          map[string]*compress.Compressor
+	dataPageVersion            int32 // 1 for DATA_PAGE (default), 2 for DATA_PAGE_V2
+	writeCRC                   bool  // compute and write CRC32 checksums on pages (default false)
+	encryptionConfig           *EncryptionConfig
+	encryptionState            *encryptionState
+	optionErrors               []error
+	offset                     int64
 
 	objs              []any
 	objsSize          int64
@@ -174,6 +189,7 @@ func (pw *ParquetWriter) initBase(ctx context.Context, pFile source.ParquetFileW
 	pw.pageSize = common.DefaultPageSize         // 8K
 	pw.rowGroupSize = common.DefaultRowGroupSize // 128M
 	pw.maxDictionarySize = DefaultMaxDictionarySize
+	pw.binaryMinMaxTruncateLength = DefaultBinaryMinMaxTruncateLength
 	pw.compressionType = parquet.CompressionCodec_SNAPPY
 	pw.compressionLevels = nil
 	pw.compressor = nil
@@ -221,6 +237,9 @@ func (pw *ParquetWriter) initBase(ctx context.Context, pFile source.ParquetFileW
 	}
 	if pw.maxDictionarySize <= 0 {
 		return fmt.Errorf("WithMaxDictionarySize: value must be positive, got %d", pw.maxDictionarySize)
+	}
+	if pw.binaryMinMaxTruncateLength <= 0 {
+		return fmt.Errorf("WithBinaryMinMaxTruncateLength: value must be positive, got %d", pw.binaryMinMaxTruncateLength)
 	}
 	if pw.dataPageVersion != 1 && pw.dataPageVersion != 2 {
 		return fmt.Errorf("WithDataPageVersion: value must be 1 or 2, got %d", pw.dataPageVersion)

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -464,6 +464,11 @@ func TestOptionValidation(t *testing.T) {
 		"np_negative":          {[]WriterOption{WithNP(-1)}, "WithNP: value must be positive"},
 		"page_size_zero":       {[]WriterOption{WithPageSize(0)}, "WithPageSize: value must be positive"},
 		"page_size_negative":   {[]WriterOption{WithPageSize(-100)}, "WithPageSize: value must be positive"},
+		"truncate_length_zero": {[]WriterOption{WithBinaryMinMaxTruncateLength(0)}, "WithBinaryMinMaxTruncateLength: value must be positive"},
+		"truncate_length_negative": {
+			[]WriterOption{WithBinaryMinMaxTruncateLength(-1)},
+			"WithBinaryMinMaxTruncateLength: value must be positive",
+		},
 		"row_group_size_zero":  {[]WriterOption{WithRowGroupSize(0)}, "WithRowGroupSize: value must be positive"},
 		"dictionary_size_zero": {[]WriterOption{WithMaxDictionarySize(0)}, "WithMaxDictionarySize: value must be positive"},
 		"dictionary_size_negative": {
@@ -481,7 +486,7 @@ func TestOptionValidation(t *testing.T) {
 		}, "WithCompressionLevel: set compression level for GZIP"},
 		"valid_defaults": {nil, ""},
 		"valid_custom": {
-			[]WriterOption{WithNP(2), WithPageSize(4096), WithRowGroupSize(1024), WithMaxDictionarySize(512), WithDataPageVersion(2)},
+			[]WriterOption{WithNP(2), WithPageSize(4096), WithRowGroupSize(1024), WithMaxDictionarySize(512), WithBinaryMinMaxTruncateLength(32), WithDataPageVersion(2)},
 			"",
 		},
 		"valid_compression_level": {[]WriterOption{


### PR DESCRIPTION
## Summary

- add `WithBinaryMinMaxTruncateLength` to configure one shared target for binary footer statistics and column-index bounds, defaulting to 64 bytes
- truncate unannotated `BYTE_ARRAY` and `FIXED_LEN_BYTE_ARRAY` as raw bytes and preserve valid UTF-8 boundaries for `STRING`/`UTF8`
- leave other logical and converted types untruncated and set min/max exactness flags consistently
- retain the original exact maximum when a shortened upper bound cannot be produced, preserving the column index
- document the supported types and target-not-hard-cap behavior

## Default policy

Unlike parquet-java, which defaults column-index truncation to 64 bytes while leaving row-group statistics effectively untruncated, parquet-go intentionally applies the same 64-byte target to both metadata locations. This keeps the API and default binary min/max size policy unified.

## Testing

- `make all`
- aggregate coverage: 95.4%

Closes #366.

Reader hardening for malformed logical bounds is tracked separately in #370.