### PR TITLE
feat: support row group sorting columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Common writer options:
 - `writer.WithCompressionLevel`
 - `writer.WithDataPageVersion`
 - `writer.WithWriteCRC`
+- `writer.WithSortingColumns`
 
 Common reader options:
 
@@ -169,6 +170,20 @@ Common reader options:
 Encryption-related options are covered in [Encryption](#encryption).
 
 Reader footers expose schema and column paths as stored in the Parquet file. Use `ParquetReader.InternalFooter()` when a tool needs a converted footer with internal Go schema names.
+
+Use `writer.WithSortingColumns` to declare that the caller supplies rows in a known order. Each `parquet.SortingColumn.ColumnIdx` is a zero-based leaf-column ordinal; the option applies the same declaration to every row group, and the writer records but does not enforce or produce that ordering. A writer using this option must be constructed with a schema so the column ordinals can be validated.
+
+```go
+pw, err := writer.NewParquetWriter(fw, new(Student), writer.WithSortingColumns(
+    &parquet.SortingColumn{ColumnIdx: 2, Descending: false, NullsFirst: false},
+))
+```
+
+Readers can inspect a row group's declaration without mutating the loaded footer:
+
+```go
+sortingColumns, err := pr.RowGroupSortingColumns(0)
+```
 
 ## Schema Definition
 

--- a/reader/footer.go
+++ b/reader/footer.go
@@ -29,6 +29,33 @@ func (pr *ParquetReader) InternalFooter() (*parquet.FileMetaData, error) {
 	return footer, nil
 }
 
+// RowGroupSortingColumns returns a copy of the sorting-column metadata for a
+// row group. ColumnIdx is the zero-based leaf-column ordinal in that row group.
+func (pr *ParquetReader) RowGroupSortingColumns(rowGroupIndex int) ([]*parquet.SortingColumn, error) {
+	if pr == nil || pr.Footer == nil {
+		return nil, fmt.Errorf("reader footer is unavailable")
+	}
+	if rowGroupIndex < 0 || rowGroupIndex >= len(pr.Footer.RowGroups) {
+		return nil, fmt.Errorf("row group index %d out of range [0, %d)", rowGroupIndex, len(pr.Footer.RowGroups))
+	}
+	rowGroup := pr.Footer.RowGroups[rowGroupIndex]
+	if rowGroup == nil {
+		return nil, fmt.Errorf("row group %d is nil", rowGroupIndex)
+	}
+	if rowGroup.SortingColumns == nil {
+		return nil, nil
+	}
+	columns := make([]*parquet.SortingColumn, len(rowGroup.SortingColumns))
+	for i, column := range rowGroup.SortingColumns {
+		if column == nil {
+			continue
+		}
+		clonedColumn := *column
+		columns[i] = &clonedColumn
+	}
+	return columns, nil
+}
+
 // RenameSchema rewrites Footer schema names and column metadata paths from
 // external Parquet names to internal Go names. Prefer InternalFooter when a
 // converted footer is needed without mutating the reader's file metadata.

--- a/reader/footer_test.go
+++ b/reader/footer_test.go
@@ -223,6 +223,52 @@ func TestParquetReaderInternalFooterNil(t *testing.T) {
 	require.Nil(t, footer)
 }
 
+func TestParquetReaderRowGroupSortingColumns(t *testing.T) {
+	first := &parquet.SortingColumn{ColumnIdx: 1, Descending: true, NullsFirst: true}
+	footer := &parquet.FileMetaData{
+		RowGroups: []*parquet.RowGroup{
+			{SortingColumns: []*parquet.SortingColumn{first}},
+			{},
+		},
+	}
+	pr := &ParquetReader{Footer: footer}
+
+	columns, err := pr.RowGroupSortingColumns(0)
+	require.NoError(t, err)
+	require.Equal(t, []*parquet.SortingColumn{first}, columns)
+	require.NotSame(t, first, columns[0])
+
+	columns[0].ColumnIdx = 0
+	columns[0] = nil
+	require.Equal(t, int32(1), pr.Footer.RowGroups[0].SortingColumns[0].ColumnIdx)
+
+	columns, err = pr.RowGroupSortingColumns(1)
+	require.NoError(t, err)
+	require.Nil(t, columns)
+
+	nilRowGroupFooter := &parquet.FileMetaData{RowGroups: []*parquet.RowGroup{nil}}
+	nilRowGroupReader := &ParquetReader{Footer: nilRowGroupFooter}
+
+	tests := []struct {
+		name          string
+		reader        *ParquetReader
+		rowGroupIndex int
+		wantErr       string
+	}{
+		{name: "nil reader", reader: nil, wantErr: "reader footer is unavailable"},
+		{name: "nil footer", reader: &ParquetReader{}, wantErr: "reader footer is unavailable"},
+		{name: "negative index", reader: pr, rowGroupIndex: -1, wantErr: "row group index -1 out of range [0, 2)"},
+		{name: "large index", reader: pr, rowGroupIndex: 2, wantErr: "row group index 2 out of range [0, 2)"},
+		{name: "nil row group", reader: nilRowGroupReader, wantErr: "row group 0 is nil"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tt.reader.RowGroupSortingColumns(tt.rowGroupIndex)
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
 func writeFooterRenamedColumnParquet(t *testing.T) []byte {
 	t.Helper()
 

--- a/writer/arrow.go
+++ b/writer/arrow.go
@@ -62,11 +62,17 @@ func NewArrowWriterWithContext(ctx context.Context, arrowSchema *arrow.Schema, p
 	}
 	res.Footer.Schema = append(res.Footer.Schema, res.SchemaHandler.SchemaElements...)
 	res.marshalFunc = marshal.MarshalArrow
+	if err = res.validateSortingColumns(); err != nil {
+		return nil, fmt.Errorf("validate sorting columns: %w", err)
+	}
 	if err = res.initBloomFilters(); err != nil {
 		return nil, fmt.Errorf("init bloom filters: %w", err)
 	}
 	if err = res.validateEncryptionColumnKeys(); err != nil {
 		return nil, fmt.Errorf("validate encryption column keys: %w", err)
+	}
+	if err = res.writeMagicHeader(); err != nil {
+		return nil, fmt.Errorf("write magic header: %w", err)
 	}
 
 	res.stopped = false

--- a/writer/csv.go
+++ b/writer/csv.go
@@ -55,11 +55,17 @@ func NewCSVWriterWithContext(ctx context.Context, md []string, pfile source.Parq
 	}
 	res.Footer.Schema = append(res.Footer.Schema, res.SchemaHandler.SchemaElements...)
 	res.marshalFunc = marshal.MarshalCSV
+	if err = res.validateSortingColumns(); err != nil {
+		return nil, fmt.Errorf("validate sorting columns: %w", err)
+	}
 	if err = res.initBloomFilters(); err != nil {
 		return nil, fmt.Errorf("init bloom filters: %w", err)
 	}
 	if err = res.validateEncryptionColumnKeys(); err != nil {
 		return nil, fmt.Errorf("validate encryption column keys: %w", err)
+	}
+	if err = res.writeMagicHeader(); err != nil {
+		return nil, fmt.Errorf("write magic header: %w", err)
 	}
 
 	res.stopped = false

--- a/writer/json.go
+++ b/writer/json.go
@@ -54,11 +54,17 @@ func NewJSONWriterWithContext(ctx context.Context, jsonSchema string, pfile sour
 	}
 	res.Footer.Schema = append(res.Footer.Schema, res.SchemaHandler.SchemaElements...)
 	res.marshalFunc = marshal.MarshalJSON
+	if err = res.validateSortingColumns(); err != nil {
+		return nil, fmt.Errorf("validate sorting columns: %w", err)
+	}
 	if err = res.initBloomFilters(); err != nil {
 		return nil, fmt.Errorf("init bloom filters: %w", err)
 	}
 	if err = res.validateEncryptionColumnKeys(); err != nil {
 		return nil, fmt.Errorf("validate encryption column keys: %w", err)
+	}
+	if err = res.writeMagicHeader(); err != nil {
+		return nil, fmt.Errorf("write magic header: %w", err)
 	}
 
 	res.stopped = false

--- a/writer/ops.go
+++ b/writer/ops.go
@@ -228,6 +228,7 @@ func (pw *ParquetWriter) buildRowGroup(chunkMap map[string]*layout.Chunk) *layou
 		rowGroup.RowGroupHeader.Columns = append(rowGroup.RowGroupHeader.Columns, chunk.ChunkHeader)
 	}
 	rowGroup.RowGroupHeader.NumRows = pw.numRows
+	rowGroup.RowGroupHeader.SortingColumns = cloneSortingColumns(pw.sortingColumns)
 	pw.numRows = 0
 	return rowGroup
 }

--- a/writer/sorting.go
+++ b/writer/sorting.go
@@ -1,0 +1,60 @@
+package writer
+
+import (
+	"fmt"
+
+	"github.com/hangxie/parquet-go/v3/parquet"
+)
+
+// WithSortingColumns declares the ordering of rows within every row group.
+// ColumnIdx is the zero-based leaf-column ordinal. The writer records this
+// metadata but does not sort or verify the rows supplied by the caller.
+func WithSortingColumns(columns ...*parquet.SortingColumn) WriterOption {
+	return writerOptionFunc(func(pw *ParquetWriter) {
+		pw.sortingColumns = make([]*parquet.SortingColumn, len(columns))
+		seen := make(map[int32]struct{}, len(columns))
+		for i, column := range columns {
+			if column == nil {
+				pw.optionErrors = append(pw.optionErrors, fmt.Errorf("WithSortingColumns: sorting column %d is nil", i))
+				continue
+			}
+			if column.ColumnIdx < 0 {
+				pw.optionErrors = append(pw.optionErrors, fmt.Errorf("WithSortingColumns: sorting column %d column index must be non-negative, got %d", i, column.ColumnIdx))
+			}
+			if _, ok := seen[column.ColumnIdx]; ok {
+				pw.optionErrors = append(pw.optionErrors, fmt.Errorf("WithSortingColumns: column index %d is duplicated", column.ColumnIdx))
+			}
+			seen[column.ColumnIdx] = struct{}{}
+			clonedColumn := *column
+			pw.sortingColumns[i] = &clonedColumn
+		}
+	})
+}
+
+func (pw *ParquetWriter) validateSortingColumns() error {
+	if len(pw.sortingColumns) == 0 {
+		return nil
+	}
+	if pw.SchemaHandler == nil {
+		return fmt.Errorf("WithSortingColumns: schema handler is required")
+	}
+	columnCount := pw.SchemaHandler.GetColumnNum()
+	for i, column := range pw.sortingColumns {
+		if int64(column.ColumnIdx) >= columnCount {
+			return fmt.Errorf("WithSortingColumns: sorting column %d column index %d out of range [0, %d)", i, column.ColumnIdx, columnCount)
+		}
+	}
+	return nil
+}
+
+func cloneSortingColumns(columns []*parquet.SortingColumn) []*parquet.SortingColumn {
+	if len(columns) == 0 {
+		return nil
+	}
+	cloned := make([]*parquet.SortingColumn, len(columns))
+	for i, column := range columns {
+		clonedColumn := *column
+		cloned[i] = &clonedColumn
+	}
+	return cloned
+}

--- a/writer/sorting_test.go
+++ b/writer/sorting_test.go
@@ -1,0 +1,135 @@
+package writer
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hangxie/parquet-go/v3/parquet"
+	"github.com/hangxie/parquet-go/v3/reader"
+	"github.com/hangxie/parquet-go/v3/source/writerfile"
+)
+
+func TestWithSortingColumns(t *testing.T) {
+	type row struct {
+		ID   int64  `parquet:"name=id, type=INT64"`
+		Name string `parquet:"name=name, type=BYTE_ARRAY, convertedtype=UTF8"`
+	}
+
+	columns := []*parquet.SortingColumn{
+		{ColumnIdx: 0, Descending: false, NullsFirst: true},
+		{ColumnIdx: 1, Descending: true, NullsFirst: false},
+	}
+	pw, buf, err := createTestParquetWriter(new(row), WithNP(1), WithSortingColumns(columns...))
+	require.NoError(t, err)
+
+	// The option owns its configuration after construction.
+	columns[0].ColumnIdx = 1
+	columns[1] = nil
+
+	require.NoError(t, pw.Write(row{ID: 1, Name: "a"}))
+	require.NoError(t, pw.Flush(true))
+	require.NoError(t, pw.Write(row{ID: 2, Name: "b"}))
+	require.NoError(t, pw.WriteStop())
+
+	pr, pf, err := createTestParquetReader(buf.Bytes(), new(row), reader.WithNP(1))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, pf.Close()) }()
+
+	want := []*parquet.SortingColumn{
+		{ColumnIdx: 0, Descending: false, NullsFirst: true},
+		{ColumnIdx: 1, Descending: true, NullsFirst: false},
+	}
+	require.Len(t, pr.Footer.RowGroups, 2)
+	for rowGroupIndex := range pr.Footer.RowGroups {
+		got, sortingErr := pr.RowGroupSortingColumns(rowGroupIndex)
+		require.NoError(t, sortingErr)
+		require.Equal(t, want, got)
+	}
+}
+
+func TestWithSortingColumnsValidation(t *testing.T) {
+	type row struct {
+		ID   int64  `parquet:"name=id, type=INT64"`
+		Name string `parquet:"name=name, type=BYTE_ARRAY, convertedtype=UTF8"`
+	}
+
+	tests := []struct {
+		name    string
+		columns []*parquet.SortingColumn
+		wantErr string
+	}{
+		{name: "nil column", columns: []*parquet.SortingColumn{nil}, wantErr: "sorting column 0 is nil"},
+		{name: "negative ordinal", columns: []*parquet.SortingColumn{{ColumnIdx: -1}}, wantErr: "column index must be non-negative"},
+		{name: "ordinal out of range", columns: []*parquet.SortingColumn{{ColumnIdx: 2}}, wantErr: "column index 2 out of range [0, 2)"},
+		{name: "duplicate ordinal", columns: []*parquet.SortingColumn{{ColumnIdx: 1}, {ColumnIdx: 1}}, wantErr: "column index 1 is duplicated"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, buf, err := createTestParquetWriter(new(row), WithSortingColumns(tt.columns...))
+			require.ErrorContains(t, err, tt.wantErr)
+			require.Empty(t, buf.Bytes())
+		})
+	}
+}
+
+func TestWithSortingColumnsRequiresSchema(t *testing.T) {
+	_, buf, err := createTestParquetWriter(nil, WithSortingColumns(&parquet.SortingColumn{ColumnIdx: 0}))
+	require.ErrorContains(t, err, "WithSortingColumns: schema handler is required")
+	require.Empty(t, buf.Bytes())
+}
+
+func TestSortingColumnsValidatedByAllWriters(t *testing.T) {
+	jsonSchema := `{"Tag":"name=root","Fields":[{"Tag":"name=id, type=INT64"}]}`
+	arrowSchema := arrow.NewSchema([]arrow.Field{{Name: "id", Type: arrow.PrimitiveTypes.Int64}}, nil)
+	invalid := WithSortingColumns(&parquet.SortingColumn{ColumnIdx: 1})
+
+	tests := []struct {
+		name string
+		new  func() (*bytes.Buffer, error)
+	}{
+		{
+			name: "ParquetWriter JSON schema",
+			new: func() (*bytes.Buffer, error) {
+				buf := new(bytes.Buffer)
+				_, err := NewParquetWriter(writerfile.NewWriterFile(buf), jsonSchema, invalid)
+				return buf, err
+			},
+		},
+		{
+			name: "JSONWriter",
+			new: func() (*bytes.Buffer, error) {
+				buf := new(bytes.Buffer)
+				_, err := NewJSONWriter(jsonSchema, writerfile.NewWriterFile(buf), invalid)
+				return buf, err
+			},
+		},
+		{
+			name: "CSVWriter",
+			new: func() (*bytes.Buffer, error) {
+				buf := new(bytes.Buffer)
+				_, err := NewCSVWriter([]string{"name=id, type=INT64"}, writerfile.NewWriterFile(buf), invalid)
+				return buf, err
+			},
+		},
+		{
+			name: "ArrowWriter",
+			new: func() (*bytes.Buffer, error) {
+				buf := new(bytes.Buffer)
+				_, err := NewArrowWriter(arrowSchema, writerfile.NewWriterFile(buf), invalid)
+				return buf, err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf, err := tt.new()
+			require.ErrorContains(t, err, "column index 1 out of range [0, 1)")
+			require.Empty(t, buf.Bytes())
+		})
+	}
+}

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -122,6 +122,7 @@ type ParquetWriter struct {
 	columnCompressors             map[string]*compress.Compressor
 	dataPageVersion               int32 // 1 for DATA_PAGE (default), 2 for DATA_PAGE_V2
 	writeCRC                      bool  // compute and write CRC32 checksums on pages (default false)
+	sortingColumns                []*parquet.SortingColumn
 	encryptionConfig              *EncryptionConfig
 	encryptionState               *encryptionState
 	optionErrors                  []error
@@ -172,13 +173,13 @@ func NewParquetWriterFromWriterWithContext(ctx context.Context, w io.Writer, obj
 	return NewParquetWriterWithContext(ctx, wf, obj, opts...)
 }
 
-// initBase sets up the ParquetWriter with defaults, applies and validates
-// constructor options, and writes the magic header. It writes PARE when
-// encryption is enabled with an encrypted footer, otherwise PAR1. Options are
-// validated before any IO so that invalid options never produce partial output.
+// initBase sets up the ParquetWriter with defaults and applies and validates
+// constructor options. It performs no IO so constructors can finish schema and
+// schema-dependent validation before writing the magic header.
 //
-// Callers must still set SchemaHandler, marshalFunc, call initBloomFilters,
-// and set stopped = false after successful schema init.
+// Callers must still set SchemaHandler and marshalFunc, finish constructor
+// validation and initialization, call writeMagicHeader, and set stopped to
+// false.
 func (pw *ParquetWriter) initBase(ctx context.Context, pFile source.ParquetFileWriter, opts ...WriterOption) error {
 	pw.defaultCtx = ctx
 	if err := pw.setContext(ctx); err != nil {
@@ -263,14 +264,16 @@ func (pw *ParquetWriter) initBase(ctx context.Context, pFile source.ParquetFileW
 		pw.encryptionState = state
 	}
 
+	return nil
+}
+
+func (pw *ParquetWriter) writeMagicHeader() error {
 	magic := common.MagicBytes
 	if pw.encryptionState != nil && !pw.encryptionState.plaintextFooter {
 		magic = common.MagicBytesEncrypted
 	}
-	if _, err := pw.write([]byte(magic)); err != nil {
-		return fmt.Errorf("write magic header: %w", err)
-	}
-	return nil
+	_, err := pw.write([]byte(magic))
+	return err
 }
 
 // buildColumnCompressors creates per-column compressors for columns that specify
@@ -339,6 +342,7 @@ func NewParquetWriterWithContext(ctx context.Context, pFile source.ParquetFileWr
 		return nil, fmt.Errorf("init writer base: %w", err)
 	}
 	res.marshalFunc = marshal.Marshal
+	sortingColumnsValidated := false
 
 	if obj != nil {
 		if sa, ok := obj.(string); ok {
@@ -346,6 +350,7 @@ func NewParquetWriterWithContext(ctx context.Context, pFile source.ParquetFileWr
 			if err := res.SetSchemaHandlerFromJSON(sa); err != nil {
 				return nil, fmt.Errorf("set schema from JSON: %w", err)
 			}
+			sortingColumnsValidated = true
 		} else {
 			var err error
 			if sa, ok := obj.(*schema.SchemaHandler); ok {
@@ -364,11 +369,19 @@ func NewParquetWriterWithContext(ctx context.Context, pFile source.ParquetFileWr
 	if err := res.buildColumnCompressors(); err != nil {
 		return nil, fmt.Errorf("build column compressors: %w", err)
 	}
+	if !sortingColumnsValidated {
+		if err := res.validateSortingColumns(); err != nil {
+			return nil, fmt.Errorf("validate sorting columns: %w", err)
+		}
+	}
 	if err := res.initBloomFilters(); err != nil {
 		return nil, fmt.Errorf("init bloom filters: %w", err)
 	}
 	if err := res.validateEncryptionColumnKeys(); err != nil {
 		return nil, fmt.Errorf("validate encryption column keys: %w", err)
+	}
+	if err := res.writeMagicHeader(); err != nil {
+		return nil, fmt.Errorf("write magic header: %w", err)
 	}
 
 	// Enable writing after init completed successfully
@@ -415,6 +428,9 @@ func (pw *ParquetWriter) SetSchemaHandlerFromJSON(jsonSchema string) error {
 	pw.Footer.Schema = append(pw.Footer.Schema, pw.SchemaHandler.SchemaElements...)
 	if err := pw.buildColumnCompressors(); err != nil {
 		return fmt.Errorf("build column compressors: %w", err)
+	}
+	if err := pw.validateSortingColumns(); err != nil {
+		return fmt.Errorf("validate sorting columns: %w", err)
 	}
 	if err := pw.initBloomFilters(); err != nil {
 		return fmt.Errorf("init bloom filters: %w", err)


### PR DESCRIPTION
## Summary

- add `writer.WithSortingColumns` with schema-aware ordinal validation
- validate constructor configuration before destination I/O, leaving failed outputs untouched
- write independent sorting-column metadata to every row group
- expose row-group sorting metadata through `ParquetReader.RowGroupSortingColumns`
- document the APIs and cover round-trip, validation, defensive-copy, and no-partial-output behavior

## Testing

- `make all`

Closes #367