### PR TITLE
fix(reader): ignore invalid min-max bounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,8 @@ The maximum length applies only to these column types:
 
 The maximum length does not apply to any other logical or converted type, including annotated `FIXED_LEN_BYTE_ARRAY`, `ENUM`, `JSON`, `BSON`, `UUID`, `DECIMAL`, `FLOAT16`, `INTERVAL`, `GEOMETRY`, and `GEOGRAPHY`. Compact Parquet bounds must remain valid values of their logical type, which arbitrary prefix truncation cannot guarantee for those annotations.
 
+When reading files from non-conforming writers, invalid footer minimum and maximum bounds are independently treated as absent. A column index containing an invalid bound is ignored in full so malformed metadata cannot be used for page pruning. Bounds with unsupported logical ordering or validation, including `GEOMETRY` and `GEOGRAPHY`, are also treated as absent. Compact bounds for unannotated `BYTE_ARRAY` and `FIXED_LEN_BYTE_ARRAY` columns remain valid raw byte bounds.
+
 ## Compression Support
 
 | Compression | Supported | Default Level | Library |

--- a/reader/index.go
+++ b/reader/index.go
@@ -10,18 +10,20 @@ import (
 
 	"github.com/hangxie/parquet-go/v3/internal/encryption"
 	"github.com/hangxie/parquet-go/v3/parquet"
+	"github.com/hangxie/parquet-go/v3/schema"
 	"github.com/hangxie/parquet-go/v3/source"
 )
 
 // ReadColumnIndex reads the column index for a row-group column. It returns nil
-// when the column chunk does not have a column index.
+// when the column chunk does not have a valid column index.
 //
 // Deprecated: use ReadColumnIndexWithContext.
 func (pr *ParquetReader) ReadColumnIndex(rowGroupIndex, columnIndex int) (*parquet.ColumnIndex, error) {
 	return pr.ReadColumnIndexWithContext(pr.defaultContext(), rowGroupIndex, columnIndex)
 }
 
-// ReadColumnIndexWithContext reads a column index using ctx.
+// ReadColumnIndexWithContext reads a column index using ctx. It returns nil when
+// the column chunk does not have an index or any non-null page has invalid bounds.
 func (pr *ParquetReader) ReadColumnIndexWithContext(ctx context.Context, rowGroupIndex, columnIndex int) (*parquet.ColumnIndex, error) {
 	if err := pr.setContext(ctx); err != nil {
 		return nil, err
@@ -42,7 +44,41 @@ func (pr *ParquetReader) ReadColumnIndexWithContext(ctx context.Context, rowGrou
 	if err := readCompactThrift(ctx, buf, index); err != nil {
 		return nil, fmt.Errorf("read column index: %w", err)
 	}
+	if schemaElement := pr.indexSchemaElement(column); schemaElement != nil && !validColumnIndexBounds(schemaElement, index) {
+		return nil, nil
+	}
 	return index, nil
+}
+
+func (pr *ParquetReader) indexSchemaElement(column *parquet.ColumnChunk) *parquet.SchemaElement {
+	if pr.SchemaHandler == nil || column == nil || column.MetaData == nil {
+		return nil
+	}
+	path := columnPathToInPath(pr.SchemaHandler, column.MetaData.GetPathInSchema(), pr.caseInsensitive)
+	index, ok := pr.SchemaHandler.MapIndex[path]
+	if !ok || index < 0 || int(index) >= len(pr.SchemaHandler.SchemaElements) {
+		return nil
+	}
+	return pr.SchemaHandler.SchemaElements[index]
+}
+
+func validColumnIndexBounds(schemaElement *parquet.SchemaElement, index *parquet.ColumnIndex) bool {
+	if index == nil || len(index.NullPages) != len(index.MinValues) || len(index.NullPages) != len(index.MaxValues) {
+		return false
+	}
+	stats := parquet.Statistics{}
+	for i, nullPage := range index.NullPages {
+		if nullPage {
+			continue
+		}
+		stats.MinValue = index.MinValues[i]
+		stats.MaxValue = index.MaxValues[i]
+		min, max, err := schema.DecodeStatisticsMinMax(schemaElement, &stats)
+		if err != nil || min == nil || max == nil {
+			return false
+		}
+	}
+	return true
 }
 
 // ReadOffsetIndex reads the offset index for a row-group column. It returns nil

--- a/reader/index_test.go
+++ b/reader/index_test.go
@@ -6,8 +6,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/hangxie/parquet-go/v3/common"
 	"github.com/hangxie/parquet-go/v3/internal/encryption"
 	"github.com/hangxie/parquet-go/v3/parquet"
+	"github.com/hangxie/parquet-go/v3/schema"
 	"github.com/hangxie/parquet-go/v3/source"
 	"github.com/hangxie/parquet-go/v3/source/buffer"
 )
@@ -41,6 +43,123 @@ func TestReadColumnAndOffsetIndex(t *testing.T) {
 	gotOffsetIndex, err := pr.ReadOffsetIndex(0, 0)
 	require.NoError(t, err)
 	require.Equal(t, offsetIndex, gotOffsetIndex)
+}
+
+func TestReadColumnIndexInvalidBounds(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		element   *parquet.SchemaElement
+		min       []byte
+		max       []byte
+		wantIndex bool
+	}{
+		{
+			name:      "compact raw fixed bounds",
+			element:   &parquet.SchemaElement{Name: "leaf", Type: common.ToPtr(parquet.Type_FIXED_LEN_BYTE_ARRAY), TypeLength: common.ToPtr(int32(4))},
+			min:       []byte{0x01},
+			max:       []byte{0xfe, 0xff},
+			wantIndex: true,
+		},
+		{
+			name:      "raw byte array empty minimum",
+			element:   &parquet.SchemaElement{Name: "leaf", Type: common.ToPtr(parquet.Type_BYTE_ARRAY)},
+			min:       []byte{},
+			max:       []byte("zebra"),
+			wantIndex: true,
+		},
+		{
+			name:      "string empty minimum and maximum",
+			element:   &parquet.SchemaElement{Name: "leaf", Type: common.ToPtr(parquet.Type_BYTE_ARRAY), LogicalType: &parquet.LogicalType{STRING: parquet.NewStringType()}},
+			min:       []byte{},
+			max:       []byte{},
+			wantIndex: true,
+		},
+		{
+			name:    "invalid UTF8 minimum",
+			element: &parquet.SchemaElement{Name: "leaf", Type: common.ToPtr(parquet.Type_BYTE_ARRAY), LogicalType: &parquet.LogicalType{STRING: parquet.NewStringType()}},
+			min:     []byte{0xff},
+			max:     []byte("zebra"),
+		},
+		{
+			name:    "invalid JSON maximum",
+			element: &parquet.SchemaElement{Name: "leaf", Type: common.ToPtr(parquet.Type_BYTE_ARRAY), LogicalType: &parquet.LogicalType{JSON: parquet.NewJsonType()}},
+			min:     []byte(`{"a":1}`),
+			max:     []byte(`{"z":`),
+		},
+		{
+			name:    "invalid BSON minimum",
+			element: &parquet.SchemaElement{Name: "leaf", Type: common.ToPtr(parquet.Type_BYTE_ARRAY), LogicalType: &parquet.LogicalType{BSON: parquet.NewBsonType()}},
+			min:     []byte{5, 0, 0},
+			max:     []byte{5, 0, 0, 0, 0},
+		},
+		{
+			name:    "invalid UUID minimum",
+			element: &parquet.SchemaElement{Name: "leaf", Type: common.ToPtr(parquet.Type_FIXED_LEN_BYTE_ARRAY), TypeLength: common.ToPtr(int32(16)), LogicalType: &parquet.LogicalType{UUID: parquet.NewUUIDType()}},
+			min:     make([]byte, 15),
+			max:     make([]byte, 16),
+		},
+		{
+			name: "invalid DECIMAL minimum",
+			element: &parquet.SchemaElement{
+				Name:          "leaf",
+				Type:          common.ToPtr(parquet.Type_FIXED_LEN_BYTE_ARRAY),
+				TypeLength:    common.ToPtr(int32(4)),
+				ConvertedType: common.ToPtr(parquet.ConvertedType_DECIMAL),
+			},
+			min: []byte{1, 2, 3},
+			max: []byte{1, 2, 3, 4},
+		},
+		{
+			name:    "invalid FLOAT16 maximum",
+			element: &parquet.SchemaElement{Name: "leaf", Type: common.ToPtr(parquet.Type_FIXED_LEN_BYTE_ARRAY), TypeLength: common.ToPtr(int32(2)), LogicalType: &parquet.LogicalType{FLOAT16: parquet.NewFloat16Type()}},
+			min:     []byte{0, 0},
+			max:     []byte{0},
+		},
+		{
+			name:    "unsupported GEOMETRY bounds",
+			element: &parquet.SchemaElement{Name: "leaf", Type: common.ToPtr(parquet.Type_BYTE_ARRAY), LogicalType: &parquet.LogicalType{GEOMETRY: parquet.NewGeometryType()}},
+			min:     []byte{1, 2},
+			max:     []byte{3, 4},
+		},
+		{
+			name:    "unsupported GEOGRAPHY bounds",
+			element: &parquet.SchemaElement{Name: "leaf", Type: common.ToPtr(parquet.Type_BYTE_ARRAY), LogicalType: &parquet.LogicalType{GEOGRAPHY: parquet.NewGeographyType()}},
+			min:     []byte{1, 2},
+			max:     []byte{3, 4},
+		},
+		{
+			name:    "unsupported unknown logical bounds",
+			element: &parquet.SchemaElement{Name: "leaf", Type: common.ToPtr(parquet.Type_BYTE_ARRAY), LogicalType: parquet.NewLogicalType()},
+			min:     []byte("a"),
+			max:     []byte("z"),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			columnIndex := &parquet.ColumnIndex{
+				NullPages:     []bool{false},
+				MinValues:     [][]byte{tc.min},
+				MaxValues:     [][]byte{tc.max},
+				BoundaryOrder: parquet.BoundaryOrder_UNORDERED,
+			}
+			buf := serializeThrift(t, columnIndex)
+			pr := indexTestReader(buf, false, nil, nil, int32(len(buf)), 0)
+			root := &parquet.SchemaElement{Name: "root", NumChildren: common.ToPtr(int32(1))}
+			pr.SchemaHandler = schema.NewSchemaHandlerFromSchemaList([]*parquet.SchemaElement{root, tc.element})
+			pr.Footer.RowGroups[0].Columns[0].MetaData = &parquet.ColumnMetaData{PathInSchema: []string{"leaf"}}
+
+			got, err := pr.ReadColumnIndex(0, 0)
+			require.NoError(t, err)
+			if tc.wantIndex {
+				require.Equal(t, columnIndex, got)
+			} else {
+				require.Nil(t, got)
+			}
+		})
+	}
 }
 
 func TestReadEncryptedColumnAndOffsetIndex(t *testing.T) {

--- a/schema/statistics.go
+++ b/schema/statistics.go
@@ -2,7 +2,11 @@ package schema
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
+	"unicode/utf8"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
 
 	"github.com/hangxie/parquet-go/v3/internal/encoding"
 	"github.com/hangxie/parquet-go/v3/parquet"
@@ -11,7 +15,8 @@ import (
 // DecodeStatisticsMinMax decodes the plain-encoded MinValue and MaxValue bytes
 // from a parquet Statistics object into typed Go values. The physical type is
 // taken from se. Returns (nil, nil, nil) when statistics or schema element is
-// absent, or when MinValue and MaxValue are both empty.
+// absent, when MinValue and MaxValue are both absent, or for each bound that is
+// not a valid physical or logical value of the column.
 //
 // The returned values follow the same type mapping as parquet-go's reader:
 //
@@ -27,26 +32,24 @@ func DecodeStatisticsMinMax(se *parquet.SchemaElement, stats *parquet.Statistics
 	if se == nil || se.Type == nil || stats == nil {
 		return nil, nil, nil
 	}
-	if len(stats.MinValue) == 0 && len(stats.MaxValue) == 0 {
+	if stats.MinValue == nil && stats.MaxValue == nil {
 		return nil, nil, nil
 	}
 
 	pT := *se.Type
 	decode := func(data []byte) (any, error) {
-		if len(data) == 0 {
+		if data == nil {
+			return nil, nil
+		}
+		if !validStatisticsValue(se, data) {
 			return nil, nil
 		}
 		// BYTE_ARRAY statistics are stored without the 4-byte length prefix
 		// that WritePlain normally prepends.
-		if pT == parquet.Type_BYTE_ARRAY {
+		if pT == parquet.Type_BYTE_ARRAY || pT == parquet.Type_FIXED_LEN_BYTE_ARRAY {
 			return string(data), nil
 		}
-		// For FIXED_LEN_BYTE_ARRAY, bitWidth carries the element length.
-		bitWidth := uint64(0)
-		if pT == parquet.Type_FIXED_LEN_BYTE_ARRAY {
-			bitWidth = uint64(se.GetTypeLength())
-		}
-		vals, err := encoding.ReadPlain(bytes.NewReader(data), pT, 1, bitWidth)
+		vals, err := encoding.ReadPlain(bytes.NewReader(data), pT, 1, 0)
 		if err != nil {
 			return nil, fmt.Errorf("decode statistic value: %w", err)
 		}
@@ -65,4 +68,90 @@ func DecodeStatisticsMinMax(se *parquet.SchemaElement, stats *parquet.Statistics
 		return nil, nil, fmt.Errorf("decode max value: %w", err)
 	}
 	return min, max, nil
+}
+
+func validStatisticsValue(se *parquet.SchemaElement, data []byte) bool {
+	if !validPhysicalStatisticsValue(se, data) {
+		return false
+	}
+	if se.LogicalType != nil && !validLogicalStatisticsValue(se.LogicalType, data) {
+		return false
+	}
+	return se.ConvertedType == nil || validConvertedStatisticsValue(*se.ConvertedType, data)
+}
+
+func validPhysicalStatisticsValue(se *parquet.SchemaElement, data []byte) bool {
+	switch se.GetType() {
+	case parquet.Type_BOOLEAN:
+		return len(data) == 1
+	case parquet.Type_INT32, parquet.Type_FLOAT:
+		return len(data) == 4
+	case parquet.Type_INT64, parquet.Type_DOUBLE:
+		return len(data) == 8
+	case parquet.Type_INT96:
+		return len(data) == 12
+	case parquet.Type_BYTE_ARRAY:
+		return true
+	case parquet.Type_FIXED_LEN_BYTE_ARRAY:
+		length := int(se.GetTypeLength())
+		if length <= 0 || len(data) > length {
+			return false
+		}
+		// Only unannotated fixed-width byte arrays may use shortened raw bounds.
+		if (se.LogicalType != nil || se.ConvertedType != nil) && len(data) != length {
+			return false
+		}
+		return true
+	default:
+		return false
+	}
+}
+
+func validLogicalStatisticsValue(logicalType *parquet.LogicalType, data []byte) bool {
+	if logicalType.CountSetFieldsLogicalType() != 1 {
+		return false
+	}
+	switch {
+	case logicalType.IsSetSTRING(), logicalType.IsSetENUM():
+		return utf8.Valid(data)
+	case logicalType.IsSetJSON():
+		return json.Valid(data)
+	case logicalType.IsSetBSON():
+		return bson.Raw(data).Validate() == nil
+	case logicalType.IsSetUUID():
+		return len(data) == 16
+	case logicalType.IsSetFLOAT16():
+		return len(data) == 2
+	case logicalType.IsSetDECIMAL():
+		return len(data) > 0
+	case logicalType.IsSetINTEGER(), logicalType.IsSetDATE(), logicalType.IsSetTIME(), logicalType.IsSetTIMESTAMP():
+		// Physical validation is sufficient for these scalar annotations.
+		return true
+	default:
+		return false
+	}
+}
+
+func validConvertedStatisticsValue(convertedType parquet.ConvertedType, data []byte) bool {
+	switch convertedType {
+	case parquet.ConvertedType_UTF8, parquet.ConvertedType_ENUM:
+		return utf8.Valid(data)
+	case parquet.ConvertedType_JSON:
+		return json.Valid(data)
+	case parquet.ConvertedType_BSON:
+		return bson.Raw(data).Validate() == nil
+	case parquet.ConvertedType_DECIMAL:
+		return len(data) > 0
+	case parquet.ConvertedType_DATE,
+		parquet.ConvertedType_TIME_MILLIS, parquet.ConvertedType_TIME_MICROS,
+		parquet.ConvertedType_TIMESTAMP_MILLIS, parquet.ConvertedType_TIMESTAMP_MICROS,
+		parquet.ConvertedType_UINT_8, parquet.ConvertedType_UINT_16,
+		parquet.ConvertedType_UINT_32, parquet.ConvertedType_UINT_64,
+		parquet.ConvertedType_INT_8, parquet.ConvertedType_INT_16,
+		parquet.ConvertedType_INT_32, parquet.ConvertedType_INT_64:
+		// Physical validation is sufficient for these scalar annotations.
+		return true
+	default:
+		return false
+	}
 }

--- a/schema/statistics_test.go
+++ b/schema/statistics_test.go
@@ -12,6 +12,9 @@ import (
 
 func typePtr(t parquet.Type) *parquet.Type { return &t }
 func int32Ptr(v int32) *int32              { return &v }
+func convertedTypePtr(t parquet.ConvertedType) *parquet.ConvertedType {
+	return &t
+}
 
 func int32Bytes(v int32) []byte {
 	b := make([]byte, 4)
@@ -75,6 +78,13 @@ func TestDecodeStatisticsMinMax(t *testing.T) {
 			wantMax: nil,
 		},
 		{
+			name:    "absent minimum",
+			se:      &parquet.SchemaElement{Type: typePtr(parquet.Type_INT32)},
+			stats:   &parquet.Statistics{MinValue: nil, MaxValue: int32Bytes(9)},
+			wantMin: nil,
+			wantMax: int32(9),
+		},
+		{
 			name:    "INT32",
 			se:      &parquet.SchemaElement{Type: typePtr(parquet.Type_INT32)},
 			stats:   &parquet.Statistics{MinValue: int32Bytes(-5), MaxValue: int32Bytes(42)},
@@ -113,6 +123,29 @@ func TestDecodeStatisticsMinMax(t *testing.T) {
 			wantMax: "zebra",
 		},
 		{
+			name: "BYTE_ARRAY empty minimum",
+			se:   &parquet.SchemaElement{Type: typePtr(parquet.Type_BYTE_ARRAY)},
+			stats: &parquet.Statistics{
+				MinValue: []byte{},
+				MaxValue: []byte("zebra"),
+			},
+			wantMin: "",
+			wantMax: "zebra",
+		},
+		{
+			name: "STRING empty minimum and maximum",
+			se: &parquet.SchemaElement{
+				Type:        typePtr(parquet.Type_BYTE_ARRAY),
+				LogicalType: &parquet.LogicalType{STRING: parquet.NewStringType()},
+			},
+			stats: &parquet.Statistics{
+				MinValue: []byte{},
+				MaxValue: []byte{},
+			},
+			wantMin: "",
+			wantMax: "",
+		},
+		{
 			name: "FIXED_LEN_BYTE_ARRAY",
 			se:   &parquet.SchemaElement{Type: typePtr(parquet.Type_FIXED_LEN_BYTE_ARRAY), TypeLength: int32Ptr(4)},
 			stats: &parquet.Statistics{
@@ -141,6 +174,229 @@ func TestDecodeStatisticsMinMax(t *testing.T) {
 			},
 			wantMin: string([]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}),
 			wantMax: string([]byte{1, 0, 0, 0, 0, 0, 0, 0, 100, 35, 0, 0}),
+		},
+		{
+			name:    "invalid physical minimum",
+			se:      &parquet.SchemaElement{Type: typePtr(parquet.Type_INT32)},
+			stats:   &parquet.Statistics{MinValue: []byte{1, 2, 3}, MaxValue: int32Bytes(9)},
+			wantMin: nil,
+			wantMax: int32(9),
+		},
+		{
+			name:    "invalid physical maximum",
+			se:      &parquet.SchemaElement{Type: typePtr(parquet.Type_DOUBLE)},
+			stats:   &parquet.Statistics{MinValue: float64Bytes(1.5), MaxValue: []byte{1, 2, 3}},
+			wantMin: float64(1.5),
+			wantMax: nil,
+		},
+		{
+			name: "compact unannotated BYTE_ARRAY",
+			se:   &parquet.SchemaElement{Type: typePtr(parquet.Type_BYTE_ARRAY)},
+			stats: &parquet.Statistics{
+				MinValue: []byte{0xff},
+				MaxValue: []byte{0xff, 0xff, 0x01},
+			},
+			wantMin: "\xff",
+			wantMax: "\xff\xff\x01",
+		},
+		{
+			name: "compact unannotated FIXED_LEN_BYTE_ARRAY",
+			se:   &parquet.SchemaElement{Type: typePtr(parquet.Type_FIXED_LEN_BYTE_ARRAY), TypeLength: int32Ptr(4)},
+			stats: &parquet.Statistics{
+				MinValue: []byte{0x01},
+				MaxValue: []byte{0xfe, 0xff},
+			},
+			wantMin: "\x01",
+			wantMax: "\xfe\xff",
+		},
+		{
+			name:    "invalid oversized FIXED_LEN_BYTE_ARRAY minimum",
+			se:      &parquet.SchemaElement{Type: typePtr(parquet.Type_FIXED_LEN_BYTE_ARRAY), TypeLength: int32Ptr(4)},
+			stats:   &parquet.Statistics{MinValue: make([]byte, 5), MaxValue: make([]byte, 4)},
+			wantMin: nil,
+			wantMax: string(make([]byte, 4)),
+		},
+		{
+			name:    "unknown physical type",
+			se:      &parquet.SchemaElement{Type: typePtr(parquet.Type(99))},
+			stats:   &parquet.Statistics{MinValue: []byte{1}, MaxValue: []byte{2}},
+			wantMin: nil,
+			wantMax: nil,
+		},
+		{
+			name: "invalid UTF8 minimum",
+			se: &parquet.SchemaElement{
+				Type:          typePtr(parquet.Type_BYTE_ARRAY),
+				ConvertedType: convertedTypePtr(parquet.ConvertedType_UTF8),
+			},
+			stats:   &parquet.Statistics{MinValue: []byte{0xff}, MaxValue: []byte("zebra")},
+			wantMin: nil,
+			wantMax: "zebra",
+		},
+		{
+			name: "invalid JSON maximum",
+			se: &parquet.SchemaElement{
+				Type:        typePtr(parquet.Type_BYTE_ARRAY),
+				LogicalType: &parquet.LogicalType{JSON: parquet.NewJsonType()},
+			},
+			stats:   &parquet.Statistics{MinValue: []byte(`{"a":1}`), MaxValue: []byte(`{"z":`)},
+			wantMin: `{"a":1}`,
+			wantMax: nil,
+		},
+		{
+			name: "invalid BSON minimum",
+			se: &parquet.SchemaElement{
+				Type:        typePtr(parquet.Type_BYTE_ARRAY),
+				LogicalType: &parquet.LogicalType{BSON: parquet.NewBsonType()},
+			},
+			stats:   &parquet.Statistics{MinValue: []byte{5, 0, 0}, MaxValue: []byte{5, 0, 0, 0, 0}},
+			wantMin: nil,
+			wantMax: string([]byte{5, 0, 0, 0, 0}),
+		},
+		{
+			name: "invalid UUID maximum",
+			se: &parquet.SchemaElement{
+				Type:          typePtr(parquet.Type_FIXED_LEN_BYTE_ARRAY),
+				TypeLength:    int32Ptr(16),
+				LogicalType:   &parquet.LogicalType{UUID: parquet.NewUUIDType()},
+				ConvertedType: nil,
+			},
+			stats:   &parquet.Statistics{MinValue: make([]byte, 16), MaxValue: make([]byte, 15)},
+			wantMin: string(make([]byte, 16)),
+			wantMax: nil,
+		},
+		{
+			name: "invalid DECIMAL minimum",
+			se: &parquet.SchemaElement{
+				Type:          typePtr(parquet.Type_FIXED_LEN_BYTE_ARRAY),
+				TypeLength:    int32Ptr(4),
+				ConvertedType: convertedTypePtr(parquet.ConvertedType_DECIMAL),
+			},
+			stats:   &parquet.Statistics{MinValue: []byte{1, 2, 3}, MaxValue: []byte{1, 2, 3, 4}},
+			wantMin: nil,
+			wantMax: string([]byte{1, 2, 3, 4}),
+		},
+		{
+			name: "invalid empty binary DECIMAL minimum",
+			se: &parquet.SchemaElement{
+				Type:          typePtr(parquet.Type_BYTE_ARRAY),
+				ConvertedType: convertedTypePtr(parquet.ConvertedType_DECIMAL),
+			},
+			stats:   &parquet.Statistics{MinValue: []byte{}, MaxValue: []byte{0}},
+			wantMin: nil,
+			wantMax: "\x00",
+		},
+		{
+			name: "logical DECIMAL",
+			se: &parquet.SchemaElement{
+				Type:        typePtr(parquet.Type_BYTE_ARRAY),
+				LogicalType: &parquet.LogicalType{DECIMAL: &parquet.DecimalType{Precision: 4, Scale: 2}},
+			},
+			stats:   &parquet.Statistics{MinValue: []byte{0}, MaxValue: []byte{1}},
+			wantMin: "\x00",
+			wantMax: "\x01",
+		},
+		{
+			name: "invalid FLOAT16 maximum",
+			se: &parquet.SchemaElement{
+				Type:        typePtr(parquet.Type_FIXED_LEN_BYTE_ARRAY),
+				TypeLength:  int32Ptr(2),
+				LogicalType: &parquet.LogicalType{FLOAT16: parquet.NewFloat16Type()},
+			},
+			stats:   &parquet.Statistics{MinValue: []byte{0, 0}, MaxValue: []byte{0}},
+			wantMin: string([]byte{0, 0}),
+			wantMax: nil,
+		},
+		{
+			name: "unsupported GEOMETRY bounds",
+			se: &parquet.SchemaElement{
+				Type:        typePtr(parquet.Type_BYTE_ARRAY),
+				LogicalType: &parquet.LogicalType{GEOMETRY: parquet.NewGeometryType()},
+			},
+			stats:   &parquet.Statistics{MinValue: []byte{1, 2}, MaxValue: []byte{3, 4}},
+			wantMin: nil,
+			wantMax: nil,
+		},
+		{
+			name: "unsupported GEOGRAPHY bounds",
+			se: &parquet.SchemaElement{
+				Type:        typePtr(parquet.Type_BYTE_ARRAY),
+				LogicalType: &parquet.LogicalType{GEOGRAPHY: parquet.NewGeographyType()},
+			},
+			stats:   &parquet.Statistics{MinValue: []byte{1, 2}, MaxValue: []byte{3, 4}},
+			wantMin: nil,
+			wantMax: nil,
+		},
+		{
+			name: "unsupported unknown logical bounds",
+			se: &parquet.SchemaElement{
+				Type:        typePtr(parquet.Type_BYTE_ARRAY),
+				LogicalType: parquet.NewLogicalType(),
+			},
+			stats:   &parquet.Statistics{MinValue: []byte("a"), MaxValue: []byte("z")},
+			wantMin: nil,
+			wantMax: nil,
+		},
+		{
+			name: "unsupported INTERVAL bounds",
+			se: &parquet.SchemaElement{
+				Type:          typePtr(parquet.Type_FIXED_LEN_BYTE_ARRAY),
+				TypeLength:    int32Ptr(12),
+				ConvertedType: convertedTypePtr(parquet.ConvertedType_INTERVAL),
+			},
+			stats:   &parquet.Statistics{MinValue: make([]byte, 12), MaxValue: make([]byte, 12)},
+			wantMin: nil,
+			wantMax: nil,
+		},
+		{
+			name: "DATE uses physical validation",
+			se: &parquet.SchemaElement{
+				Type:        typePtr(parquet.Type_INT32),
+				LogicalType: &parquet.LogicalType{DATE: parquet.NewDateType()},
+			},
+			stats:   &parquet.Statistics{MinValue: int32Bytes(1), MaxValue: int32Bytes(9)},
+			wantMin: int32(1),
+			wantMax: int32(9),
+		},
+		{
+			name: "INTEGER uses physical validation",
+			se: &parquet.SchemaElement{
+				Type:        typePtr(parquet.Type_INT32),
+				LogicalType: &parquet.LogicalType{INTEGER: &parquet.IntType{BitWidth: 32, IsSigned: true}},
+			},
+			stats:   &parquet.Statistics{MinValue: int32Bytes(1), MaxValue: int32Bytes(9)},
+			wantMin: int32(1),
+			wantMax: int32(9),
+		},
+		{
+			name: "converted DATE uses physical validation",
+			se: &parquet.SchemaElement{
+				Type:          typePtr(parquet.Type_INT32),
+				ConvertedType: convertedTypePtr(parquet.ConvertedType_DATE),
+			},
+			stats:   &parquet.Statistics{MinValue: int32Bytes(1), MaxValue: int32Bytes(9)},
+			wantMin: int32(1),
+			wantMax: int32(9),
+		},
+		{
+			name: "converted JSON",
+			se: &parquet.SchemaElement{
+				Type:          typePtr(parquet.Type_BYTE_ARRAY),
+				ConvertedType: convertedTypePtr(parquet.ConvertedType_JSON),
+			},
+			stats:   &parquet.Statistics{MinValue: []byte(`{"a":1}`), MaxValue: []byte(`{"z":9}`)},
+			wantMin: `{"a":1}`,
+			wantMax: `{"z":9}`,
+		},
+		{
+			name: "converted BSON",
+			se: &parquet.SchemaElement{
+				Type:          typePtr(parquet.Type_BYTE_ARRAY),
+				ConvertedType: convertedTypePtr(parquet.ConvertedType_BSON),
+			},
+			stats:   &parquet.Statistics{MinValue: []byte{5, 0, 0, 0, 0}, MaxValue: []byte{5, 0, 0, 0, 0}},
+			wantMin: string([]byte{5, 0, 0, 0, 0}),
+			wantMax: string([]byte{5, 0, 0, 0, 0}),
 		},
 	}
 


### PR DESCRIPTION
## Summary

- validate footer statistics and column-index bounds against physical and logical types before using them
- treat independently invalid footer bounds as absent and ignore a complete column index when a non-null page has invalid bounds
- fail closed for unsupported logical and converted annotations, including GEOMETRY and GEOGRAPHY
- preserve compact unannotated binary bounds and valid empty `BYTE_ARRAY`/STRING bounds
- cover malformed physical values, UTF-8, JSON, BSON, UUID, DECIMAL, FLOAT16, unsupported geospatial, and unknown logical metadata

## Validation

- `make all`
- branch coverage: 10,345 / 10,843 statements (95.407175%)
- `origin/main` coverage: 10,291 / 10,787 statements (95.401873%)

Closes #370