### PR TITLE
fix(writer): preserve full binary bounds by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ Encoding notes:
 
 ### Binary statistics bound truncation
 
-Binary footer statistics and column-index bounds target a 64-byte maximum by default; tune it with `writer.WithBinaryMinMaxTruncateLength`. Unlike parquet-java, which leaves row-group statistics effectively untruncated by default, parquet-go intentionally applies the same default truncation policy to both footer statistics and column-index bounds.
+Binary footer statistics and column-index bounds are not truncated by default, preserving the writer's historical behavior. Enable truncation and set its target byte length with `writer.WithBinaryMinMaxTruncateLength`.
 
 The maximum length applies only to these column types:
 

--- a/writer/pages_test.go
+++ b/writer/pages_test.go
@@ -205,29 +205,48 @@ func TestColumnIndex(t *testing.T) {
 		require.Equal(t, [][]byte{[]byte(`{"z":9}`)}, index.MaxValues)
 	})
 
-	t.Run("default_binary_bound_length", func(t *testing.T) {
-		type Entry struct {
+	t.Run("default_binary_bounds_are_not_truncated", func(t *testing.T) {
+		type rawEntry struct {
+			Value string `parquet:"name=value, type=BYTE_ARRAY"`
+		}
+		type stringEntry struct {
 			Value string `parquet:"name=value, type=BYTE_ARRAY, convertedtype=UTF8"`
 		}
 
-		pw, buf, err := createTestParquetWriter(new(Entry), WithNP(1))
-		require.NoError(t, err)
-		require.NoError(t, pw.Write(Entry{Value: strings.Repeat("a", DefaultBinaryMinMaxTruncateLength+6)}))
-		require.NoError(t, pw.WriteStop())
+		value := strings.Repeat("a", 70)
+		tests := []struct {
+			name string
+			obj  any
+			row  any
+		}{
+			{name: "raw", obj: new(rawEntry), row: rawEntry{Value: value}},
+			{name: "utf8", obj: new(stringEntry), row: stringEntry{Value: value}},
+		}
 
-		pf := buffer.NewBufferReaderFromBytesNoAlloc(buf.Bytes())
-		defer func() { require.NoError(t, pf.Close()) }()
-		pr, err := reader.NewParquetReader(pf, nil, reader.WithNP(1)) //nolint:staticcheck
-		require.NoError(t, err)
-		require.NoError(t, pr.ReadFooter()) //nolint:staticcheck
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				pw, buf, err := createTestParquetWriter(tt.obj, WithNP(1))
+				require.NoError(t, err)
+				require.NoError(t, pw.Write(tt.row))
+				require.NoError(t, pw.WriteStop())
 
-		chunk := pr.Footer.RowGroups[0].Columns[0]
-		require.Len(t, chunk.MetaData.Statistics.MinValue, DefaultBinaryMinMaxTruncateLength)
-		require.Len(t, chunk.MetaData.Statistics.MaxValue, DefaultBinaryMinMaxTruncateLength)
-		index, err := readColumnIndex(pr.PFile, *chunk.ColumnIndexOffset)
-		require.NoError(t, err)
-		require.Len(t, index.MinValues[0], DefaultBinaryMinMaxTruncateLength)
-		require.Len(t, index.MaxValues[0], DefaultBinaryMinMaxTruncateLength)
+				pf := buffer.NewBufferReaderFromBytesNoAlloc(buf.Bytes())
+				defer func() { require.NoError(t, pf.Close()) }()
+				pr, err := reader.NewParquetReader(pf, nil, reader.WithNP(1)) //nolint:staticcheck
+				require.NoError(t, err)
+				require.NoError(t, pr.ReadFooter()) //nolint:staticcheck
+
+				chunk := pr.Footer.RowGroups[0].Columns[0]
+				require.Equal(t, []byte(value), chunk.MetaData.Statistics.MinValue)
+				require.Equal(t, []byte(value), chunk.MetaData.Statistics.MaxValue)
+				require.True(t, chunk.MetaData.Statistics.GetIsMinValueExact())
+				require.True(t, chunk.MetaData.Statistics.GetIsMaxValueExact())
+				index, err := readColumnIndex(pr.PFile, *chunk.ColumnIndexOffset)
+				require.NoError(t, err)
+				require.Equal(t, [][]byte{[]byte(value)}, index.MinValues)
+				require.Equal(t, [][]byte{[]byte(value)}, index.MaxValues)
+			})
+		}
 	})
 
 	t.Run("truncated_binary_bounds", func(t *testing.T) {

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -18,13 +18,8 @@ import (
 	"github.com/hangxie/parquet-go/v3/source/writerfile"
 )
 
-const (
-	// DefaultMaxDictionarySize is the default encoded dictionary value-byte limit.
-	DefaultMaxDictionarySize = 1024 * 1024
-	// DefaultBinaryMinMaxTruncateLength is the default byte-length target for binary
-	// footer statistics and column-index bounds.
-	DefaultBinaryMinMaxTruncateLength = 64
-)
+// DefaultMaxDictionarySize is the default encoded dictionary value-byte limit.
+const DefaultMaxDictionarySize = 1024 * 1024
 
 // columnCompressorKey uniquely identifies a (codec, level) combination for sharing compressor instances.
 type columnCompressorKey struct {
@@ -67,11 +62,14 @@ func WithMaxDictionarySize(size int64) WriterOption {
 
 // WithBinaryMinMaxTruncateLength sets the target byte limit for unannotated
 // BYTE_ARRAY/FIXED_LEN_BYTE_ARRAY and STRING/UTF8 statistics and column-index
-// bounds. Default is 64. STRING/UTF8 bounds may exceed the target when they
-// cannot be shortened to a valid UTF-8 bound. Other annotated types remain
-// untruncated.
+// bounds. By default, bounds are not truncated. STRING/UTF8 bounds may exceed
+// the target when they cannot be shortened to a valid UTF-8 bound. Other
+// annotated types remain untruncated.
 func WithBinaryMinMaxTruncateLength(length int) WriterOption {
-	return writerOptionFunc(func(pw *ParquetWriter) { pw.binaryMinMaxTruncateLength = length })
+	return writerOptionFunc(func(pw *ParquetWriter) {
+		pw.binaryMinMaxTruncateLength = length
+		pw.binaryMinMaxTruncateLengthSet = true
+	})
 }
 
 // WithCompressionCodec sets the compression codec. Default is SNAPPY.
@@ -112,21 +110,22 @@ type ParquetWriter struct {
 	Footer        *parquet.FileMetaData
 	PFile         source.ParquetFileWriter
 
-	np                         int64 // parallel number
-	pageSize                   int64
-	rowGroupSize               int64
-	maxDictionarySize          int64
-	binaryMinMaxTruncateLength int
-	compressionType            parquet.CompressionCodec
-	compressionLevels          map[parquet.CompressionCodec]int
-	compressor                 *compress.Compressor
-	columnCompressors          map[string]*compress.Compressor
-	dataPageVersion            int32 // 1 for DATA_PAGE (default), 2 for DATA_PAGE_V2
-	writeCRC                   bool  // compute and write CRC32 checksums on pages (default false)
-	encryptionConfig           *EncryptionConfig
-	encryptionState            *encryptionState
-	optionErrors               []error
-	offset                     int64
+	np                            int64 // parallel number
+	pageSize                      int64
+	rowGroupSize                  int64
+	maxDictionarySize             int64
+	binaryMinMaxTruncateLength    int
+	binaryMinMaxTruncateLengthSet bool
+	compressionType               parquet.CompressionCodec
+	compressionLevels             map[parquet.CompressionCodec]int
+	compressor                    *compress.Compressor
+	columnCompressors             map[string]*compress.Compressor
+	dataPageVersion               int32 // 1 for DATA_PAGE (default), 2 for DATA_PAGE_V2
+	writeCRC                      bool  // compute and write CRC32 checksums on pages (default false)
+	encryptionConfig              *EncryptionConfig
+	encryptionState               *encryptionState
+	optionErrors                  []error
+	offset                        int64
 
 	objs              []any
 	objsSize          int64
@@ -189,7 +188,8 @@ func (pw *ParquetWriter) initBase(ctx context.Context, pFile source.ParquetFileW
 	pw.pageSize = common.DefaultPageSize         // 8K
 	pw.rowGroupSize = common.DefaultRowGroupSize // 128M
 	pw.maxDictionarySize = DefaultMaxDictionarySize
-	pw.binaryMinMaxTruncateLength = DefaultBinaryMinMaxTruncateLength
+	pw.binaryMinMaxTruncateLength = 0
+	pw.binaryMinMaxTruncateLengthSet = false
 	pw.compressionType = parquet.CompressionCodec_SNAPPY
 	pw.compressionLevels = nil
 	pw.compressor = nil
@@ -238,7 +238,7 @@ func (pw *ParquetWriter) initBase(ctx context.Context, pFile source.ParquetFileW
 	if pw.maxDictionarySize <= 0 {
 		return fmt.Errorf("WithMaxDictionarySize: value must be positive, got %d", pw.maxDictionarySize)
 	}
-	if pw.binaryMinMaxTruncateLength <= 0 {
+	if pw.binaryMinMaxTruncateLengthSet && pw.binaryMinMaxTruncateLength <= 0 {
 		return fmt.Errorf("WithBinaryMinMaxTruncateLength: value must be positive, got %d", pw.binaryMinMaxTruncateLength)
 	}
 	if pw.dataPageVersion != 1 && pw.dataPageVersion != 2 {


### PR DESCRIPTION
## Summary

- preserve complete binary footer statistics and column-index bounds when `WithBinaryMinMaxTruncateLength` is omitted
- keep truncation opt-in while retaining validation for explicitly configured non-positive lengths
- document the backward-compatible default and cover raw and UTF-8 binary bounds

## Testing

- `make all`