### PR TITLE
perf(reader): use offset indexes for row skips

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,8 @@ pw, err := writer.NewParquetWriter(fw, new(MyStruct),
 )
 ```
 
+`ParquetReader.SkipRows` jumps ahead using the file's own positional metadata: it skips whole row groups by their declared row counts and, when a column offset index is present, seeks straight to the target data page instead of decoding every page along the way. Both are taken on trust, the same way the reader already trusts row group row counts everywhere else, so a corrupted file could in theory point a skip at the wrong row. That is really a broken file rather than a reader bug, and parquet-go just does its best with what the file declares: if an offset index is missing or structurally unusable it quietly falls back to a plain sequential skip, which reads the real page boundaries.
+
 ## File Sources
 
 File sources implement separate reader and writer interfaces.

--- a/reader/columnbuffer.go
+++ b/reader/columnbuffer.go
@@ -46,6 +46,11 @@ type ColumnBufferType struct {
 	// past the end (which would report phantom rows) nor across the shared skip-then-read
 	// use of a column buffer.
 	dataTableNumRowsNormalized bool
+	// indexedPagesRemaining counts data pages left to read on a cursor positioned by
+	// the offset index; zero means no such cursor is active. Reaching zero marks the
+	// column chunk as fully consumed even though earlier pages were skipped unread.
+	indexedPagesRemaining    int
+	indexedDictionaryPending bool
 }
 
 // NewColumnBuffer creates a column buffer for the column identified by pathStr.
@@ -197,6 +202,8 @@ func (cbt *ColumnBufferType) NextRowGroup() error {
 	cbt.ThriftReader = thriftReader
 	cbt.ChunkReadValues = 0
 	cbt.DictPage = nil
+	cbt.indexedPagesRemaining = 0
+	cbt.indexedDictionaryPending = false
 	return nil
 }
 
@@ -209,6 +216,7 @@ func (cbt *ColumnBufferType) context() context.Context {
 
 type columnBufferReader struct {
 	buffer    *ColumnBufferType
+	file      source.ParquetFileReader
 	remaining int64
 }
 
@@ -219,7 +227,11 @@ func (r *columnBufferReader) Read(p []byte) (int, error) {
 	if int64(len(p)) > r.remaining {
 		p = p[:r.remaining]
 	}
-	n, err := source.ReadWithContext(r.buffer.context(), r.buffer.PFile, p)
+	file := r.file
+	if file == nil {
+		file = r.buffer.PFile
+	}
+	n, err := source.ReadWithContext(r.buffer.context(), file, p)
 	r.remaining -= int64(n)
 	return n, err
 }
@@ -374,6 +386,9 @@ func (cbt *ColumnBufferType) ReadPage() error {
 		return nil
 	}
 
+	if err := cbt.ensureIndexedDictionary(); err != nil {
+		return fmt.Errorf("load indexed dictionary: %w", err)
+	}
 	page.Decode(cbt.DictPage)
 	if cbt.DataTable == nil {
 		cbt.DataTable = layout.NewTableFromTable(page.DataTable)
@@ -382,6 +397,7 @@ func (cbt *ColumnBufferType) ReadPage() error {
 	cbt.DataTable.Merge(page.DataTable)
 	cbt.ChunkReadValues += numValues
 	cbt.DataTableNumRows += numRows
+	cbt.finishIndexedDataPage()
 	return nil
 }
 

--- a/reader/columnbuffer_offset_index.go
+++ b/reader/columnbuffer_offset_index.go
@@ -1,0 +1,294 @@
+package reader
+
+import (
+	"fmt"
+	"io"
+	"sort"
+
+	"github.com/apache/thrift/lib/go/thrift"
+
+	"github.com/hangxie/parquet-go/v3/internal/layout"
+	"github.com/hangxie/parquet-go/v3/parquet"
+	"github.com/hangxie/parquet-go/v3/source"
+)
+
+// Offset-index skipping trusts the writer-provided FirstRowIndex values to position the
+// cursor: a page's absolute start cannot be confirmed without reading (and counting) the
+// very pages the optimization skips, so there is no cheap way to detect an index whose
+// offsets are self-consistent but shifted. The structural checks below only establish
+// that the index is well formed enough to seek and read safely; a chunk whose data is
+// genuinely unreadable that way falls back to a sequential skip. This matches how the
+// non-indexed reader and other Parquet implementations treat the offset index.
+
+type indexedSkipTarget struct {
+	pageIndex int
+	offset    int64
+	chunkEnd  int64
+	firstRow  int64
+	// pageCount is how many data pages remain from the target page to the end of the
+	// chunk; the cursor reads them in order until this many have been consumed.
+	pageCount int
+}
+
+func (cbt *ColumnBufferType) hasIndexedPageCursor() bool {
+	return cbt.indexedPagesRemaining > 0
+}
+
+func (cbt *ColumnBufferType) skipWithOffsetIndex(num int64) (int64, bool, error) {
+	if cbt.Reader == nil || cbt.ChunkHeader == nil || cbt.ChunkHeader.MetaData == nil ||
+		cbt.ChunkReadValues != 0 || cbt.hasIndexedPageCursor() {
+		return 0, false, nil
+	}
+	rowGroupIndex := cbt.RowGroupIndex - 1
+	if rowGroupIndex < 0 || int(rowGroupIndex) >= len(cbt.Footer.GetRowGroups()) {
+		return 0, false, nil
+	}
+	rowGroup := cbt.Footer.RowGroups[rowGroupIndex]
+	if rowGroup == nil || num >= rowGroup.GetNumRows() {
+		return 0, false, nil
+	}
+
+	index, err := cbt.Reader.readOffsetIndexWithContext(cbt.context(), int(rowGroupIndex), int(cbt.ColumnOrdinal))
+	if err != nil {
+		if ctxErr := cbt.context().Err(); ctxErr != nil {
+			// The caller cancelled or timed out; surface that rather than hiding it.
+			return 0, true, fmt.Errorf("read row group %d column %d: %w", rowGroupIndex, cbt.ColumnOrdinal, err)
+		}
+		// The offset index could not be read or decoded. It is only an optimization
+		// hint, and a failure confined to the index region leaves the data pages
+		// readable, so fall back to sequential page skipping. A genuine I/O fault that
+		// also affects the data pages will resurface there.
+		return 0, false, nil
+	}
+	if index == nil {
+		return 0, false, nil
+	}
+	target, err := validateIndexedSkipTarget(cbt.ChunkHeader.MetaData, index, rowGroup.GetNumRows(), num)
+	if err != nil {
+		// A structurally invalid offset index is an unusable hint; fall back rather
+		// than failing the skip.
+		return 0, false, nil
+	}
+	if target.pageIndex > int(^uint16(0)>>1) && cbt.ChunkHeader.GetCryptoMetadata() != nil {
+		// The encrypted page ordinal is a signed 16-bit value; a chunk with more pages
+		// than that cannot be seeked by ordinal, so skip the optimization.
+		return 0, false, nil
+	}
+
+	withinPage := num - target.firstRow
+	if err := cbt.seekToIndexedPage(target, withinPage > 0); err != nil {
+		return 0, true, fmt.Errorf("seek row group %d column %d to data page %d: %w", rowGroupIndex, cbt.ColumnOrdinal, target.pageIndex, err)
+	}
+	if withinPage == 0 {
+		return num, true, nil
+	}
+	skipped, err := cbt.skipByReadingPages(withinPage)
+	return target.firstRow + skipped, true, err
+}
+
+func validateIndexedSkipTarget(meta *parquet.ColumnMetaData, index *parquet.OffsetIndex, rowCount, targetRow int64) (indexedSkipTarget, error) {
+	if meta == nil {
+		return indexedSkipTarget{}, fmt.Errorf("column metadata is nil")
+	}
+	locations := index.GetPageLocations()
+	if len(locations) == 0 {
+		return indexedSkipTarget{}, fmt.Errorf("offset index has no page locations")
+	}
+	if rowCount <= 0 || targetRow < 0 || targetRow >= rowCount {
+		return indexedSkipTarget{}, fmt.Errorf("target row %d is outside row group with %d rows", targetRow, rowCount)
+	}
+
+	chunkStart, chunkEnd, err := indexedChunkRange(meta)
+	if err != nil {
+		return indexedSkipTarget{}, err
+	}
+	if err := validateIndexedPageLocations(meta, locations, rowCount, chunkStart, chunkEnd); err != nil {
+		return indexedSkipTarget{}, err
+	}
+
+	pageIndex := sort.Search(len(locations), func(i int) bool {
+		return locations[i].GetFirstRowIndex() > targetRow
+	}) - 1
+	location := locations[pageIndex]
+	return indexedSkipTarget{
+		pageIndex: pageIndex,
+		offset:    location.GetOffset(),
+		chunkEnd:  chunkEnd,
+		firstRow:  location.GetFirstRowIndex(),
+		pageCount: len(locations) - pageIndex,
+	}, nil
+}
+
+func indexedChunkRange(meta *parquet.ColumnMetaData) (int64, int64, error) {
+	chunkStart := meta.GetDataPageOffset()
+	if meta.IsSetDictionaryPageOffset() && meta.GetDictionaryPageOffset() < chunkStart {
+		chunkStart = meta.GetDictionaryPageOffset()
+	}
+	chunkSize := meta.GetTotalCompressedSize()
+	if chunkStart < 0 || chunkSize <= 0 || chunkStart > int64(^uint64(0)>>1)-chunkSize {
+		return 0, 0, fmt.Errorf("invalid column chunk range: offset=%d size=%d", chunkStart, chunkSize)
+	}
+	return chunkStart, chunkStart + chunkSize, nil
+}
+
+func validateIndexedPageLocations(meta *parquet.ColumnMetaData, locations []*parquet.PageLocation, rowCount, chunkStart, chunkEnd int64) error {
+	for i, location := range locations {
+		if location == nil {
+			return fmt.Errorf("page location %d is nil", i)
+		}
+	}
+	for i := range locations {
+		if err := validateIndexedPageLocation(meta, locations, i, rowCount, chunkStart, chunkEnd); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateIndexedPageLocation(meta *parquet.ColumnMetaData, locations []*parquet.PageLocation, pageIndex int, rowCount, chunkStart, chunkEnd int64) error {
+	location := locations[pageIndex]
+	if pageIndex == 0 {
+		if location.GetFirstRowIndex() != 0 {
+			return fmt.Errorf("first page starts at row %d, want 0", location.GetFirstRowIndex())
+		}
+		if location.GetOffset() != meta.GetDataPageOffset() {
+			return fmt.Errorf("first page offset %d does not match data page offset %d", location.GetOffset(), meta.GetDataPageOffset())
+		}
+	} else if location.GetFirstRowIndex() <= locations[pageIndex-1].GetFirstRowIndex() {
+		return fmt.Errorf("page %d first row %d is not greater than page %d first row %d", pageIndex, location.GetFirstRowIndex(), pageIndex-1, locations[pageIndex-1].GetFirstRowIndex())
+	}
+	if location.GetFirstRowIndex() < 0 || location.GetFirstRowIndex() >= rowCount {
+		return fmt.Errorf("page %d first row %d is outside row group with %d rows", pageIndex, location.GetFirstRowIndex(), rowCount)
+	}
+	size := int64(location.GetCompressedPageSize())
+	if size <= 0 || location.GetOffset() < meta.GetDataPageOffset() || location.GetOffset() > chunkEnd-size {
+		return fmt.Errorf("page %d has invalid range: offset=%d size=%d chunk=[%d,%d)", pageIndex, location.GetOffset(), size, chunkStart, chunkEnd)
+	}
+	// Listed data pages are read back-to-back from a single stream, so each must abut the
+	// next, exactly as the non-indexed reader consumes a chunk. The final page only has
+	// to fit inside the chunk: like a sequential read, the cursor stops once the chunk's
+	// declared value count is reached, so any trailing bytes (padding accounted for in
+	// TotalCompressedSize) are never touched.
+	pageEndOffset := location.GetOffset() + size
+	if pageIndex+1 < len(locations) && pageEndOffset != locations[pageIndex+1].GetOffset() {
+		return fmt.Errorf("page %d ends at %d, next page starts at %d", pageIndex, pageEndOffset, locations[pageIndex+1].GetOffset())
+	}
+	return nil
+}
+
+func (cbt *ColumnBufferType) seekToIndexedPage(target indexedSkipTarget, loadDictionary bool) error {
+	pageFile, err := source.CloneWithContext(cbt.context(), cbt.PFile)
+	if err != nil {
+		return fmt.Errorf("clone column file: %w", err)
+	}
+	keepFile := false
+	defer func() {
+		if !keepFile {
+			_ = source.CloseWithContext(cbt.context(), pageFile)
+		}
+	}()
+
+	var dictionary *layout.Page
+	if loadDictionary && cbt.ChunkHeader.MetaData.IsSetDictionaryPageOffset() {
+		dictionary, err = cbt.readIndexedDictionary(pageFile)
+		if err != nil {
+			return err
+		}
+	}
+	transport, err := cbt.newIndexedTransport(pageFile, target.offset, target.chunkEnd-target.offset)
+	if err != nil {
+		return err
+	}
+	if cbt.PageReadOptions.Decryptor != nil {
+		cbt.PageReadOptions.Decryptor.PageOrdinal = int16(target.pageIndex)
+	}
+
+	oldFile := cbt.PFile
+	if cbt.ThriftReader != nil {
+		_ = cbt.ThriftReader.Close()
+	}
+	cbt.PFile = pageFile
+	cbt.ThriftReader = transport
+	cbt.DictPage = dictionary
+	cbt.indexedPagesRemaining = target.pageCount
+	cbt.indexedDictionaryPending = dictionary == nil && cbt.ChunkHeader.MetaData.IsSetDictionaryPageOffset()
+	keepFile = true
+	_ = source.CloseWithContext(cbt.context(), oldFile)
+	return nil
+}
+
+func (cbt *ColumnBufferType) readIndexedDictionary(pageFile source.ParquetFileReader) (*layout.Page, error) {
+	dictionaryOffset := cbt.ChunkHeader.MetaData.GetDictionaryPageOffset()
+	dataOffset := cbt.ChunkHeader.MetaData.GetDataPageOffset()
+	if dictionaryOffset < 0 || dictionaryOffset >= dataOffset {
+		return nil, fmt.Errorf("invalid dictionary page offset %d for data page offset %d", dictionaryOffset, dataOffset)
+	}
+	transport, err := cbt.newIndexedTransport(pageFile, dictionaryOffset, dataOffset-dictionaryOffset)
+	if err != nil {
+		return nil, fmt.Errorf("prepare dictionary page: %w", err)
+	}
+	defer func() { _ = transport.Close() }()
+	options := cbt.PageReadOptions
+	if options.Decryptor != nil {
+		decryptor := *options.Decryptor
+		decryptor.PageOrdinal = 0
+		options.Decryptor = &decryptor
+	}
+	page, err := layout.ReadPageRawData(transport, cbt.SchemaHandler, cbt.readMetaData(), &options)
+	if err != nil {
+		return nil, fmt.Errorf("read dictionary page: %w", err)
+	}
+	if page.Header.GetType() != parquet.PageType_DICTIONARY_PAGE {
+		return nil, fmt.Errorf("page at dictionary offset %d has type %v", dictionaryOffset, page.Header.GetType())
+	}
+	if _, _, err := page.GetRLDLFromRawData(cbt.SchemaHandler); err != nil {
+		return nil, fmt.Errorf("read dictionary levels: %w", err)
+	}
+	if err := page.GetValueFromRawData(cbt.SchemaHandler); err != nil {
+		return nil, fmt.Errorf("decode dictionary page: %w", err)
+	}
+	return page, nil
+}
+
+func (cbt *ColumnBufferType) newIndexedTransport(pageFile source.ParquetFileReader, offset, remaining int64) (*thrift.TBufferedTransport, error) {
+	position, err := source.SeekWithContext(cbt.context(), pageFile, offset, io.SeekStart)
+	if err != nil {
+		return nil, fmt.Errorf("seek to offset %d: %w", offset, err)
+	}
+	if position != offset {
+		return nil, fmt.Errorf("seek to offset %d stopped at %d", offset, position)
+	}
+	stream := thrift.NewStreamTransportR(&columnBufferReader{buffer: cbt, file: pageFile, remaining: remaining})
+	return thrift.NewTBufferedTransport(stream, 4096), nil
+}
+
+func (cbt *ColumnBufferType) ensureIndexedDictionary() error {
+	if !cbt.indexedDictionaryPending {
+		return nil
+	}
+	pageFile, err := source.CloneWithContext(cbt.context(), cbt.PFile)
+	if err != nil {
+		return fmt.Errorf("clone column file: %w", err)
+	}
+	defer func() { _ = source.CloseWithContext(cbt.context(), pageFile) }()
+	dictionary, err := cbt.readIndexedDictionary(pageFile)
+	if err != nil {
+		return err
+	}
+	cbt.DictPage = dictionary
+	cbt.indexedDictionaryPending = false
+	return nil
+}
+
+func (cbt *ColumnBufferType) finishIndexedDataPage() {
+	if !cbt.hasIndexedPageCursor() {
+		return
+	}
+	cbt.indexedPagesRemaining--
+	if cbt.indexedPagesRemaining == 0 {
+		// The skipped leading pages never advanced ChunkReadValues, so force it to the
+		// chunk's full value count now that the last indexed page is consumed; otherwise
+		// the chunk would look unfinished and read past its end.
+		cbt.ChunkReadValues = cbt.ChunkHeader.MetaData.GetNumValues()
+	}
+}

--- a/reader/columnbuffer_offset_index_test.go
+++ b/reader/columnbuffer_offset_index_test.go
@@ -1,0 +1,555 @@
+package reader
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/apache/thrift/lib/go/thrift"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hangxie/parquet-go/v3/parquet"
+	"github.com/hangxie/parquet-go/v3/source/buffer"
+	"github.com/hangxie/parquet-go/v3/source/writerfile"
+	"github.com/hangxie/parquet-go/v3/writer"
+)
+
+func TestSkipRows_OffsetIndexRoundTrip(t *testing.T) {
+	t.Run("dictionary page boundary and interior", func(t *testing.T) {
+		type record struct {
+			Name string `parquet:"name=name, type=BYTE_ARRAY, convertedtype=UTF8, encoding=RLE_DICTIONARY"`
+		}
+		rows := make([]record, 128)
+		for i := range rows {
+			rows[i].Name = fmt.Sprintf("value-%02d", i%11)
+		}
+		data := writeOffsetIndexRecords(t, new(record), rows, writer.WithPageSize(48))
+
+		for _, insidePage := range []bool{false, true} {
+			pr, err := NewParquetReader(buffer.NewBufferReaderFromBytesNoAlloc(data), new(record), WithNP(1))
+			require.NoError(t, err)
+			index, err := pr.ReadOffsetIndexWithContext(context.Background(), 0, 0)
+			require.NoError(t, err)
+			require.GreaterOrEqual(t, len(index.PageLocations), 3)
+			skip := index.PageLocations[2].FirstRowIndex
+			if insidePage {
+				pageEnd := pr.Footer.RowGroups[0].NumRows
+				if len(index.PageLocations) > 3 {
+					pageEnd = index.PageLocations[3].FirstRowIndex
+				}
+				require.Greater(t, pageEnd-skip, int64(1))
+				skip++
+			}
+			require.NoError(t, pr.SkipRows(skip))
+			got := make([]record, 1)
+			require.NoError(t, pr.Read(&got))
+			require.Equal(t, rows[skip], got[0])
+			require.NoError(t, pr.ReadStop())
+		}
+
+		pr, err := NewParquetReader(buffer.NewBufferReaderFromBytesNoAlloc(data), new(record), WithNP(1))
+		require.NoError(t, err)
+		index, err := pr.ReadOffsetIndexWithContext(context.Background(), 0, 0)
+		require.NoError(t, err)
+		lastPage := index.PageLocations[len(index.PageLocations)-1]
+		require.Greater(t, int64(len(rows))-lastPage.FirstRowIndex, int64(1))
+		require.NoError(t, pr.SkipRows(lastPage.FirstRowIndex))
+		require.NoError(t, pr.SkipRows(1))
+		got := make([]record, 1)
+		require.NoError(t, pr.Read(&got))
+		require.Equal(t, rows[lastPage.FirstRowIndex+1], got[0])
+		require.NoError(t, pr.ReadStop())
+	})
+
+	t.Run("columns with different page boundaries", func(t *testing.T) {
+		type record struct {
+			ID     int64   `parquet:"name=id, type=INT64"`
+			Label  *string `parquet:"name=label, type=BYTE_ARRAY, convertedtype=UTF8, repetitiontype=OPTIONAL"`
+			Values []int64 `parquet:"name=values, type=INT64, repetitiontype=REPEATED"`
+		}
+		rows := make([]record, 96)
+		for i := range rows {
+			label := fmt.Sprintf("row-%03d-%s", i, string(bytes.Repeat([]byte{'x'}, i%19)))
+			rows[i] = record{ID: int64(i), Label: &label, Values: make([]int64, i%7+1)}
+			for j := range rows[i].Values {
+				rows[i].Values[j] = int64(i*100 + j)
+			}
+		}
+		data := writeOffsetIndexRecords(t, new(record), rows, writer.WithPageSize(64), writer.WithDataPageVersion(2))
+		pr, err := NewParquetReader(buffer.NewBufferReaderFromBytesNoAlloc(data), new(record), WithNP(3))
+		require.NoError(t, err)
+		defer func() { require.NoError(t, pr.ReadStop()) }()
+
+		const skip = int64(67)
+		require.NoError(t, pr.SkipRows(skip))
+		got := make([]record, 1)
+		require.NoError(t, pr.Read(&got))
+		require.Equal(t, rows[skip], got[0])
+	})
+
+	t.Run("missing index falls back", func(t *testing.T) {
+		type record struct {
+			Value int64 `parquet:"name=value, type=INT64"`
+		}
+		rows := make([]record, 64)
+		for i := range rows {
+			rows[i].Value = int64(i)
+		}
+		data := writeOffsetIndexRecords(t, new(record), rows, writer.WithPageSize(32))
+		pr, err := NewParquetReader(buffer.NewBufferReaderFromBytesNoAlloc(data), new(record), WithNP(1))
+		require.NoError(t, err)
+		defer func() { require.NoError(t, pr.ReadStop()) }()
+		chunk := pr.Footer.RowGroups[0].Columns[0]
+		chunk.OffsetIndexOffset = nil
+		chunk.OffsetIndexLength = nil
+
+		const skip = int64(37)
+		require.NoError(t, pr.SkipRows(skip))
+		got := make([]record, 1)
+		require.NoError(t, pr.Read(&got))
+		require.Equal(t, rows[skip], got[0])
+	})
+}
+
+func TestSkipRows_EncryptedOffsetIndex(t *testing.T) {
+	type record struct {
+		ID   int64  `parquet:"name=id, type=INT64"`
+		Name string `parquet:"name=name, type=BYTE_ARRAY, convertedtype=UTF8, encoding=RLE_DICTIONARY"`
+	}
+	footerKey := []byte("0123456789abcdef")
+	columnKey := []byte("abcdef0123456789")
+	rows := make([]record, 128)
+	for i := range rows {
+		rows[i] = record{ID: int64(i), Name: fmt.Sprintf("name-%02d", i%13)}
+	}
+
+	for _, algorithm := range []struct {
+		name   string
+		option writer.WriterOption
+	}{
+		{name: "gcm", option: writer.WithEncryptionAlgorithm(writer.EncryptionAESGCMV1)},
+		{name: "gcm_ctr", option: writer.WithEncryptionAlgorithm(writer.EncryptionAESGCMCTRV1)},
+	} {
+		t.Run(algorithm.name, func(t *testing.T) {
+			data := writeOffsetIndexRecords(t, new(record), rows,
+				writer.WithPageSize(48),
+				algorithm.option,
+				writer.WithFooterKey(footerKey),
+				writer.WithColumnEncrypted("name", writer.ColumnKey(columnKey)),
+				writer.WithAADPrefix([]byte("offset-index-test")),
+				writer.WithAADFileUnique([]byte("offset-index-001")),
+			)
+			pr, err := NewParquetReader(
+				buffer.NewBufferReaderFromBytesNoAlloc(data),
+				new(record),
+				WithNP(2),
+				WithFooterKey(footerKey),
+				WithColumnKey("name", columnKey),
+			)
+			require.NoError(t, err)
+			defer func() { require.NoError(t, pr.ReadStop()) }()
+
+			nameColumn := encryptedColumnIndex(t, pr, "name")
+			index, err := pr.ReadOffsetIndexWithContext(context.Background(), 0, nameColumn)
+			require.NoError(t, err)
+			require.GreaterOrEqual(t, len(index.PageLocations), 3)
+			skip := index.PageLocations[2].FirstRowIndex
+			require.NoError(t, pr.SkipRows(skip))
+			got := make([]record, 1)
+			require.NoError(t, pr.Read(&got))
+			require.Equal(t, rows[skip], got[0])
+		})
+	}
+}
+
+func TestSkipRows_OffsetIndexExternalColumnChunk(t *testing.T) {
+	type record struct {
+		Value int64 `parquet:"name=value, type=INT64"`
+	}
+	rows := make([]record, 96)
+	for i := range rows {
+		rows[i].Value = int64(i)
+	}
+	data := writeOffsetIndexRecords(t, new(record), rows, writer.WithPageSize(32))
+	pf := newRecordingReader("main", map[string][]byte{"main": data, "column.parquet": data})
+	pr, err := NewParquetColumnReader(pf, WithNP(1))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, pr.ReadStop()) }()
+	index, err := pr.ReadOffsetIndexWithContext(context.Background(), 0, 0)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(index.PageLocations), 3)
+	externalPath := "column.parquet"
+	pr.Footer.RowGroups[0].Columns[0].FilePath = &externalPath
+
+	skip := index.PageLocations[2].FirstRowIndex
+	require.NoError(t, pr.SkipRows(skip))
+	values, _, _, err := pr.ReadColumnByIndex(0, 1)
+	require.NoError(t, err)
+	require.Equal(t, []any{skip}, values)
+	require.Positive(t, pf.state.bytesRead(externalPath), "data page must be read from the referenced external file")
+}
+
+func TestValidateIndexedSkipTarget(t *testing.T) {
+	validMeta := func() *parquet.ColumnMetaData {
+		return &parquet.ColumnMetaData{DataPageOffset: 100, TotalCompressedSize: 60}
+	}
+	validIndex := func() *parquet.OffsetIndex {
+		return &parquet.OffsetIndex{PageLocations: []*parquet.PageLocation{
+			{Offset: 100, CompressedPageSize: 20, FirstRowIndex: 0},
+			{Offset: 120, CompressedPageSize: 20, FirstRowIndex: 10},
+			{Offset: 140, CompressedPageSize: 20, FirstRowIndex: 20},
+		}}
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*parquet.ColumnMetaData, *parquet.OffsetIndex)
+		want   string
+	}{
+		{name: "nil page", mutate: func(_ *parquet.ColumnMetaData, index *parquet.OffsetIndex) { index.PageLocations[1] = nil }, want: "page location 1 is nil"},
+		{name: "nonzero first row", mutate: func(_ *parquet.ColumnMetaData, index *parquet.OffsetIndex) { index.PageLocations[0].FirstRowIndex = 1 }, want: "want 0"},
+		{name: "nonmonotonic rows", mutate: func(_ *parquet.ColumnMetaData, index *parquet.OffsetIndex) { index.PageLocations[2].FirstRowIndex = 10 }, want: "not greater"},
+		{name: "negative size", mutate: func(_ *parquet.ColumnMetaData, index *parquet.OffsetIndex) {
+			index.PageLocations[1].CompressedPageSize = -1
+		}, want: "invalid range"},
+		{name: "inconsistent size", mutate: func(_ *parquet.ColumnMetaData, index *parquet.OffsetIndex) {
+			index.PageLocations[1].CompressedPageSize = 19
+		}, want: "ends at 139"},
+		{name: "overlapping offsets", mutate: func(_ *parquet.ColumnMetaData, index *parquet.OffsetIndex) { index.PageLocations[1].Offset = 119 }, want: "next page starts at 119"},
+		{name: "outside chunk", mutate: func(_ *parquet.ColumnMetaData, index *parquet.OffsetIndex) { index.PageLocations[2].Offset = 160 }, want: "next page starts at 160"},
+		{name: "wrong first offset", mutate: func(meta *parquet.ColumnMetaData, _ *parquet.OffsetIndex) { meta.DataPageOffset = 99 }, want: "does not match"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			meta, index := validMeta(), validIndex()
+			tt.mutate(meta, index)
+			_, err := validateIndexedSkipTarget(meta, index, 30, 15)
+			require.ErrorContains(t, err, tt.want)
+		})
+	}
+
+	target, err := validateIndexedSkipTarget(validMeta(), validIndex(), 30, 15)
+	require.NoError(t, err)
+	require.Equal(t, 1, target.pageIndex)
+	require.Equal(t, int64(10), target.firstRow)
+	require.Equal(t, 2, target.pageCount)
+
+	_, err = validateIndexedSkipTarget(nil, validIndex(), 30, 15)
+	require.ErrorContains(t, err, "column metadata is nil")
+	_, err = validateIndexedSkipTarget(validMeta(), &parquet.OffsetIndex{}, 30, 15)
+	require.ErrorContains(t, err, "no page locations")
+	_, err = validateIndexedSkipTarget(validMeta(), validIndex(), 30, 30)
+	require.ErrorContains(t, err, "outside row group")
+	invalidChunk := validMeta()
+	invalidChunk.TotalCompressedSize = 0
+	_, err = validateIndexedSkipTarget(invalidChunk, validIndex(), 30, 15)
+	require.ErrorContains(t, err, "invalid column chunk range")
+	outsideRow := validIndex()
+	outsideRow.PageLocations[2].FirstRowIndex = 30
+	_, err = validateIndexedSkipTarget(validMeta(), outsideRow, 30, 15)
+	require.ErrorContains(t, err, "outside row group")
+	// A last page that ends before the chunk end is accepted: the trailing bytes are
+	// padding counted in TotalCompressedSize and, like a sequential read, are never read.
+	trailingPadding := validIndex()
+	trailingPadding.PageLocations[2].CompressedPageSize = 19
+	target, err = validateIndexedSkipTarget(validMeta(), trailingPadding, 30, 25)
+	require.NoError(t, err)
+	require.Equal(t, 2, target.pageIndex)
+	require.Equal(t, 1, target.pageCount)
+	// A last page that would extend past the chunk end is still rejected as out of range.
+	overrunLastPage := validIndex()
+	overrunLastPage.PageLocations[2].CompressedPageSize = 21
+	_, err = validateIndexedSkipTarget(validMeta(), overrunLastPage, 30, 25)
+	require.ErrorContains(t, err, "invalid range")
+}
+
+func TestIndexedPageCursorErrors(t *testing.T) {
+	cb := &ColumnBufferType{}
+	_, err := cb.newIndexedTransport(buffer.NewBufferReaderFromBytesNoAlloc([]byte{0}), 2, 1)
+	require.ErrorContains(t, err, "stopped at 1")
+
+	failingFile := newMockColumnBufferFileReader(nil)
+	failingFile.SetShouldFail(true)
+	_, err = cb.newIndexedTransport(failingFile, 0, 1)
+	require.ErrorContains(t, err, "mock seek error")
+
+	cloneFailure := newMockColumnBufferFileReader(nil)
+	cloneFailure.SetCloneFails(true)
+	cb = &ColumnBufferType{PFile: cloneFailure, indexedDictionaryPending: true}
+	err = cb.ensureIndexedDictionary()
+	require.ErrorContains(t, err, "clone column file")
+	err = cb.seekToIndexedPage(indexedSkipTarget{}, false)
+	require.ErrorContains(t, err, "clone column file")
+
+	dictionaryOffset := int64(5)
+	cb = &ColumnBufferType{ChunkHeader: &parquet.ColumnChunk{MetaData: &parquet.ColumnMetaData{
+		DictionaryPageOffset: &dictionaryOffset,
+		DataPageOffset:       5,
+	}}}
+	_, err = cb.readIndexedDictionary(newMockColumnBufferFileReader(nil))
+	require.ErrorContains(t, err, "invalid dictionary page offset")
+
+	// A row group that cannot be located makes skipWithOffsetIndex decline the
+	// optimization (used=false) rather than error.
+	unlocatable := &ColumnBufferType{
+		Reader:      &ParquetReader{},
+		Footer:      &parquet.FileMetaData{},
+		ChunkHeader: &parquet.ColumnChunk{MetaData: &parquet.ColumnMetaData{NumValues: 4}},
+	}
+	skipped, used, err := unlocatable.skipWithOffsetIndex(1)
+	require.NoError(t, err)
+	require.False(t, used)
+	require.Zero(t, skipped)
+
+	// seekToIndexedPage closes the cloned handle and surfaces a transport failure when
+	// the target data page cannot be reached.
+	seekErr := &ColumnBufferType{
+		PFile:       buffer.NewBufferReaderFromBytesNoAlloc([]byte{0}),
+		ChunkHeader: &parquet.ColumnChunk{MetaData: &parquet.ColumnMetaData{}},
+	}
+	err = seekErr.seekToIndexedPage(indexedSkipTarget{offset: 8, chunkEnd: 9, pageCount: 1}, false)
+	require.ErrorContains(t, err, "seek to offset 8")
+
+	// ensureIndexedDictionary propagates a dictionary read failure after a successful
+	// clone.
+	badDictOffset := int64(8)
+	ensureErr := &ColumnBufferType{
+		PFile:                    buffer.NewBufferReaderFromBytesNoAlloc([]byte{0}),
+		indexedDictionaryPending: true,
+		ChunkHeader: &parquet.ColumnChunk{MetaData: &parquet.ColumnMetaData{
+			DictionaryPageOffset: &badDictOffset,
+			DataPageOffset:       8,
+		}},
+	}
+	err = ensureErr.ensureIndexedDictionary()
+	require.ErrorContains(t, err, "invalid dictionary page offset")
+}
+
+func TestSkipRows_OffsetIndexSeekFailureSurfaces(t *testing.T) {
+	type record struct {
+		Value int64 `parquet:"name=value, type=INT64"`
+	}
+	rows := make([]record, 96)
+	for i := range rows {
+		rows[i].Value = int64(i)
+	}
+	data := writeOffsetIndexRecords(t, new(record), rows, writer.WithPageSize(32))
+	pr, err := NewParquetReader(buffer.NewBufferReaderFromBytesNoAlloc(data), new(record), WithNP(1))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, pr.ReadStop()) }()
+	index, err := pr.ReadOffsetIndexWithContext(context.Background(), 0, 0)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(index.PageLocations), 2)
+
+	cb := pr.ColumnBuffers[pr.SchemaHandler.ValueColumns[0]]
+	require.NotNil(t, cb)
+	// The offset index is still read through the reader's own file, but the column file
+	// can no longer be cloned, so seeking to the target data page fails and the error is
+	// surfaced (used=true) instead of silently degrading.
+	unclonable := newMockColumnBufferFileReader(nil)
+	unclonable.SetCloneFails(true)
+	cb.PFile = unclonable
+
+	skipped, used, err := cb.skipWithOffsetIndex(index.PageLocations[1].FirstRowIndex)
+	require.True(t, used)
+	require.ErrorContains(t, err, "seek row group 0 column 0 to data page")
+	require.Zero(t, skipped)
+
+	// Reading a dictionary page from bytes that do not decode into one is reported
+	// rather than mistaken for valid dictionary values.
+	_, err = cb.readIndexedDictionary(buffer.NewBufferReaderFromBytesNoAlloc(make([]byte, 256)))
+	require.ErrorContains(t, err, "dictionary")
+}
+
+func TestSkipRows_MalformedOffsetIndexFallsBack(t *testing.T) {
+	type record struct {
+		Value int64 `parquet:"name=value, type=INT64"`
+	}
+	rows := make([]record, 64)
+	for i := range rows {
+		rows[i].Value = int64(i)
+	}
+	data := writeOffsetIndexRecords(t, new(record), rows, writer.WithPageSize(32))
+	inspect, err := NewParquetReader(buffer.NewBufferReaderFromBytesNoAlloc(data), new(record), WithNP(1))
+	require.NoError(t, err)
+	index, err := inspect.ReadOffsetIndexWithContext(context.Background(), 0, 0)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(index.PageLocations), 2)
+	chunk := inspect.Footer.RowGroups[0].Columns[0]
+	offset, length := chunk.GetOffsetIndexOffset(), int(chunk.GetOffsetIndexLength())
+	require.NoError(t, inspect.ReadStop())
+
+	// Corrupt the offset index while keeping it a parseable thrift struct, so the reader
+	// must detect the invalid page layout during the skip rather than while decoding it.
+	index.PageLocations[0].FirstRowIndex = 1
+	serializer := thrift.NewTSerializer()
+	serializer.Protocol = thrift.NewTCompactProtocolFactoryConf(&thrift.TConfiguration{}).GetProtocol(serializer.Transport)
+	malformedModule, err := serializer.Write(context.Background(), index)
+	require.NoError(t, err)
+	require.Len(t, malformedModule, length)
+	copy(data[offset:offset+int64(length)], malformedModule)
+
+	pr, err := NewParquetReader(buffer.NewBufferReaderFromBytesNoAlloc(data), new(record), WithNP(1))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, pr.ReadStop()) }()
+	cb := pr.ColumnBuffers[pr.SchemaHandler.ValueColumns[0]]
+	require.NotNil(t, cb)
+
+	// The offset index is only an optimization hint. An invalid one must not fail the
+	// skip: it falls back to sequential page reading and still returns the correct row.
+	require.NoError(t, pr.SkipRows(17))
+	require.False(t, cb.hasIndexedPageCursor())
+	require.Positive(t, cb.ChunkReadValues, "fallback must read pages sequentially")
+	got := make([]record, 1)
+	require.NoError(t, pr.Read(&got))
+	require.Equal(t, rows[17], got[0])
+}
+
+func TestSkipRows_UnreadableOffsetIndexFallsBack(t *testing.T) {
+	type record struct {
+		Value int64 `parquet:"name=value, type=INT64"`
+	}
+	rows := make([]record, 96)
+	for i := range rows {
+		rows[i].Value = int64(i)
+	}
+	data := writeOffsetIndexRecords(t, new(record), rows, writer.WithPageSize(32))
+	pr, err := NewParquetReader(buffer.NewBufferReaderFromBytesNoAlloc(data), new(record), WithNP(1))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, pr.ReadStop()) }()
+	cb := pr.ColumnBuffers[pr.SchemaHandler.ValueColumns[0]]
+	require.NotNil(t, cb)
+
+	// Point the offset index at a region past end of file: reading it fails, but the
+	// failure is confined to the index, so the (uncancelled) skip must fall back to
+	// sequential reading instead of aborting.
+	badOffset := int64(len(data) + 1024)
+	pr.Footer.RowGroups[0].Columns[0].OffsetIndexOffset = &badOffset
+
+	require.NoError(t, pr.SkipRows(37))
+	require.False(t, cb.hasIndexedPageCursor())
+	require.Positive(t, cb.ChunkReadValues, "fallback must read pages sequentially")
+	got := make([]record, 1)
+	require.NoError(t, pr.Read(&got))
+	require.Equal(t, rows[37], got[0])
+}
+
+func TestSkipRows_OffsetIndexCancellation(t *testing.T) {
+	type record struct {
+		Value int64 `parquet:"name=value, type=INT64"`
+	}
+	rows := make([]record, 64)
+	data := writeOffsetIndexRecords(t, new(record), rows, writer.WithPageSize(32))
+	pr, err := NewParquetReader(buffer.NewBufferReaderFromBytesNoAlloc(data), new(record), WithNP(1))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, pr.ReadStop()) }()
+	cb := pr.ColumnBuffers[pr.SchemaHandler.ValueColumns[0]]
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	cb.PageReadOptions.Context = ctx
+
+	skipped, err := cb.SkipRows(17)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Zero(t, skipped)
+	require.Zero(t, cb.ChunkReadValues)
+	require.False(t, cb.hasIndexedPageCursor())
+}
+
+func writeOffsetIndexRecords[T any](t *testing.T, schema *T, rows []T, options ...writer.WriterOption) []byte {
+	t.Helper()
+	var out bytes.Buffer
+	options = append([]writer.WriterOption{
+		writer.WithNP(1),
+		writer.WithRowGroupSize(1 << 30),
+		writer.WithCompressionCodec(parquet.CompressionCodec_UNCOMPRESSED),
+	}, options...)
+	pw, err := writer.NewParquetWriterWithContext(context.Background(), writerfile.NewWriterFile(&out), schema, options...)
+	require.NoError(t, err)
+	for _, row := range rows {
+		require.NoError(t, pw.WriteWithContext(context.Background(), row))
+	}
+	require.NoError(t, pw.WriteStopWithContext(context.Background()))
+	return append([]byte(nil), out.Bytes()...)
+}
+
+func BenchmarkSkipRowsOffsetIndex(b *testing.B) {
+	type record struct {
+		Value int64 `parquet:"name=value, type=INT64"`
+	}
+	var out bytes.Buffer
+	pw, err := writer.NewParquetWriterWithContext(
+		context.Background(),
+		writerfile.NewWriterFile(&out),
+		new(record),
+		writer.WithNP(1),
+		writer.WithRowGroupSize(1<<30),
+		writer.WithPageSize(128),
+		writer.WithCompressionCodec(parquet.CompressionCodec_UNCOMPRESSED),
+	)
+	if err != nil {
+		b.Fatal(err)
+	}
+	for i := range int64(4096) {
+		if err := pw.WriteWithContext(context.Background(), record{Value: i}); err != nil {
+			b.Fatal(err)
+		}
+	}
+	if err := pw.WriteStopWithContext(context.Background()); err != nil {
+		b.Fatal(err)
+	}
+	data := append([]byte(nil), out.Bytes()...)
+
+	for _, depth := range []struct {
+		name string
+		skip int64
+	}{
+		{name: "shallow", skip: 17},
+		{name: "deep", skip: 3073},
+	} {
+		for _, indexed := range []bool{true, false} {
+			name := "fallback"
+			if indexed {
+				name = "indexed"
+			}
+			b.Run(depth.name+"/"+name, func(b *testing.B) {
+				runSkipRowsBenchmark(b, data, indexed, depth.skip)
+			})
+		}
+	}
+}
+
+func runSkipRowsBenchmark(b *testing.B, data []byte, indexed bool, skip int64) {
+	type record struct {
+		Value int64 `parquet:"name=value, type=INT64"`
+	}
+	pf := newRecordingReader("main", map[string][]byte{"main": data})
+	pr, err := NewParquetReader(pf, new(record), WithNP(1))
+	if err != nil {
+		b.Fatal(err)
+	}
+	if !indexed {
+		chunk := pr.Footer.RowGroups[0].Columns[0]
+		chunk.OffsetIndexOffset = nil
+		chunk.OffsetIndexLength = nil
+	}
+	b.Cleanup(func() { _ = pr.ReadStop() })
+	b.ReportAllocs()
+	b.ResetTimer()
+	var totalBytes int64
+	for range b.N {
+		if err := pr.Reset(); err != nil {
+			b.Fatal(err)
+		}
+		pf.state.reset()
+		if err := pr.SkipRows(skip); err != nil {
+			b.Fatal(err)
+		}
+		if _, _, _, err := pr.ReadColumnByIndex(0, 1); err != nil {
+			b.Fatal(err)
+		}
+		totalBytes += pf.state.bytesRead(pf.name)
+	}
+	b.ReportMetric(float64(totalBytes)/float64(b.N), "read-B/op")
+}

--- a/reader/columnbuffer_skip.go
+++ b/reader/columnbuffer_skip.go
@@ -88,6 +88,7 @@ func (cbt *ColumnBufferType) readRawPageForSkip() (*layout.Page, error) {
 	cbt.DataTable.Merge(page.DataTable)
 	cbt.ChunkReadValues += numValues
 	cbt.DataTableNumRows += numRows
+	cbt.finishIndexedDataPage()
 	return page, nil
 }
 
@@ -143,7 +144,7 @@ func (cbt *ColumnBufferType) skipEntireRowGroups(num int64) (int64, error) {
 	}
 	rowGroups := cbt.Footer.RowGroups
 	// A partially consumed chunk cannot use the row group's full row count.
-	for num > 0 && cbt.ChunkReadValues == 0 &&
+	for num > 0 && cbt.ChunkReadValues == 0 && !cbt.hasIndexedPageCursor() &&
 		cbt.RowGroupIndex > 0 && cbt.RowGroupIndex < int64(len(rowGroups)) {
 		// RowGroupIndex points one past the currently loaded row group.
 		currentRG := rowGroups[cbt.RowGroupIndex-1]
@@ -213,6 +214,9 @@ func (cbt *ColumnBufferType) skipByReadingPages(num int64) (int64, error) {
 	}
 
 	if page != nil {
+		if err = cbt.ensureIndexedDictionary(); err != nil {
+			return skipped, fmt.Errorf("load indexed dictionary: %w", err)
+		}
 		if err = page.GetValueFromRawData(cbt.SchemaHandler); err != nil {
 			return skipped, fmt.Errorf("decode page values during skip: %w", err)
 		}
@@ -266,6 +270,12 @@ func (cbt *ColumnBufferType) SkipRows(num int64) (int64, error) {
 	// surface an error from data beyond the requested skip boundary.
 	if num == 0 {
 		return originalNum, nil
+	}
+
+	if skipped, used, indexErr := cbt.skipWithOffsetIndex(num); indexErr != nil {
+		return originalNum - num + skipped, fmt.Errorf("skip with offset index: %w", indexErr)
+	} else if used {
+		return originalNum - num + skipped, nil
 	}
 
 	// Finally, skip remaining rows by reading pages.

--- a/reader/columnbuffer_skip_test.go
+++ b/reader/columnbuffer_skip_test.go
@@ -1,8 +1,11 @@
 package reader
 
 import (
+	"bytes"
 	"context"
+	"fmt"
 	"io"
+	"sync"
 	"testing"
 
 	"github.com/apache/thrift/lib/go/thrift"
@@ -11,9 +14,196 @@ import (
 	"github.com/hangxie/parquet-go/v3/common"
 	"github.com/hangxie/parquet-go/v3/internal/layout"
 	"github.com/hangxie/parquet-go/v3/parquet"
+	"github.com/hangxie/parquet-go/v3/source"
 	"github.com/hangxie/parquet-go/v3/source/buffer"
+	"github.com/hangxie/parquet-go/v3/source/writerfile"
 	"github.com/hangxie/parquet-go/v3/writer"
 )
+
+type countingReadRange struct {
+	start int64
+	end   int64
+}
+
+// recordingReadState collects the byte ranges every clone of a recordingReader has
+// read, keyed by file name, so a test can assert which regions were (or were not)
+// touched and how many bytes each backing file served.
+type recordingReadState struct {
+	mu    sync.Mutex
+	reads map[string][]countingReadRange
+}
+
+func newRecordingReadState() *recordingReadState {
+	return &recordingReadState{reads: map[string][]countingReadRange{}}
+}
+
+func (s *recordingReadState) record(name string, read countingReadRange) {
+	s.mu.Lock()
+	s.reads[name] = append(s.reads[name], read)
+	s.mu.Unlock()
+}
+
+func (s *recordingReadState) ranges(name string) []countingReadRange {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]countingReadRange(nil), s.reads[name]...)
+}
+
+func (s *recordingReadState) bytesRead(name string) int64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var total int64
+	for _, read := range s.reads[name] {
+		total += read.end - read.start
+	}
+	return total
+}
+
+func (s *recordingReadState) reset() {
+	s.mu.Lock()
+	s.reads = map[string][]countingReadRange{}
+	s.mu.Unlock()
+}
+
+// recordingReader is an in-memory source.ParquetFileReader over one or more named
+// files that records every read range in a shared recordingReadState. Clones and
+// Opens share that state, so reads performed by the reader's per-column clones are
+// visible to the test that created it.
+type recordingReader struct {
+	files  map[string][]byte
+	name   string
+	offset int64
+	state  *recordingReadState
+}
+
+func newRecordingReader(name string, files map[string][]byte) *recordingReader {
+	return &recordingReader{files: files, name: name, state: newRecordingReadState()}
+}
+
+func (r *recordingReader) Read(p []byte) (int, error) {
+	data := r.files[r.name]
+	if r.offset >= int64(len(data)) {
+		return 0, io.EOF
+	}
+	start := r.offset
+	n := copy(p, data[r.offset:])
+	r.offset += int64(n)
+	r.state.record(r.name, countingReadRange{start: start, end: r.offset})
+	if r.offset == int64(len(data)) {
+		return n, io.EOF
+	}
+	return n, nil
+}
+
+func (r *recordingReader) Seek(offset int64, whence int) (int64, error) {
+	switch whence {
+	case io.SeekStart:
+		r.offset = offset
+	case io.SeekCurrent:
+		r.offset += offset
+	case io.SeekEnd:
+		r.offset = int64(len(r.files[r.name])) + offset
+	}
+	return r.offset, nil
+}
+
+func (r *recordingReader) Close() error { return nil }
+
+func (r *recordingReader) Open(name string) (source.ParquetFileReader, error) {
+	if _, ok := r.files[name]; !ok {
+		return nil, fmt.Errorf("file %q not found", name)
+	}
+	return &recordingReader{files: r.files, name: name, state: r.state}, nil
+}
+
+func (r *recordingReader) Clone() (source.ParquetFileReader, error) {
+	return &recordingReader{files: r.files, name: r.name, offset: r.offset, state: r.state}, nil
+}
+
+func TestSkipRows_UsesOffsetIndex(t *testing.T) {
+	for _, pageVersion := range []int{1, 2} {
+		t.Run(fmt.Sprintf("v%d", pageVersion), func(t *testing.T) {
+			testSkipRowsUsesOffsetIndexVersion(t, pageVersion)
+		})
+	}
+}
+
+func testSkipRowsUsesOffsetIndexVersion(t *testing.T, pageVersion int) {
+	type record struct {
+		Value int64 `parquet:"name=value, type=INT64"`
+	}
+
+	var parquetData bytes.Buffer
+	options := []writer.WriterOption{
+		writer.WithNP(1),
+		writer.WithPageSize(64),
+		writer.WithCompressionCodec(parquet.CompressionCodec_UNCOMPRESSED),
+	}
+	if pageVersion == 2 {
+		options = append(options, writer.WithDataPageVersion(2))
+	}
+	pw, err := writer.NewParquetWriterWithContext(context.Background(), writerfile.NewWriterFile(&parquetData), new(record), options...)
+	require.NoError(t, err)
+	for i := range int64(256) {
+		require.NoError(t, pw.WriteWithContext(context.Background(), record{Value: i}))
+	}
+	require.NoError(t, pw.WriteStopWithContext(context.Background()))
+
+	pf := newRecordingReader("main", map[string][]byte{"main": parquetData.Bytes()})
+	pr, err := NewParquetReader(pf, new(record), WithNP(1))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, pr.ReadStop()) }()
+
+	index, err := pr.ReadOffsetIndexWithContext(context.Background(), 0, 0)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(index.PageLocations), 3)
+	targetPage := 2
+	pageStart := index.PageLocations[targetPage].FirstRowIndex
+	pageEnd := pr.Footer.RowGroups[0].NumRows
+	if targetPage+1 < len(index.PageLocations) {
+		pageEnd = index.PageLocations[targetPage+1].FirstRowIndex
+	}
+
+	positions := []struct {
+		name string
+		skip int64
+	}{{name: "page_boundary", skip: pageStart}}
+	if pageEnd-pageStart > 1 {
+		positions = append(positions, struct {
+			name string
+			skip int64
+		}{name: "inside_page", skip: pageStart + 1})
+	}
+
+	for _, position := range positions {
+		t.Run(position.name, func(t *testing.T) {
+			testIndexedSkipReadRanges(t, pr, pf, index, targetPage, position.skip)
+		})
+	}
+}
+
+func testIndexedSkipReadRanges(t *testing.T, pr *ParquetReader, pf *recordingReader, index *parquet.OffsetIndex, targetPage int, skip int64) {
+	require.NoError(t, pr.Reset())
+	pf.state.reset()
+
+	require.NoError(t, pr.SkipRows(skip))
+	values, _, _, err := pr.ReadColumnByIndex(0, 1)
+	require.NoError(t, err)
+	require.Equal(t, []any{skip}, values)
+	// Pages entirely before the landing page are jumped over via the offset index and
+	// must never be read; that skipped I/O is the whole point of the optimization.
+	for page := range targetPage {
+		assertPageRangeUnread(t, index.PageLocations[page], pf.state.ranges(pf.name), "skip read preceding data page")
+	}
+}
+
+func assertPageRangeUnread(t *testing.T, page *parquet.PageLocation, reads []countingReadRange, message string) {
+	pageEnd := page.Offset + int64(page.CompressedPageSize)
+	for _, read := range reads {
+		require.False(t, read.start < pageEnd && read.end > page.Offset,
+			"%s [%d,%d) via read [%d,%d)", message, page.Offset, pageEnd, read.start, read.end)
+	}
+}
 
 func TestSkipRows(t *testing.T) {
 	tests := []struct {

--- a/reader/index.go
+++ b/reader/index.go
@@ -36,7 +36,7 @@ func (pr *ParquetReader) ReadColumnIndexWithContext(ctx context.Context, rowGrou
 		return nil, nil
 	}
 
-	buf, err := pr.readIndexModule(column, rowGroupOrdinal, columnOrdinal, column.GetColumnIndexOffset(), column.GetColumnIndexLength(), encryption.ModuleColumnIndex)
+	buf, err := pr.readIndexModule(ctx, column, rowGroupOrdinal, columnOrdinal, column.GetColumnIndexOffset(), column.GetColumnIndexLength(), encryption.ModuleColumnIndex)
 	if err != nil {
 		return nil, fmt.Errorf("read column index module: %w", err)
 	}
@@ -94,6 +94,18 @@ func (pr *ParquetReader) ReadOffsetIndexWithContext(ctx context.Context, rowGrou
 	if err := pr.setContext(ctx); err != nil {
 		return nil, err
 	}
+	return pr.readOffsetIndexWithContext(ctx, rowGroupIndex, columnIndex)
+}
+
+// readOffsetIndexWithContext avoids mutating reader-wide context while column
+// buffers perform the same SkipRows operation in parallel.
+func (pr *ParquetReader) readOffsetIndexWithContext(ctx context.Context, rowGroupIndex, columnIndex int) (*parquet.OffsetIndex, error) {
+	if ctx == nil {
+		return nil, fmt.Errorf("context is nil")
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	column, rowGroupOrdinal, columnOrdinal, err := pr.indexColumn(rowGroupIndex, columnIndex)
 	if err != nil {
 		return nil, fmt.Errorf("locate column for offset index: %w", err)
@@ -102,7 +114,7 @@ func (pr *ParquetReader) ReadOffsetIndexWithContext(ctx context.Context, rowGrou
 		return nil, nil
 	}
 
-	buf, err := pr.readIndexModule(column, rowGroupOrdinal, columnOrdinal, column.GetOffsetIndexOffset(), column.GetOffsetIndexLength(), encryption.ModuleOffsetIndex)
+	buf, err := pr.readIndexModule(ctx, column, rowGroupOrdinal, columnOrdinal, column.GetOffsetIndexOffset(), column.GetOffsetIndexLength(), encryption.ModuleOffsetIndex)
 	if err != nil {
 		return nil, fmt.Errorf("read offset index module: %w", err)
 	}
@@ -135,16 +147,16 @@ func (pr *ParquetReader) indexColumn(rowGroupIndex, columnIndex int) (*parquet.C
 	return rowGroup.Columns[columnIndex], rowGroupOrdinal, int16(columnIndex), nil
 }
 
-func (pr *ParquetReader) readIndexModule(column *parquet.ColumnChunk, rowGroupOrdinal, columnOrdinal int16, offset int64, length int32, moduleType encryption.ModuleType) ([]byte, error) {
+func (pr *ParquetReader) readIndexModule(ctx context.Context, column *parquet.ColumnChunk, rowGroupOrdinal, columnOrdinal int16, offset int64, length int32, moduleType encryption.ModuleType) ([]byte, error) {
 	if pr.PFile == nil {
 		return nil, fmt.Errorf("file reader is nil")
 	}
-	pf, err := source.CloneWithContext(pr.context(), pr.PFile)
+	pf, err := source.CloneWithContext(ctx, pr.PFile)
 	if err != nil {
 		return nil, fmt.Errorf("clone file reader: %w", err)
 	}
-	defer func() { _ = source.CloseWithContext(pr.context(), pf) }()
-	contextFile := source.ReadSeekerWithContext{Ctx: pr.context(), ReadSeeker: pf}
+	defer func() { _ = source.CloseWithContext(ctx, pf) }()
+	contextFile := source.ReadSeekerWithContext{Ctx: ctx, ReadSeeker: pf}
 
 	if column.GetCryptoMetadata() == nil {
 		return readPlainIndexModule(contextFile, offset, length)


### PR DESCRIPTION
## Summary

Speeds up `ParquetReader.SkipRows` by using column **offset indexes** to jump straight to the data page that contains the target row, instead of decoding every page along the way.

When a skip lands inside a chunk that has an offset index, the reader now:

- binary-searches the page locations for the page holding the target row,
- seeks directly to that page (loading the column's dictionary page on demand for dictionary-encoded columns), and
- reads forward from there.

Pages before the target are never read. Whole-row-group skipping (via `RowGroup.num_rows`) is unchanged and still runs first; the offset-index path only kicks in for the remaining within-row-group skip.

## Behavior & safety

- **Graceful fallback.** The offset index is an optional optimization hint. If it is missing, structurally malformed, or unreadable, the skip silently falls back to the existing sequential page-reading path, which is always correct. Context cancellation/deadline is still surfaced rather than swallowed.
- **Trust model.** Positioning trusts the writer-provided `first_row_index` values, exactly as the reader already trusts `RowGroup.num_rows` to skip whole row groups without decoding them. A corrupted-but-well-formed index could mispose a skip — that's a broken file, and it's documented in the README. Fully verifying absolute positions would require reading the very pages being skipped, defeating the optimization.
- **Relaxed page-location validation.** The last listed page only needs to fit inside the chunk (trailing padding counted in `TotalCompressedSize` is fine), matching how the non-indexed reader stops at `num_values` and ignores trailing bytes. Listed pages must still abut one another, which mirrors the reader's contiguous-chunk streaming model.

## Coverage

- Encrypted columns (AES-GCM and AES-GCM-CTR), including on-demand dictionary decryption at the target page.
- External column chunks (`file_path`), reading data pages from the referenced file while reading the index from the main file.
- Data Page V1 and V2, flat and repeated columns.
- Parallel per-column skips (offset-index reads use per-column context, no shared reader-context mutation).
- Round-trip, page-boundary and interior landings, malformed/unreadable-index fallback, and cancellation.

## Testing

- `make all` passes (format, lint, race tests, examples, build).
- Statement coverage stays at/above `main`.
