### PR TITLE
feat(writer): compute column index boundary order

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ Encoding notes:
 - `writer.WithDataPageVersion(2)` applies to both dictionary-encoded and plain data pages.
 - Use `omitstats=true` in a field tag to skip statistics for large array fields.
 - Whenever min/max statistics are available, the current `min_value`/`max_value` fields are written. The deprecated `min`/`max` fields (PARQUET-251) are limited to signed sort orders; for unsigned-ordered columns (e.g. `BYTE_ARRAY`/UTF8 and unsigned integer logical types) they are omitted so legacy readers do not misinterpret them.
+- Column indexes advertise `ASCENDING` or `DESCENDING` boundary order when both page-level minimum and maximum bounds are monotonic under the column's Parquet sort order. Null-only pages are ignored when determining the order; `FLOAT`/`DOUBLE` NaN bounds and other non-monotonic bound sequences are marked `UNORDERED`.
 
 ### Binary statistics bound truncation
 

--- a/writer/pages.go
+++ b/writer/pages.go
@@ -2,8 +2,10 @@ package writer
 
 import (
 	"fmt"
+	"math"
 	"sync"
 
+	"github.com/hangxie/parquet-go/v3/common"
 	"github.com/hangxie/parquet-go/v3/internal/compress"
 	"github.com/hangxie/parquet-go/v3/internal/layout"
 	"github.com/hangxie/parquet-go/v3/parquet"
@@ -188,16 +190,68 @@ func pageIsAllNull(page *layout.Page) bool {
 	return hist[len(hist)-1] == 0
 }
 
-// recordDataPage fills the ColumnIndex/OffsetIndex entries for one data page.
-// It returns hasValidBounds=false when the page is a non-null page that carries
-// no min/max (statistics omitted, or a type such as GEOMETRY/GEOGRAPHY/INTERVAL
-// that intentionally has none). The caller must not emit a ColumnIndex whose
-// non-null pages lack bounds: the Parquet spec requires min_values[i]/
-// max_values[i] to be valid whenever null_pages[i] is false, so an index with
-// empty bounds there would make predicate-pushdown readers skip matching rows.
-func (pw *ParquetWriter) recordDataPage(page *layout.Page, columnIndex *parquet.ColumnIndex, offsetIndex *parquet.OffsetIndex, dataPageIdx, dataPageCount int, firstRowIndex *int64) (hasValidBounds bool, err error) {
+type pageBounds struct {
+	minVal any
+	maxVal any
+}
+
+func columnIndexBoundaryOrder(schemaElement *parquet.SchemaElement, bounds []pageBounds) parquet.BoundaryOrder {
+	if schemaElement == nil || schemaElement.Type == nil {
+		return parquet.BoundaryOrder_UNORDERED
+	}
+
+	funcTable, err := common.FindFuncTable(schemaElement.Type, schemaElement.ConvertedType, schemaElement.LogicalType)
+	if err != nil {
+		return parquet.BoundaryOrder_UNORDERED
+	}
+
+	ascending, descending := true, true
+	var previousMin, previousMax any
+	seenNonNullPage := false
+	for _, page := range bounds {
+		if page.minVal == nil && page.maxVal == nil {
+			continue
+		}
+		if page.minVal == nil || page.maxVal == nil || isNaNBound(page.minVal) || isNaNBound(page.maxVal) {
+			return parquet.BoundaryOrder_UNORDERED
+		}
+		if seenNonNullPage {
+			ascending = ascending && !funcTable.LessThan(page.minVal, previousMin) && !funcTable.LessThan(page.maxVal, previousMax)
+			descending = descending && !funcTable.LessThan(previousMin, page.minVal) && !funcTable.LessThan(previousMax, page.maxVal)
+			if !ascending && !descending {
+				return parquet.BoundaryOrder_UNORDERED
+			}
+		}
+		previousMin, previousMax = page.minVal, page.maxVal
+		seenNonNullPage = true
+	}
+	if ascending {
+		return parquet.BoundaryOrder_ASCENDING
+	}
+	if descending {
+		return parquet.BoundaryOrder_DESCENDING
+	}
+	return parquet.BoundaryOrder_UNORDERED
+}
+
+func isNaNBound(value any) bool {
+	switch value := value.(type) {
+	case float32:
+		return math.IsNaN(float64(value))
+	case float64:
+		return math.IsNaN(value)
+	default:
+		return false
+	}
+}
+
+// recordDataPage records one data page in the column and offset indexes and
+// returns its bounds for order detection. A non-null page without min/max
+// invalidates the ColumnIndex because the Parquet spec requires valid bounds
+// whenever null_pages[i] is false.
+func (pw *ParquetWriter) recordDataPage(page *layout.Page, columnIndex *parquet.ColumnIndex, offsetIndex *parquet.OffsetIndex, dataPageIdx, dataPageCount int, firstRowIndex *int64) (bounds pageBounds, hasValidBounds bool, err error) {
 	if page.Header.DataPageHeader == nil && page.Header.DataPageHeaderV2 == nil {
-		return false, fmt.Errorf("unsupported data page: %s", page.Header.String())
+		return bounds, false, fmt.Errorf("unsupported data page: %s", page.Header.String())
 	}
 
 	stats := extractPageStats(page)
@@ -224,6 +278,13 @@ func (pw *ParquetWriter) recordDataPage(page *layout.Page, columnIndex *parquet.
 		}
 		columnIndex.MinValues[dataPageIdx] = minValue
 		columnIndex.MaxValues[dataPageIdx] = maxValue
+		bounds = pageBounds{minVal: page.MinVal, maxVal: page.MaxVal}
+		if page.Schema != nil && page.Schema.Type != nil &&
+			(*page.Schema.Type == parquet.Type_BYTE_ARRAY || *page.Schema.Type == parquet.Type_FIXED_LEN_BYTE_ARRAY) {
+			// Binary bounds may be truncated, so compare the values actually
+			// serialized into the ColumnIndex rather than the exact page extrema.
+			bounds = pageBounds{minVal: string(minValue), maxVal: string(maxValue)}
+		}
 	}
 	if stats.nullCount != nil {
 		if columnIndex.NullCounts == nil {
@@ -252,7 +313,7 @@ func (pw *ParquetWriter) recordDataPage(page *layout.Page, columnIndex *parquet.
 	// Parquet spec first_row_index counts repetition-level-0 entries, which
 	// differs from NumValues for columns under repeated (LIST/MAP) fields.
 	*firstRowIndex += page.NumRows
-	return hasValidBounds, nil
+	return bounds, hasValidBounds, nil
 }
 
 func (pw *ParquetWriter) writeChunkPages(chunk *layout.Chunk, rowGroupOrdinal, columnOrdinal int16) error {
@@ -288,6 +349,8 @@ func (pw *ParquetWriter) writeChunkPages(chunk *layout.Chunk, rowGroupOrdinal, c
 	firstRowIndex := int64(0)
 	dataPageIdx := 0
 	columnIndexValid := true
+	dataPageBounds := make([]pageBounds, 0, dataPageCount)
+	var dataPageSchema *parquet.SchemaElement
 
 	for _, page := range pages {
 		pageOrdinal := int16(dataPageIdx)
@@ -307,10 +370,14 @@ func (pw *ParquetWriter) writeChunkPages(chunk *layout.Chunk, rowGroupOrdinal, c
 			chunk.ChunkHeader.MetaData.TotalCompressedSize += int64(len(page.RawData) - plainRawLen)
 		}
 		if isDataPage {
-			hasValidBounds, err := pw.recordDataPage(page, columnIndex, offsetIndex, dataPageIdx, dataPageCount, &firstRowIndex)
+			bounds, hasValidBounds, err := pw.recordDataPage(page, columnIndex, offsetIndex, dataPageIdx, dataPageCount, &firstRowIndex)
 			if err != nil {
 				return fmt.Errorf("record data page %d: %w", dataPageIdx, err)
 			}
+			if dataPageSchema == nil {
+				dataPageSchema = page.Schema
+			}
+			dataPageBounds = append(dataPageBounds, bounds)
 			if !hasValidBounds {
 				columnIndexValid = false
 			}
@@ -328,6 +395,8 @@ func (pw *ParquetWriter) writeChunkPages(chunk *layout.Chunk, rowGroupOrdinal, c
 	// unset, which is spec-valid and keeps the per-chunk slot alignment intact.
 	if !columnIndexValid {
 		pw.columnIndexes[columnIndexSlot] = nil
+	} else {
+		columnIndex.BoundaryOrder = columnIndexBoundaryOrder(dataPageSchema, dataPageBounds)
 	}
 	return nil
 }

--- a/writer/pages_test.go
+++ b/writer/pages_test.go
@@ -3,6 +3,7 @@ package writer
 import (
 	"bytes"
 	"fmt"
+	"math"
 	"strings"
 	"testing"
 
@@ -74,6 +75,188 @@ func TestExtractPageStats(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestColumnIndexBoundaryOrderCalculation(t *testing.T) {
+	tests := []struct {
+		name   string
+		schema *parquet.SchemaElement
+		bounds []pageBounds
+		want   parquet.BoundaryOrder
+	}{
+		{
+			name:   "ascending",
+			schema: &parquet.SchemaElement{Type: common.ToPtr(parquet.Type_INT32)},
+			bounds: []pageBounds{{minVal: int32(1), maxVal: int32(2)}, {minVal: int32(3), maxVal: int32(4)}, {minVal: int32(3), maxVal: int32(5)}},
+			want:   parquet.BoundaryOrder_ASCENDING,
+		},
+		{
+			name:   "descending",
+			schema: &parquet.SchemaElement{Type: common.ToPtr(parquet.Type_INT32)},
+			bounds: []pageBounds{{minVal: int32(5), maxVal: int32(6)}, {minVal: int32(3), maxVal: int32(4)}, {minVal: int32(1), maxVal: int32(2)}},
+			want:   parquet.BoundaryOrder_DESCENDING,
+		},
+		{
+			name:   "unordered_when_only_minima_are_monotonic",
+			schema: &parquet.SchemaElement{Type: common.ToPtr(parquet.Type_INT32)},
+			bounds: []pageBounds{{minVal: int32(1), maxVal: int32(4)}, {minVal: int32(2), maxVal: int32(6)}, {minVal: int32(3), maxVal: int32(5)}},
+			want:   parquet.BoundaryOrder_UNORDERED,
+		},
+		{
+			name:   "equal_bounds_prefer_ascending",
+			schema: &parquet.SchemaElement{Type: common.ToPtr(parquet.Type_BYTE_ARRAY)},
+			bounds: []pageBounds{{minVal: "same", maxVal: "same"}, {minVal: "same", maxVal: "same"}},
+			want:   parquet.BoundaryOrder_ASCENDING,
+		},
+		{
+			name:   "null_pages_do_not_break_ordering",
+			schema: &parquet.SchemaElement{Type: common.ToPtr(parquet.Type_BYTE_ARRAY)},
+			bounds: []pageBounds{{minVal: "a", maxVal: "b"}, {}, {minVal: "c", maxVal: "d"}},
+			want:   parquet.BoundaryOrder_ASCENDING,
+		},
+		{
+			name:   "all_null_pages_are_ascending",
+			schema: &parquet.SchemaElement{Type: common.ToPtr(parquet.Type_INT32)},
+			bounds: []pageBounds{{}, {}},
+			want:   parquet.BoundaryOrder_ASCENDING,
+		},
+		{
+			name: "unsigned_logical_integer",
+			schema: &parquet.SchemaElement{
+				Type:        common.ToPtr(parquet.Type_INT32),
+				LogicalType: &parquet.LogicalType{INTEGER: &parquet.IntType{BitWidth: 32, IsSigned: false}},
+			},
+			bounds: []pageBounds{
+				{minVal: int32(-2147483648), maxVal: int32(-2147483647)},
+				{minVal: int32(-1), maxVal: int32(-1)},
+			},
+			want: parquet.BoundaryOrder_ASCENDING,
+		},
+		{
+			name:   "nan_bound",
+			schema: &parquet.SchemaElement{Type: common.ToPtr(parquet.Type_FLOAT)},
+			bounds: []pageBounds{{minVal: float32(1), maxVal: float32(2)}, {minVal: float32(math.NaN()), maxVal: float32(3)}},
+			want:   parquet.BoundaryOrder_UNORDERED,
+		},
+		{
+			name:   "nan_double_bound",
+			schema: &parquet.SchemaElement{Type: common.ToPtr(parquet.Type_DOUBLE)},
+			bounds: []pageBounds{{minVal: float64(1), maxVal: float64(2)}, {minVal: float64(3), maxVal: math.NaN()}},
+			want:   parquet.BoundaryOrder_UNORDERED,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, columnIndexBoundaryOrder(tt.schema, tt.bounds))
+		})
+	}
+}
+
+func TestColumnIndexBoundaryOrder(t *testing.T) {
+	type Entry struct {
+		Value int32 `parquet:"name=value, type=INT32"`
+	}
+
+	tests := []struct {
+		name   string
+		values []int32
+		want   parquet.BoundaryOrder
+	}{
+		{name: "ascending", values: []int32{1, 2, 3, 4, 5, 6, 7, 8}, want: parquet.BoundaryOrder_ASCENDING},
+		{name: "descending", values: []int32{8, 7, 6, 5, 4, 3, 2, 1}, want: parquet.BoundaryOrder_DESCENDING},
+		{name: "unordered", values: []int32{1, 2, 7, 8, 3, 4, 5, 6}, want: parquet.BoundaryOrder_UNORDERED},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pw, buf, err := createTestParquetWriter(new(Entry), WithNP(1), WithPageSize(8))
+			require.NoError(t, err)
+			for _, value := range tt.values {
+				require.NoError(t, pw.Write(Entry{Value: value}))
+			}
+			require.NoError(t, pw.WriteStop())
+
+			pr, pf, err := createTestParquetReader(buf.Bytes(), new(Entry), reader.WithNP(1))
+			require.NoError(t, err)
+			defer func() { require.NoError(t, pf.Close()) }()
+
+			chunk := pr.Footer.RowGroups[0].Columns[0]
+			index, err := readColumnIndex(pr.PFile, *chunk.ColumnIndexOffset)
+			require.NoError(t, err)
+			require.Greater(t, len(index.MinValues), 1)
+			require.Equal(t, tt.want, index.BoundaryOrder)
+		})
+	}
+}
+
+func TestDictionaryColumnIndexBoundaryOrder(t *testing.T) {
+	t.Run("utf8", func(t *testing.T) {
+		type Entry struct {
+			Value string `parquet:"name=value, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
+		}
+
+		pw, buf, err := createTestParquetWriter(new(Entry), WithNP(1), WithPageSize(8))
+		require.NoError(t, err)
+		for _, value := range []string{"azzz", "azzz", "baaa", "baaa", "czzz", "czzz", "daaa", "daaa"} {
+			require.NoError(t, pw.Write(Entry{Value: value}))
+		}
+		require.NoError(t, pw.WriteStop())
+
+		pr, pf, err := createTestParquetReader(buf.Bytes(), new(Entry), reader.WithNP(1))
+		require.NoError(t, err)
+		defer func() { require.NoError(t, pf.Close()) }()
+		chunk := pr.Footer.RowGroups[0].Columns[0]
+		index, err := readColumnIndex(pr.PFile, *chunk.ColumnIndexOffset)
+		require.NoError(t, err)
+		require.Greater(t, len(index.MinValues), 1)
+		require.Equal(t, parquet.BoundaryOrder_ASCENDING, index.BoundaryOrder)
+	})
+
+	t.Run("unsigned_int32", func(t *testing.T) {
+		type Entry struct {
+			Value uint32 `parquet:"name=value, type=INT32, convertedtype=UINT_32, encoding=PLAIN_DICTIONARY"`
+		}
+
+		pw, buf, err := createTestParquetWriter(new(Entry), WithNP(1), WithPageSize(8))
+		require.NoError(t, err)
+		values := []uint32{0x7ffffffe, 0x7ffffffe, 0x7fffffff, 0x7fffffff, 0x80000000, 0x80000000, 0xffffffff, 0xffffffff}
+		for _, value := range values {
+			require.NoError(t, pw.Write(Entry{Value: value}))
+		}
+		require.NoError(t, pw.WriteStop())
+
+		pr, pf, err := createTestParquetReader(buf.Bytes(), new(Entry), reader.WithNP(1))
+		require.NoError(t, err)
+		defer func() { require.NoError(t, pf.Close()) }()
+		chunk := pr.Footer.RowGroups[0].Columns[0]
+		index, err := readColumnIndex(pr.PFile, *chunk.ColumnIndexOffset)
+		require.NoError(t, err)
+		require.Greater(t, len(index.MinValues), 1)
+		require.Equal(t, parquet.BoundaryOrder_ASCENDING, index.BoundaryOrder)
+	})
+}
+
+func TestNaNColumnIndexBoundaryOrder(t *testing.T) {
+	type Entry struct {
+		Value float32 `parquet:"name=value, type=FLOAT"`
+	}
+
+	pw, buf, err := createTestParquetWriter(new(Entry), WithNP(1), WithPageSize(8))
+	require.NoError(t, err)
+	for _, value := range []float32{1, 2, float32(math.NaN()), 3} {
+		require.NoError(t, pw.Write(Entry{Value: value}))
+	}
+	require.NoError(t, pw.WriteStop())
+
+	pr, pf, err := createTestParquetReader(buf.Bytes(), new(Entry), reader.WithNP(1))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, pf.Close()) }()
+	chunk := pr.Footer.RowGroups[0].Columns[0]
+	index, err := readColumnIndex(pr.PFile, *chunk.ColumnIndexOffset)
+	require.NoError(t, err)
+	require.Greater(t, len(index.MinValues), 1)
+	require.Equal(t, parquet.BoundaryOrder_UNORDERED, index.BoundaryOrder)
 }
 
 // TestOffsetIndexFirstRowIndex verifies that PageLocation.first_row_index


### PR DESCRIPTION
## Summary

- compute ascending and descending ColumnIndex boundary order from page bounds using the column sort order
- ignore null-only pages and conservatively mark NaN or non-monotonic bounds unordered
- preserve correct ordering for dictionary-encoded, unsigned, and truncated binary columns
- avoid decoding serialized bounds again by retaining typed page bounds

## Testing

- add table-driven boundary-order tests
- add serialized multi-page tests for plain, dictionary-encoded UTF8, unsigned INT32, and NaN columns
- make all

Closes #368