### PR TITLE
fix: read parquet-mr files (unnamed root schema, Hadoop LZ4 framing, V2 page levels)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ This document defines expectations for contributors to the parquet-go library pr
 - Follow idiomatic Go style; run `gofumpt`/`goimports` on changes.
 - Handle errors explicitly and return meaningful error messages.
 - Write concise, clear code comments explaining intent or non-obvious reasoning; do not restate what the code already says.
+- Keep declaration comments to one line and put longer reasoning in the function body next to the code it explains; question any comment past three lines, as it usually means the code should be clearer.
 - Use `context.Context` for cancellable operations.
 - Avoid leaking goroutines or unnecessary memory allocations.
 - Maintain clean public API surfaces; avoid exposing internal details.

--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ Compression notes:
 - Set a file-level codec with `writer.WithCompressionCodec`.
 - Set a per-column codec with a struct tag such as `parquet:"name=col, compression=GZIP"`.
 - Set codec-level compression levels with `writer.WithCompressionLevel(codec, level)`. All columns using that codec share the same level.
-- `LZ4` uses the legacy framed LZ4 format. `LZ4_RAW` uses raw LZ4 blocks and is the preferred LZ4 variant in the Parquet specification.
+- `LZ4` is deprecated and ambiguous: files in the wild carry either the framed LZ4 format or the Hadoop block framing that parquet-mr writes. Reads accept both, detected from the payload. Writes always emit the framed format, so a file written with `LZ4` is not readable by parquet-mr or Arrow. Use `LZ4_RAW`, which uses raw LZ4 blocks and is the preferred LZ4 variant in the Parquet specification.
 - Compression codecs enforce decompressed size limits, defaulting to 256 MB, via `compress.WithMaxDecompressedSize`.
 
 ## Readers and Writers

--- a/internal/compress/lz4.go
+++ b/internal/compress/lz4.go
@@ -5,6 +5,8 @@ package compress
 
 import (
 	"bytes"
+	"encoding/binary"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -46,10 +48,137 @@ func lz4Compress(pool *sync.Pool) func([]byte) ([]byte, error) {
 	}
 }
 
+// errNotHadoopLZ4 reports that a payload is not Hadoop framed, so another framing should be tried.
+var errNotHadoopLZ4 = errors.New("not hadoop lz4 framing")
+
+// hadoopLZ4LengthSize is the size of the length prefixing a block or a chunk.
+const hadoopLZ4LengthSize = 4
+
+// hadoopLZ4MaxExpansion bounds how far a raw LZ4 block can expand.
+const hadoopLZ4MaxExpansion = 255
+
+// hadoopLZ4Length reads a block or chunk length prefix.
+func hadoopLZ4Length(buf []byte) int64 {
+	// Hadoop's rawReadInt puts these in a Java int, so the high bit means negative
+	// and invalid rather than a length past 2GiB.
+	return int64(int32(binary.BigEndian.Uint32(buf[0:4])))
+}
+
+// hadoopLZ4Uncompress decodes the Hadoop LZ4 framing that parquet-mr writes for the deprecated LZ4 codec.
+func hadoopLZ4Uncompress(buf []byte, maxSize int64) ([]byte, error) {
+	// A block length, then chunks each prefixed by their own length. Every length
+	// is checked against the payload so an LZ4 frame is rejected, not decoded.
+	var res []byte
+	var total int64
+
+	// The smallest thing Hadoop writes is an empty block's four-byte zero length.
+	if len(buf) == 0 {
+		return nil, fmt.Errorf("empty payload: %w", errNotHadoopLZ4)
+	}
+
+	for len(buf) > 0 {
+		if len(buf) < hadoopLZ4LengthSize {
+			return nil, fmt.Errorf("truncated block length: %w", errNotHadoopLZ4)
+		}
+		blockLen := hadoopLZ4Length(buf)
+		buf = buf[hadoopLZ4LengthSize:]
+
+		if blockLen < 0 {
+			return nil, fmt.Errorf("negative block length %d: %w", blockLen, errNotHadoopLZ4)
+		}
+
+		// BlockDecompressorStream reads a zero length as EOF, so bytes behind one
+		// are bytes Hadoop would never return.
+		if blockLen == 0 {
+			if len(buf) > 0 {
+				return nil, fmt.Errorf("%d bytes remain after the zero block length that ends the stream: %w",
+					len(buf), errNotHadoopLZ4)
+			}
+			break
+		}
+
+		// Judged before the size limit: a limit error for a buffer that was never
+		// Hadoop framed would suppress the frame fallback.
+		if blockLen > int64(len(buf))*hadoopLZ4MaxExpansion {
+			return nil, fmt.Errorf("block length %d exceeds what %d remaining bytes can produce: %w",
+				blockLen, len(buf), errNotHadoopLZ4)
+		}
+
+		total += blockLen
+		if maxSize > 0 && total > maxSize {
+			return nil, fmt.Errorf("decompressed data (%d bytes) exceeds maximum size %d: %w",
+				total, maxSize, ErrDecompressedSizeExceeded)
+		}
+
+		// The block declares its decompressed size, so grow it onto the result and
+		// let its chunks decode straight into it.
+		start := int64(len(res))
+		res = append(res, make([]byte, blockLen)...)
+
+		var err error
+		if buf, err = fillHadoopLZ4Block(buf, res[start:start+blockLen:start+blockLen]); err != nil {
+			return nil, err
+		}
+	}
+
+	return res, nil
+}
+
+// fillHadoopLZ4Block decodes chunks into block until it is full, returning what is left of buf.
+func fillHadoopLZ4Block(buf, block []byte) ([]byte, error) {
+	// A chunk that would overrun the block fails below, and a block the chunks
+	// cannot fill runs out of payload, so neither passes as Hadoop framing.
+	for filled := 0; filled < len(block); {
+		if len(buf) < hadoopLZ4LengthSize {
+			return nil, fmt.Errorf("truncated chunk length %d bytes into a %d byte block: %w",
+				filled, len(block), errNotHadoopLZ4)
+		}
+		chunkLen := hadoopLZ4Length(buf)
+		buf = buf[hadoopLZ4LengthSize:]
+		if chunkLen < 0 {
+			return nil, fmt.Errorf("negative chunk length %d: %w", chunkLen, errNotHadoopLZ4)
+		}
+		if chunkLen == 0 || chunkLen > int64(len(buf)) {
+			return nil, fmt.Errorf("chunk length %d out of range for %d remaining bytes: %w",
+				chunkLen, len(buf), errNotHadoopLZ4)
+		}
+
+		// Decoding into the unfilled tail caps a chunk at the space left.
+		count, err := lz4.UncompressBlock(buf[:chunkLen], block[filled:])
+		if err != nil || count <= 0 {
+			return nil, fmt.Errorf("decode chunk into the %d bytes left of a %d byte block (%v): %w",
+				len(block)-filled, len(block), err, errNotHadoopLZ4)
+		}
+		filled += count
+		buf = buf[chunkLen:]
+	}
+	return buf, nil
+}
+
+// lz4Uncompress decodes the deprecated LZ4 codec, which two incompatible framings share.
 func lz4Uncompress(buf []byte, maxSize int64) ([]byte, error) {
-	rbuf := bytes.NewReader(buf)
-	lz4Reader := lz4.NewReader(rbuf)
-	return limitedReadAll(lz4Reader, maxSize)
+	// Frame first: a frame is self-describing, while its magic doubles as a valid
+	// Hadoop block length (69356824), so the reverse order would misclassify.
+	res, frameErr := limitedReadAll(lz4.NewReader(bytes.NewReader(buf)), maxSize)
+	if frameErr == nil {
+		return res, nil
+	}
+	// Only a real frame decodes far enough to breach the limit, so report that
+	// rather than letting the Hadoop decoder reinterpret the same bytes.
+	if errors.Is(frameErr, ErrDecompressedSizeExceeded) {
+		return nil, frameErr
+	}
+
+	res, err := hadoopLZ4Uncompress(buf, maxSize)
+	if err == nil {
+		return res, nil
+	}
+	if errors.Is(err, ErrDecompressedSizeExceeded) {
+		return nil, err
+	}
+	// The frame error leads, but a truncated parquet-mr page needs the Hadoop
+	// diagnosis too: alone, the frame error names the wrong framing entirely.
+	return nil, errors.Join(frameErr, err)
 }
 
 func lz4CompressWithLevel(pool *sync.Pool, cl lz4.CompressionLevel) func([]byte) ([]byte, error) {

--- a/internal/compress/lz4_test.go
+++ b/internal/compress/lz4_test.go
@@ -1,6 +1,9 @@
 package compress
 
 import (
+	"bytes"
+	"crypto/rand"
+	"encoding/binary"
 	"sync"
 	"testing"
 
@@ -81,4 +84,261 @@ func TestCodec_LZ4(t *testing.T) {
 
 	_, err = c.Uncompress([]byte{0}, parquet.CompressionCodec_LZ4)
 	require.Contains(t, err.Error(), "unexpected EOF")
+}
+
+// hadoopLZ4Block builds one Hadoop-framed block from the given chunks.
+func hadoopLZ4Block(t *testing.T, chunks ...[]byte) []byte {
+	t.Helper()
+
+	// The block's total uncompressed length, then every chunk prefixed by its own
+	// compressed length. More than one chunk is what Hadoop emits past its buffer.
+	var body []byte
+	var uncompressedLen int
+	for _, chunk := range chunks {
+		compressed := make([]byte, lz4.CompressBlockBound(len(chunk)))
+		var compressor lz4.Compressor
+		n, err := compressor.CompressBlock(chunk, compressed)
+		require.NoError(t, err)
+		require.NotZero(t, n, "chunk did not compress, test data is too small")
+
+		header := make([]byte, 4)
+		binary.BigEndian.PutUint32(header, uint32(n))
+		body = append(body, header...)
+		body = append(body, compressed[:n]...)
+		uncompressedLen += len(chunk)
+	}
+
+	res := make([]byte, 4)
+	binary.BigEndian.PutUint32(res, uint32(uncompressedLen))
+	return append(res, body...)
+}
+
+func TestCodec_LZ4_HadoopFraming(t *testing.T) {
+	c := DefaultCompressor()
+	first := bytes.Repeat([]byte("hadoop lz4 chunk one "), 16)
+	second := bytes.Repeat([]byte("hadoop lz4 chunk two "), 16)
+	both := append(append([]byte(nil), first...), second...)
+
+	t.Run("single chunk block", func(t *testing.T) {
+		got, err := c.Uncompress(hadoopLZ4Block(t, first), parquet.CompressionCodec_LZ4)
+		require.NoError(t, err)
+		require.Equal(t, first, got)
+	})
+
+	t.Run("multiple chunks in one block", func(t *testing.T) {
+		// What Hadoop emits past its codec buffer: one block length covering
+		// chunks that each carry only their own compressed length.
+		got, err := c.Uncompress(hadoopLZ4Block(t, first, second), parquet.CompressionCodec_LZ4)
+		require.NoError(t, err)
+		require.Equal(t, both, got)
+	})
+
+	t.Run("multiple blocks concatenate", func(t *testing.T) {
+		buf := append(hadoopLZ4Block(t, first), hadoopLZ4Block(t, second)...)
+
+		got, err := c.Uncompress(buf, parquet.CompressionCodec_LZ4)
+		require.NoError(t, err)
+		require.Equal(t, both, got)
+	})
+
+	t.Run("empty block marker", func(t *testing.T) {
+		// finish() writes a bare zero length when the compressor buffered nothing.
+		got, err := c.Uncompress([]byte{0, 0, 0, 0}, parquet.CompressionCodec_LZ4)
+		require.NoError(t, err)
+		require.Empty(t, got)
+
+		// BlockDecompressorStream reads a zero length as EOF, so blocks behind one
+		// are bytes Hadoop would never return. Decoding them would disagree.
+		buf := append([]byte{0, 0, 0, 0}, hadoopLZ4Block(t, first)...)
+		_, err = c.Uncompress(buf, parquet.CompressionCodec_LZ4)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "after the zero block length")
+	})
+
+	t.Run("zero block terminates a stream that carried data", func(t *testing.T) {
+		buf := append(hadoopLZ4Block(t, first), 0, 0, 0, 0)
+		got, err := c.Uncompress(buf, parquet.CompressionCodec_LZ4)
+		require.NoError(t, err)
+		require.Equal(t, first, got)
+	})
+
+	t.Run("frame framing still round-trips", func(t *testing.T) {
+		framed, err := c.Compress(first, parquet.CompressionCodec_LZ4)
+		require.NoError(t, err)
+
+		got, err := c.Uncompress(framed, parquet.CompressionCodec_LZ4)
+		require.NoError(t, err)
+		require.Equal(t, first, got)
+	})
+
+	t.Run("frame framing round-trips under a size limit", func(t *testing.T) {
+		// Under 69356824, a frame's magic read as a Hadoop block length, where a
+		// size error could wrongly skip the frame fallback.
+		incompressible := make([]byte, 400_000)
+		_, err := rand.Read(incompressible)
+		require.NoError(t, err)
+
+		for _, tc := range []struct {
+			name string
+			data []byte
+		}{
+			{"tiny", first},
+			{"compressible", bytes.Repeat([]byte("large payload "), 20_000)},
+			// Big enough to clear the expansion guard, leaving the magic as
+			// the only thing that can reject it.
+			{"incompressible", incompressible},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				limited, err := NewCompressor(WithMaxDecompressedSize(1 << 20))
+				require.NoError(t, err)
+
+				framed, err := limited.Compress(tc.data, parquet.CompressionCodec_LZ4)
+				require.NoError(t, err)
+
+				got, err := limited.Uncompress(framed, parquet.CompressionCodec_LZ4)
+				require.NoError(t, err)
+				require.Equal(t, tc.data, got)
+			})
+		}
+	})
+
+	t.Run("block length must match chunk contents", func(t *testing.T) {
+		// A block larger than its chunks decode to runs out of payload, and is no
+		// valid frame either, so it must fail rather than truncate.
+		buf := hadoopLZ4Block(t, first)
+		binary.BigEndian.PutUint32(buf[0:4], uint32(len(first)+1))
+
+		_, err := c.Uncompress(buf, parquet.CompressionCodec_LZ4)
+		require.Error(t, err)
+	})
+
+	t.Run("chunk overrunning its block is rejected", func(t *testing.T) {
+		buf := hadoopLZ4Block(t, first)
+		binary.BigEndian.PutUint32(buf[0:4], uint32(len(first)-1))
+
+		_, err := c.Uncompress(buf, parquet.CompressionCodec_LZ4)
+		require.ErrorIs(t, err, errNotHadoopLZ4)
+	})
+
+	t.Run("a corrupt hadoop payload keeps its own diagnosis", func(t *testing.T) {
+		// The frame error alone would name the framing this page was never in.
+		buf := hadoopLZ4Block(t, first)
+
+		_, err := c.Uncompress(buf[:len(buf)-4], parquet.CompressionCodec_LZ4)
+		require.ErrorIs(t, err, errNotHadoopLZ4)
+		require.Contains(t, err.Error(), "bad magic number", "frame error should still lead")
+	})
+
+	t.Run("empty payload is not hadoop framing", func(t *testing.T) {
+		// No bytes at all is a truncated stream. Reaching this needs a direct
+		// call, since lz4Uncompress decodes an empty payload as an empty frame.
+		_, err := hadoopLZ4Uncompress(nil, 1<<20)
+		require.ErrorIs(t, err, errNotHadoopLZ4)
+
+		got, err := DefaultCompressor().Uncompress(nil, parquet.CompressionCodec_LZ4)
+		require.NoError(t, err)
+		require.Empty(t, got)
+	})
+
+	t.Run("size limit is enforced", func(t *testing.T) {
+		limited, err := NewCompressor(WithMaxDecompressedSize(int64(len(first)) - 1))
+		require.NoError(t, err)
+
+		_, err = limited.Uncompress(hadoopLZ4Block(t, first), parquet.CompressionCodec_LZ4)
+		require.ErrorIs(t, err, ErrDecompressedSizeExceeded)
+	})
+}
+
+func TestHadoopLZ4Uncompress_Rejects(t *testing.T) {
+	// These guards bound allocation and settle framing, so they are driven
+	// directly rather than through payloads that happen to reach them.
+	tests := []struct {
+		name string
+		buf  []byte
+	}{
+		{
+			// More than the 255x a raw LZ4 block can manage, so no payload
+			// could produce it.
+			name: "block length beyond the maximum expansion",
+			buf:  []byte{0x00, 0x10, 0x00, 0x00, 0x01, 0x02, 0x03, 0x04},
+		},
+		{
+			name: "zero chunk length",
+			buf:  []byte{0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x01, 0x02},
+		},
+		{
+			name: "chunk length past the end of the payload",
+			buf:  []byte{0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x40, 0x01, 0x02},
+		},
+		{
+			name: "truncated block length",
+			buf:  []byte{0x00, 0x00},
+		},
+		{
+			name: "block with no chunk at all",
+			buf:  []byte{0x00, 0x00, 0x00, 0x08},
+		},
+		{
+			name: "empty payload",
+			buf:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := hadoopLZ4Uncompress(tt.buf, 1<<20)
+			require.ErrorIs(t, err, errNotHadoopLZ4)
+		})
+	}
+}
+
+// TestHadoopLZ4Uncompress_NegativeLengths covers length prefixes with the high bit set.
+func TestHadoopLZ4Uncompress_NegativeLengths(t *testing.T) {
+	// Read unsigned, 0xffffffff becomes 4294967295 rather than Hadoop's -1, and
+	// enough trailing bytes clear the expansion guard for it to be allocated.
+	tests := []struct {
+		name string
+		buf  []byte
+	}{
+		{
+			name: "negative block length",
+			buf:  []byte{0xff, 0xff, 0xff, 0xff, 0x01, 0x02, 0x03, 0x04},
+		},
+		{
+			name: "block length with only the high bit set",
+			buf:  []byte{0x80, 0x00, 0x00, 0x00, 0x01, 0x02, 0x03, 0x04},
+		},
+		{
+			name: "negative chunk length",
+			buf:  []byte{0x00, 0x00, 0x00, 0x08, 0xff, 0xff, 0xff, 0xff, 0x01, 0x02},
+		},
+		{
+			name: "chunk length with only the high bit set",
+			buf:  []byte{0x00, 0x00, 0x00, 0x08, 0x80, 0x00, 0x00, 0x00, 0x01, 0x02},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// A disabled limit leaves the length as the only bound on the
+			// allocation, so both are exercised.
+			for _, maxSize := range []int64{1 << 20, 0} {
+				_, err := hadoopLZ4Uncompress(tt.buf, maxSize)
+				require.ErrorIs(t, err, errNotHadoopLZ4)
+				require.Contains(t, err.Error(), "negative")
+			}
+		})
+	}
+}
+
+func TestLZ4Uncompress_FrameSizeLimitSkipsHadoop(t *testing.T) {
+	// A frame that breaches the limit must report that, not be handed to the
+	// Hadoop decoder to reinterpret into a different complaint.
+	c := DefaultCompressor()
+	framed, err := c.Compress(bytes.Repeat([]byte("over the limit "), 4096), parquet.CompressionCodec_LZ4)
+	require.NoError(t, err)
+
+	_, err = lz4Uncompress(framed, 1024)
+	require.ErrorIs(t, err, ErrDecompressedSizeExceeded)
+	require.NotErrorIs(t, err, errNotHadoopLZ4)
 }

--- a/internal/layout/page_read.go
+++ b/internal/layout/page_read.go
@@ -276,20 +276,22 @@ func ReadPage(thriftReader *thrift.TBufferedTransport, schemaHandler *schema.Sch
 		return nil, 0, 0, fmt.Errorf("page size %d exceeds limit %d", compressedPageSize, opt.MaxPageSize)
 	}
 
+	path := make([]string, 0)
+	path = append(path, schemaHandler.GetRootInName())
+	path = append(path, colMetaData.GetPathInSchema()...)
+	name := common.PathToStr(path)
+
 	var buf []byte
 	if pageHeader.GetType() == parquet.PageType_DATA_PAGE_V2 {
-		buf, err = readPageV2Data(thriftReader, pageHeader, colMetaData, opt.Compressor, opt)
+		maxDefinitionLevel, _ := schemaHandler.MaxDefinitionLevel(path)
+		maxRepetitionLevel, _ := schemaHandler.MaxRepetitionLevel(path)
+		buf, err = readPageV2Data(thriftReader, pageHeader, colMetaData, opt.Compressor, opt, maxRepetitionLevel, maxDefinitionLevel)
 	} else {
 		buf, err = readPageV1Data(thriftReader, pageHeader, colMetaData, opt.Compressor, opt)
 	}
 	if err != nil {
 		return nil, 0, 0, fmt.Errorf("read page data: %w", err)
 	}
-
-	path := make([]string, 0)
-	path = append(path, schemaHandler.GetRootInName())
-	path = append(path, colMetaData.GetPathInSchema()...)
-	name := common.PathToStr(path)
 
 	switch pageHeader.GetType() {
 	case parquet.PageType_DICTIONARY_PAGE:

--- a/internal/layout/page_read_body.go
+++ b/internal/layout/page_read_body.go
@@ -26,7 +26,10 @@ func readPageV2Data(thriftReader *thrift.TBufferedTransport, pageHeader *parquet
 	if dll < 0 || rll < 0 {
 		return nil, fmt.Errorf("ReadPage: invalid level byte lengths (dll=%d, rll=%d)", dll, rll)
 	}
-	if dll+rll > compressedPageSize {
+	// Widened before summing: two positive int32 lengths can wrap negative, slipping
+	// past this check and reaching make() below with a negative length.
+	levelsLen := int64(dll) + int64(rll)
+	if levelsLen > int64(compressedPageSize) {
 		return nil, fmt.Errorf("ReadPage: level byte lengths exceed page size (dll=%d + rll=%d > %d)", dll, rll, compressedPageSize)
 	}
 	if err := validateV2LevelSections(rll, dll, maxRepetitionLevel, maxDefinitionLevel,
@@ -40,7 +43,7 @@ func readPageV2Data(thriftReader *thrift.TBufferedTransport, pageHeader *parquet
 		if err != nil {
 			return nil, fmt.Errorf("read encrypted v2 body: %w", err)
 		}
-		if int32(len(plain)) < rll+dll {
+		if int64(len(plain)) < levelsLen {
 			return nil, fmt.Errorf("ReadPage: decrypted data page v2 body too small")
 		}
 		repetitionLevelsBuf = append([]byte(nil), plain[:rll]...)
@@ -49,7 +52,7 @@ func readPageV2Data(thriftReader *thrift.TBufferedTransport, pageHeader *parquet
 	} else {
 		repetitionLevelsBuf = make([]byte, rll)
 		definitionLevelsBuf = make([]byte, dll)
-		dataBuf = make([]byte, compressedPageSize-rll-dll)
+		dataBuf = make([]byte, int64(compressedPageSize)-levelsLen)
 
 		if _, err := io.ReadFull(thriftReader, repetitionLevelsBuf); err != nil {
 			return nil, fmt.Errorf("read v2 repetition levels: %w", err)
@@ -67,7 +70,7 @@ func readPageV2Data(thriftReader *thrift.TBufferedTransport, pageHeader *parquet
 	}
 
 	if pageHeader.DataPageHeaderV2.GetIsCompressed() && len(dataBuf) > 0 {
-		expectedDataSize := int64(pageHeader.GetUncompressedPageSize()) - int64(rll) - int64(dll)
+		expectedDataSize := int64(pageHeader.GetUncompressedPageSize()) - levelsLen
 		var err error
 		if dataBuf, err = resolveCompressor(c).UncompressWithExpectedSize(dataBuf, colMetaData.GetCodec(), expectedDataSize); err != nil {
 			return nil, fmt.Errorf("decompress v2 data: %w", err)

--- a/internal/layout/page_read_body.go
+++ b/internal/layout/page_read_body.go
@@ -15,7 +15,7 @@ import (
 )
 
 // readPageV2Data reads a DATA_PAGE_V2 from the reader, decompresses if needed, and reassembles with level prefixes.
-func readPageV2Data(thriftReader *thrift.TBufferedTransport, pageHeader *parquet.PageHeader, colMetaData *parquet.ColumnMetaData, c *compress.Compressor, opt PageReadOptions) ([]byte, error) {
+func readPageV2Data(thriftReader *thrift.TBufferedTransport, pageHeader *parquet.PageHeader, colMetaData *parquet.ColumnMetaData, c *compress.Compressor, opt PageReadOptions, maxRepetitionLevel, maxDefinitionLevel int32) ([]byte, error) {
 	if pageHeader.DataPageHeaderV2 == nil {
 		return nil, fmt.Errorf("ReadPage: data page v2 missing DataPageHeaderV2")
 	}
@@ -28,6 +28,10 @@ func readPageV2Data(thriftReader *thrift.TBufferedTransport, pageHeader *parquet
 	}
 	if dll+rll > compressedPageSize {
 		return nil, fmt.Errorf("ReadPage: level byte lengths exceed page size (dll=%d + rll=%d > %d)", dll, rll, compressedPageSize)
+	}
+	if err := validateV2LevelSections(rll, dll, maxRepetitionLevel, maxDefinitionLevel,
+		pageHeader.DataPageHeaderV2.GetNumValues()); err != nil {
+		return nil, err
 	}
 
 	var repetitionLevelsBuf, definitionLevelsBuf, dataBuf []byte
@@ -70,13 +74,32 @@ func readPageV2Data(thriftReader *thrift.TBufferedTransport, pageHeader *parquet
 		}
 	}
 
-	return assembleLevelPrefixedBuf(rll, dll, repetitionLevelsBuf, definitionLevelsBuf, dataBuf)
+	return assembleLevelPrefixedBuf(rll, dll, repetitionLevelsBuf, definitionLevelsBuf, dataBuf, maxRepetitionLevel, maxDefinitionLevel)
+}
+
+// validateV2LevelSections rejects a V2 page whose level sections contradict the schema.
+func validateV2LevelSections(rll, dll, maxRepetitionLevel, maxDefinitionLevel, numValues int32) error {
+	// A page holding no values has no levels to carry either way.
+	if numValues == 0 {
+		return nil
+	}
+	// Omitting required levels would have the next section read as those levels,
+	// returning garbage for every value. Only a malformed page does this.
+	if maxRepetitionLevel > 0 && rll == 0 {
+		return fmt.Errorf("data page v2 carries no repetition levels for a column with max repetition level %d", maxRepetitionLevel)
+	}
+	if maxDefinitionLevel > 0 && dll == 0 {
+		return fmt.Errorf("data page v2 carries no definition levels for a column with max definition level %d", maxDefinitionLevel)
+	}
+	return nil
 }
 
 // assembleLevelPrefixedBuf prefixes level buffers with their lengths and appends the data.
-func assembleLevelPrefixedBuf(rll, dll int32, repBuf, defBuf, dataBuf []byte) ([]byte, error) {
+func assembleLevelPrefixedBuf(rll, dll int32, repBuf, defBuf, dataBuf []byte, maxRepetitionLevel, maxDefinitionLevel int32) ([]byte, error) {
+	// Included only where the schema says those levels exist, matching what
+	// readDataPageBody reads back; writers pad the byte length even at level 0.
 	buf := make([]byte, 0)
-	if rll > 0 {
+	if rll > 0 && maxRepetitionLevel > 0 {
 		tmpBuf, err := encoding.WritePlainINT32([]any{int32(rll)})
 		if err != nil {
 			return nil, fmt.Errorf("encode repetition level length: %w", err)
@@ -84,7 +107,7 @@ func assembleLevelPrefixedBuf(rll, dll int32, repBuf, defBuf, dataBuf []byte) ([
 		buf = append(buf, tmpBuf...)
 		buf = append(buf, repBuf...)
 	}
-	if dll > 0 {
+	if dll > 0 && maxDefinitionLevel > 0 {
 		tmpBuf, err := encoding.WritePlainINT32([]any{int32(dll)})
 		if err != nil {
 			return nil, fmt.Errorf("encode definition level length: %w", err)

--- a/internal/layout/page_read_body_test.go
+++ b/internal/layout/page_read_body_test.go
@@ -19,14 +19,14 @@ func TestReadPageV2Data_InvalidLevels(t *testing.T) {
 			DefinitionLevelsByteLength: -1,
 		},
 	}
-	_, err := readPageV2Data(nil, header, nil, nil, PageReadOptions{})
+	_, err := readPageV2Data(nil, header, nil, nil, PageReadOptions{}, 1, 1)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid level byte lengths")
 
 	header.DataPageHeaderV2.DefinitionLevelsByteLength = 10
 	header.DataPageHeaderV2.RepetitionLevelsByteLength = 10
 	header.CompressedPageSize = 15
-	_, err = readPageV2Data(nil, header, nil, nil, PageReadOptions{})
+	_, err = readPageV2Data(nil, header, nil, nil, PageReadOptions{}, 1, 1)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "level byte lengths exceed page size")
 }
@@ -56,7 +56,7 @@ func TestReadPageV2Data_Compressed(t *testing.T) {
 	mem.Write(compressed)
 	thriftReader := thrift.NewTBufferedTransport(mem, 1024)
 
-	res, err := readPageV2Data(thriftReader, header, colMetaData, nil, PageReadOptions{})
+	res, err := readPageV2Data(thriftReader, header, colMetaData, nil, PageReadOptions{}, 0, 0)
 	require.NoError(t, err)
 	// res should be prefixed by 0, 0 (rll, dll) as they are 0
 	require.Equal(t, data, res)
@@ -66,17 +66,101 @@ func TestAssembleLevelPrefixedBuf_WithRll(t *testing.T) {
 	repBuf := []byte{0x01}
 	defBuf := []byte{0x02}
 	dataBuf := []byte{0x03}
-	res, err := assembleLevelPrefixedBuf(1, 1, repBuf, defBuf, dataBuf)
+	res, err := assembleLevelPrefixedBuf(1, 1, repBuf, defBuf, dataBuf, 1, 1)
 	require.NoError(t, err)
 	require.NotEmpty(t, res)
 }
 
 func TestAssembleLevelPrefixedBuf_NoLevels(t *testing.T) {
 	dataBuf := []byte{0x0A, 0x0B, 0x0C}
-	res, err := assembleLevelPrefixedBuf(0, 0, nil, nil, dataBuf)
+	res, err := assembleLevelPrefixedBuf(0, 0, nil, nil, dataBuf, 1, 1)
 	require.NoError(t, err)
 	// With no levels, only the data is returned without length prefixes.
 	require.Equal(t, dataBuf, res)
+}
+
+func TestValidateV2LevelSections(t *testing.T) {
+	// A page omitting levels the schema requires would have the following section
+	// read as those levels, returning garbage for every value.
+	tests := []struct {
+		name                                   string
+		rll, dll                               int32
+		maxRepetitionLevel, maxDefinitionLevel int32
+		numValues                              int32
+		errMsg                                 string
+	}{
+		{name: "both levels present", rll: 2, dll: 2, maxRepetitionLevel: 1, maxDefinitionLevel: 1, numValues: 1},
+		{name: "flat column carries no levels", numValues: 1},
+		{
+			name: "repetition levels missing", dll: 2,
+			maxRepetitionLevel: 1, maxDefinitionLevel: 1, numValues: 1,
+			errMsg: "carries no repetition levels",
+		},
+		{
+			name: "definition levels missing", rll: 2,
+			maxRepetitionLevel: 1, maxDefinitionLevel: 1, numValues: 1,
+			errMsg: "carries no definition levels",
+		},
+		{
+			// Nothing to carry levels for, so the sections may be absent.
+			name: "empty page is exempt", maxRepetitionLevel: 1, maxDefinitionLevel: 1, numValues: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateV2LevelSections(tt.rll, tt.dll, tt.maxRepetitionLevel, tt.maxDefinitionLevel, tt.numValues)
+			if tt.errMsg == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.errMsg)
+		})
+	}
+}
+
+func TestReadPageV2Data_RejectsPageContradictingSchema(t *testing.T) {
+	// Wires up validateV2LevelSections, so a dropped call site fails here. The nil
+	// reader proves the page is turned away before any body is read.
+	header := &parquet.PageHeader{
+		Type:                 parquet.PageType_DATA_PAGE_V2,
+		CompressedPageSize:   8,
+		UncompressedPageSize: 8,
+		DataPageHeaderV2: &parquet.DataPageHeaderV2{
+			NumValues:                  1,
+			Encoding:                   parquet.Encoding_PLAIN,
+			RepetitionLevelsByteLength: 0,
+			DefinitionLevelsByteLength: 2,
+		},
+	}
+
+	_, err := readPageV2Data(nil, header, nil, nil, PageReadOptions{}, 1, 1)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "carries no repetition levels")
+}
+
+func TestAssembleLevelPrefixedBuf_LevelsAbsentFromSchema(t *testing.T) {
+	repBuf := []byte{0x01, 0x02}
+	defBuf := []byte{0x03}
+	dataBuf := []byte{0x0A, 0x0B, 0x0C}
+
+	t.Run("repetition levels dropped when column cannot repeat", func(t *testing.T) {
+		// Writers emit a non-zero repetition_levels_byte_length even at max level 0;
+		// those bytes hold no levels and would be misread as the definition ones.
+		res, err := assembleLevelPrefixedBuf(2, 1, repBuf, defBuf, dataBuf, 0, 1)
+		require.NoError(t, err)
+
+		want := append([]byte{0x01, 0x00, 0x00, 0x00}, defBuf...)
+		want = append(want, dataBuf...)
+		require.Equal(t, want, res)
+	})
+
+	t.Run("definition levels dropped when column is required", func(t *testing.T) {
+		res, err := assembleLevelPrefixedBuf(2, 1, repBuf, defBuf, dataBuf, 0, 0)
+		require.NoError(t, err)
+		require.Equal(t, dataBuf, res)
+	})
 }
 
 func TestReadPageV1Data_Compressed(t *testing.T) {
@@ -369,7 +453,7 @@ func TestReadDictionaryPageBody_NilHeader(t *testing.T) {
 
 func TestReadPageV2Data_NilHeader(t *testing.T) {
 	pageHeader := &parquet.PageHeader{Type: parquet.PageType_DATA_PAGE_V2}
-	_, err := readPageV2Data(nil, pageHeader, &parquet.ColumnMetaData{}, nil, PageReadOptions{})
+	_, err := readPageV2Data(nil, pageHeader, &parquet.ColumnMetaData{}, nil, PageReadOptions{}, 1, 1)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "missing DataPageHeaderV2")
 }
@@ -395,7 +479,7 @@ func TestReadPageV2Data_CRCFailure(t *testing.T) {
 	mem.Write(data)
 	thriftReader := thrift.NewTBufferedTransport(mem, 1024)
 
-	_, err := readPageV2Data(thriftReader, header, colMetaData, nil, PageReadOptions{CRCMode: common.CRCStrict})
+	_, err := readPageV2Data(thriftReader, header, colMetaData, nil, PageReadOptions{CRCMode: common.CRCStrict}, 0, 0)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "CRC validation failed")
 }
@@ -418,7 +502,7 @@ func TestReadPageV2Data_TruncatedDefinitionLevels(t *testing.T) {
 	mem.Write([]byte{0x01, 0x02}) // only the 2 repetition-level bytes
 	thriftReader := thrift.NewTBufferedTransport(mem, 1024)
 
-	_, err := readPageV2Data(thriftReader, header, colMetaData, nil, PageReadOptions{})
+	_, err := readPageV2Data(thriftReader, header, colMetaData, nil, PageReadOptions{}, 1, 1)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "definition levels")
 }
@@ -441,7 +525,7 @@ func TestReadPageV2Data_TruncatedData(t *testing.T) {
 	mem.Write([]byte{0x01, 0x02, 0x03, 0x04}) // rep+def levels but no data bytes
 	thriftReader := thrift.NewTBufferedTransport(mem, 1024)
 
-	_, err := readPageV2Data(thriftReader, header, colMetaData, nil, PageReadOptions{})
+	_, err := readPageV2Data(thriftReader, header, colMetaData, nil, PageReadOptions{}, 1, 1)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "v2 data")
 }
@@ -465,7 +549,7 @@ func TestReadPageV2Data_DecompressError(t *testing.T) {
 	mem.Write([]byte{0xFF, 0xFF, 0xFF, 0xFF}) // not valid snappy data
 	thriftReader := thrift.NewTBufferedTransport(mem, 1024)
 
-	_, err := readPageV2Data(thriftReader, header, colMetaData, nil, PageReadOptions{})
+	_, err := readPageV2Data(thriftReader, header, colMetaData, nil, PageReadOptions{}, 0, 0)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "decompress v2 data")
 }

--- a/internal/layout/page_read_body_test.go
+++ b/internal/layout/page_read_body_test.go
@@ -1,6 +1,7 @@
 package layout
 
 import (
+	"math"
 	"testing"
 
 	"github.com/apache/thrift/lib/go/thrift"
@@ -27,6 +28,54 @@ func TestReadPageV2Data_InvalidLevels(t *testing.T) {
 	header.DataPageHeaderV2.RepetitionLevelsByteLength = 10
 	header.CompressedPageSize = 15
 	_, err = readPageV2Data(nil, header, nil, nil, PageReadOptions{}, 1, 1)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "level byte lengths exceed page size")
+}
+
+// TestReadPageV2Data_LevelLengthSumOverflow covers level lengths that overflow when summed.
+func TestReadPageV2Data_LevelLengthSumOverflow(t *testing.T) {
+	// Two positive lengths whose int32 sum wraps negative, slipping under the page
+	// size check and reaching make() with a negative length.
+	for _, tt := range []struct {
+		name     string
+		dll, rll int32
+	}{
+		{"definition dominates", math.MaxInt32, 1},
+		{"repetition dominates", 1, math.MaxInt32},
+		{"both halfway", math.MaxInt32 / 2, math.MaxInt32/2 + 2},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			header := &parquet.PageHeader{
+				Type:               parquet.PageType_DATA_PAGE_V2,
+				CompressedPageSize: 64,
+				DataPageHeaderV2: &parquet.DataPageHeaderV2{
+					NumValues:                  1,
+					DefinitionLevelsByteLength: tt.dll,
+					RepetitionLevelsByteLength: tt.rll,
+				},
+			}
+			_, err := readPageV2Data(nil, header, nil, nil, PageReadOptions{}, 1, 1)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "level byte lengths exceed page size")
+		})
+	}
+}
+
+// TestReadPageV2Data_LevelLengthSumOverflowEncrypted covers the same overflow when decrypting.
+func TestReadPageV2Data_LevelLengthSumOverflowEncrypted(t *testing.T) {
+	// The decrypted path slices the plaintext by that sum, so the wrap goes out of
+	// range instead of allocating.
+	header := &parquet.PageHeader{
+		Type:               parquet.PageType_DATA_PAGE_V2,
+		CompressedPageSize: 64,
+		DataPageHeaderV2: &parquet.DataPageHeaderV2{
+			NumValues:                  1,
+			DefinitionLevelsByteLength: math.MaxInt32,
+			RepetitionLevelsByteLength: 1,
+		},
+	}
+	opt := PageReadOptions{Decryptor: &PageDecryptor{}}
+	_, err := readPageV2Data(nil, header, nil, nil, opt, 1, 1)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "level byte lengths exceed page size")
 }
@@ -230,8 +279,7 @@ func TestReadPageV1Data_ReadError(t *testing.T) {
 	require.Error(t, err)
 }
 
-// leafPathName builds the InName path and joined name for a leaf column the same
-// way the page reader does (root InName + capitalized column InName).
+// leafPathName builds a leaf column's InName path and joined name as the page reader does.
 func leafPathName(sh *schema.SchemaHandler, colInName string) ([]string, string) {
 	path := []string{sh.GetRootInName(), colInName}
 	return path, common.PathToStr(path)

--- a/internal/layout/page_read_levels.go
+++ b/internal/layout/page_read_levels.go
@@ -21,8 +21,11 @@ func (p *Page) extractV2LevelBuffers(maxRepetitionLevel, maxDefinitionLevel int3
 	if dll < 0 || rll < 0 {
 		return nil, fmt.Errorf("GetRLDLFromRawData: invalid level byte lengths (dll=%d, rll=%d)", dll, rll)
 	}
-	rawDataLen := int32(len(p.RawData))
-	if dll+rll > rawDataLen {
+	// Widened before summing: two positive int32 lengths can wrap negative, slipping
+	// past this check and reaching make() below with a negative length.
+	levelsLen := int64(dll) + int64(rll)
+	rawDataLen := int64(len(p.RawData))
+	if levelsLen > rawDataLen {
 		return nil, fmt.Errorf("GetRLDLFromRawData: level byte lengths exceed raw data size (dll=%d + rll=%d > %d)", dll, rll, rawDataLen)
 	}
 	if err := validateV2LevelSections(rll, dll, maxRepetitionLevel, maxDefinitionLevel,
@@ -32,7 +35,7 @@ func (p *Page) extractV2LevelBuffers(maxRepetitionLevel, maxDefinitionLevel int3
 
 	bytesReader := bytes.NewReader(p.RawData)
 	repetitionLevelsBuf, definitionLevelsBuf := make([]byte, rll), make([]byte, dll)
-	dataBuf := make([]byte, len(p.RawData)-int(rll)-int(dll))
+	dataBuf := make([]byte, rawDataLen-levelsLen)
 	if _, err := bytesReader.Read(repetitionLevelsBuf); err != nil {
 		return nil, fmt.Errorf("read v2 repetition levels: %w", err)
 	}

--- a/internal/layout/page_read_levels.go
+++ b/internal/layout/page_read_levels.go
@@ -11,9 +11,10 @@ import (
 	"github.com/hangxie/parquet-go/v3/schema"
 )
 
-// extractV2LevelBuffers extracts the level data from a V2 data page and reassembles it into
-// a contiguous buffer with level-length prefixes followed by value data.
-func (p *Page) extractV2LevelBuffers() ([]byte, error) {
+// extractV2LevelBuffers reassembles a V2 data page into level-length prefixes followed by value data.
+func (p *Page) extractV2LevelBuffers(maxRepetitionLevel, maxDefinitionLevel int32) ([]byte, error) {
+	// The schema's max levels decide which sections get a prefix, matching what
+	// decodeDataPageLevels reads back; writers pad the length even at level 0.
 	dll := p.Header.DataPageHeaderV2.GetDefinitionLevelsByteLength()
 	rll := p.Header.DataPageHeaderV2.GetRepetitionLevelsByteLength()
 
@@ -23,6 +24,10 @@ func (p *Page) extractV2LevelBuffers() ([]byte, error) {
 	rawDataLen := int32(len(p.RawData))
 	if dll+rll > rawDataLen {
 		return nil, fmt.Errorf("GetRLDLFromRawData: level byte lengths exceed raw data size (dll=%d + rll=%d > %d)", dll, rll, rawDataLen)
+	}
+	if err := validateV2LevelSections(rll, dll, maxRepetitionLevel, maxDefinitionLevel,
+		p.Header.DataPageHeaderV2.GetNumValues()); err != nil {
+		return nil, err
 	}
 
 	bytesReader := bytes.NewReader(p.RawData)
@@ -39,7 +44,7 @@ func (p *Page) extractV2LevelBuffers() ([]byte, error) {
 	}
 
 	buf := make([]byte, 0)
-	if rll > 0 {
+	if rll > 0 && maxRepetitionLevel > 0 {
 		tmpBuf, err := encoding.WritePlainINT32([]any{int32(rll)})
 		if err != nil {
 			return nil, fmt.Errorf("encode repetition level length: %w", err)
@@ -47,7 +52,7 @@ func (p *Page) extractV2LevelBuffers() ([]byte, error) {
 		buf = append(buf, tmpBuf...)
 		buf = append(buf, repetitionLevelsBuf...)
 	}
-	if dll > 0 {
+	if dll > 0 && maxDefinitionLevel > 0 {
 		tmpBuf, err := encoding.WritePlainINT32([]any{int32(dll)})
 		if err != nil {
 			return nil, fmt.Errorf("encode definition level length: %w", err)
@@ -85,7 +90,9 @@ func (p *Page) GetRLDLFromRawData(schemaHandler *schema.SchemaHandler) (int64, i
 	var err error
 
 	if p.Header.GetType() == parquet.PageType_DATA_PAGE_V2 {
-		buf, err = p.extractV2LevelBuffers()
+		maxDefinitionLevel, _ := schemaHandler.MaxDefinitionLevel(p.Path)
+		maxRepetitionLevel, _ := schemaHandler.MaxRepetitionLevel(p.Path)
+		buf, err = p.extractV2LevelBuffers(maxRepetitionLevel, maxDefinitionLevel)
 		if err != nil {
 			return 0, 0, fmt.Errorf("extract v2 level buffers: %w", err)
 		}

--- a/internal/layout/page_read_levels_test.go
+++ b/internal/layout/page_read_levels_test.go
@@ -2,6 +2,7 @@ package layout
 
 import (
 	"bytes"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -443,6 +444,36 @@ func TestExtractV2LevelBuffers_Errors(t *testing.T) {
 	page.RawData = make([]byte, 15)
 	_, err = page.extractV2LevelBuffers(1, 1)
 	require.Error(t, err)
+}
+
+// TestExtractV2LevelBuffers_LevelLengthSumOverflow covers level lengths that overflow when summed.
+func TestExtractV2LevelBuffers_LevelLengthSumOverflow(t *testing.T) {
+	// Two positive lengths whose int32 sum wraps negative, slipping under the raw
+	// data size check and reaching make() with a negative length.
+	for _, tt := range []struct {
+		name     string
+		dll, rll int32
+	}{
+		{"definition dominates", math.MaxInt32, 1},
+		{"repetition dominates", 1, math.MaxInt32},
+		{"both halfway", math.MaxInt32 / 2, math.MaxInt32/2 + 2},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			page := &Page{
+				Header: &parquet.PageHeader{
+					DataPageHeaderV2: &parquet.DataPageHeaderV2{
+						NumValues:                  1,
+						DefinitionLevelsByteLength: tt.dll,
+						RepetitionLevelsByteLength: tt.rll,
+					},
+				},
+				RawData: make([]byte, 64),
+			}
+			_, err := page.extractV2LevelBuffers(1, 1)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "level byte lengths exceed raw data size")
+		})
+	}
 }
 
 func TestExtractV2LevelBuffers(t *testing.T) {

--- a/internal/layout/page_read_levels_test.go
+++ b/internal/layout/page_read_levels_test.go
@@ -435,14 +435,65 @@ func TestExtractV2LevelBuffers_Errors(t *testing.T) {
 			},
 		},
 	}
-	_, err := page.extractV2LevelBuffers()
+	_, err := page.extractV2LevelBuffers(1, 1)
 	require.Error(t, err)
 
 	page.Header.DataPageHeaderV2.DefinitionLevelsByteLength = 10
 	page.Header.DataPageHeaderV2.RepetitionLevelsByteLength = 10
 	page.RawData = make([]byte, 15)
-	_, err = page.extractV2LevelBuffers()
+	_, err = page.extractV2LevelBuffers(1, 1)
 	require.Error(t, err)
+}
+
+func TestExtractV2LevelBuffers(t *testing.T) {
+	// 2 bytes of repetition levels, 1 of definition levels, 3 of values. Which
+	// sections survive depends on the schema's max levels.
+	newPage := func() *Page {
+		return &Page{
+			Header: &parquet.PageHeader{
+				DataPageHeaderV2: &parquet.DataPageHeaderV2{
+					NumValues:                  1,
+					RepetitionLevelsByteLength: 2,
+					DefinitionLevelsByteLength: 1,
+				},
+			},
+			RawData: []byte{0x01, 0x02, 0x03, 0x0A, 0x0B, 0x0C},
+		}
+	}
+
+	t.Run("repeated column keeps both sections", func(t *testing.T) {
+		buf, err := newPage().extractV2LevelBuffers(1, 1)
+		require.NoError(t, err)
+		require.Equal(t, []byte{
+			0x02, 0x00, 0x00, 0x00, 0x01, 0x02, // rll prefix + repetition levels
+			0x01, 0x00, 0x00, 0x00, 0x03, // dll prefix + definition levels
+			0x0A, 0x0B, 0x0C, // values
+		}, buf)
+	})
+
+	t.Run("repetition levels dropped when column cannot repeat", func(t *testing.T) {
+		// Those 2 bytes hold no levels and must not reach the level decoder.
+		buf, err := newPage().extractV2LevelBuffers(0, 1)
+		require.NoError(t, err)
+		require.Equal(t, []byte{0x01, 0x00, 0x00, 0x00, 0x03, 0x0A, 0x0B, 0x0C}, buf)
+	})
+
+	t.Run("both dropped when column is required and flat", func(t *testing.T) {
+		buf, err := newPage().extractV2LevelBuffers(0, 0)
+		require.NoError(t, err)
+		require.Equal(t, []byte{0x0A, 0x0B, 0x0C}, buf)
+	})
+
+	t.Run("page contradicting the schema is rejected", func(t *testing.T) {
+		// Wires up validateV2LevelSections: no repetition levels on a column
+		// that repeats would have the definition levels read as repetition ones.
+		page := newPage()
+		page.Header.DataPageHeaderV2.RepetitionLevelsByteLength = 0
+
+		_, err := page.extractV2LevelBuffers(1, 1)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "carries no repetition levels")
+	})
 }
 
 func TestReadLevelValues_MaxLevel(t *testing.T) {

--- a/reader/path.go
+++ b/reader/path.go
@@ -8,18 +8,22 @@ import (
 	"github.com/hangxie/parquet-go/v3/schema"
 )
 
-func schemaRootInName(sh *schema.SchemaHandler) string {
+// schemaRootInName reports the root element's internal name and whether a root exists.
+func schemaRootInName(sh *schema.SchemaHandler) (string, bool) {
+	// parquet-mr names the root "", so presence is reported separately: treating
+	// "" as "no root" drops the root prefix and no column ever matches.
 	if sh == nil || len(sh.Infos) == 0 || sh.Infos[0] == nil {
-		return ""
+		return "", false
 	}
-	return sh.Infos[0].InName
+	return sh.Infos[0].InName, true
 }
 
-func schemaRootExName(sh *schema.SchemaHandler) string {
+// schemaRootExName reports the root element's external name and whether a root exists.
+func schemaRootExName(sh *schema.SchemaHandler) (string, bool) {
 	if sh == nil || len(sh.Infos) == 0 || sh.Infos[0] == nil {
-		return ""
+		return "", false
 	}
-	return sh.Infos[0].ExName
+	return sh.Infos[0].ExName, true
 }
 
 func lookupExternalPath(sh *schema.SchemaHandler, path string, caseInsensitive bool) (string, bool) {
@@ -43,8 +47,8 @@ func lookupExternalPath(sh *schema.SchemaHandler, path string, caseInsensitive b
 }
 
 func columnPathToInPath(sh *schema.SchemaHandler, path []string, caseInsensitive bool) string {
-	rootInName := schemaRootInName(sh)
-	if rootInName == "" {
+	rootInName, ok := schemaRootInName(sh)
+	if !ok {
 		return common.PathToStr(path)
 	}
 
@@ -55,10 +59,8 @@ func columnPathToInPath(sh *schema.SchemaHandler, path []string, caseInsensitive
 		}
 	}
 
-	rootExName := schemaRootExName(sh)
-	if rootExName == "" {
-		return inPath
-	}
+	// The root is known to exist by now, and "" is still a name to build a path from.
+	rootExName, _ := schemaRootExName(sh)
 
 	exPath := common.PathToStr(append([]string{rootExName}, path...))
 	if mappedPath, ok := lookupExternalPath(sh, exPath, caseInsensitive); ok {

--- a/reader/path_test.go
+++ b/reader/path_test.go
@@ -23,12 +23,27 @@ func testPathSchemaHandler() *schema.SchemaHandler {
 	}
 }
 
+// unnamedRootSchemaHandler mirrors a parquet-mr file whose root element carries no name.
+func unnamedRootSchemaHandler() *schema.SchemaHandler {
+	inPath := common.PathToStr([]string{"", "C0"})
+	exPath := common.PathToStr([]string{"", "c0"})
+	return &schema.SchemaHandler{
+		Infos: []*common.Tag{
+			{InName: "", ExName: ""},
+			{InName: "C0", ExName: "c0"},
+		},
+		MapIndex:       map[string]int32{inPath: 1},
+		ExPathToInPath: map[string]string{exPath: inPath},
+	}
+}
+
 func TestSchemaRootNames(t *testing.T) {
 	tests := []struct {
 		name       string
 		handler    *schema.SchemaHandler
 		wantInName string
 		wantExName string
+		wantOK     bool
 	}{
 		{name: "nil_handler"},
 		{name: "empty_infos", handler: &schema.SchemaHandler{}},
@@ -40,13 +55,24 @@ func TestSchemaRootNames(t *testing.T) {
 			},
 			wantInName: "RootIn",
 			wantExName: "root_ex",
+			wantOK:     true,
+		},
+		{
+			name:    "empty_root_names_still_present",
+			handler: &schema.SchemaHandler{Infos: []*common.Tag{{}}},
+			wantOK:  true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.wantInName, schemaRootInName(tt.handler))
-			require.Equal(t, tt.wantExName, schemaRootExName(tt.handler))
+			gotInName, gotInOK := schemaRootInName(tt.handler)
+			require.Equal(t, tt.wantInName, gotInName)
+			require.Equal(t, tt.wantOK, gotInOK)
+
+			gotExName, gotExOK := schemaRootExName(tt.handler)
+			require.Equal(t, tt.wantExName, gotExName)
+			require.Equal(t, tt.wantOK, gotExOK)
 		})
 	}
 }
@@ -99,10 +125,20 @@ func TestColumnPathToInPath(t *testing.T) {
 		{name: "case_mismatch_falls_back", handler: handler, path: []string{"COL_L1"}, want: common.PathToStr([]string{common.ParGoRootInName, "COL_L1"})},
 		{name: "case_insensitive_external_path", handler: handler, path: []string{"COL_L1"}, caseInsensitive: true, want: wantInPath},
 		{
-			name:    "empty_external_root_falls_back",
+			// An empty external root name still builds a path; this falls back to
+			// the internal one because nothing maps it.
+			name:    "unmapped_external_path_falls_back",
 			handler: &schema.SchemaHandler{Infos: []*common.Tag{{InName: "Root"}}, MapIndex: map[string]int32{}},
 			path:    []string{"leaf"},
 			want:    common.PathToStr([]string{"Root", "leaf"}),
+		},
+		{
+			// parquet-mr leaves the root unnamed; that empty name must still
+			// prefix the path so the column resolves through ExPathToInPath.
+			name:    "unnamed_root",
+			handler: unnamedRootSchemaHandler(),
+			path:    []string{"c0"},
+			want:    common.PathToStr([]string{"", "C0"}),
 		},
 	}
 


### PR DESCRIPTION
Four read-path fixes. The first three each made a file written by parquet-mr unreadable; they were found together while reading parquet-mr output and are otherwise unrelated.

- **Unnamed root schema element.** parquet-mr leaves the root schema element's name empty, which was indistinguishable from a missing root, so column paths lost their root prefix and every column failed with `Column not found`. Presence is now tracked separately from the name.
- **Hadoop LZ4 framing.** parquet-mr writes the deprecated LZ4 codec with Hadoop's block framing, which failed with `lz4: bad magic number`. Decoding now tries the self-describing LZ4 frame first and falls back to the Hadoop framing. Reads accept both; writes still emit frames only, so the README notes that an LZ4 file this library writes is unreadable by parquet-mr — the concrete reason to prefer `LZ4_RAW`.
- **V2 page level sections.** Which level sections a `DATA_PAGE_V2` carries is now decided by the schema's max levels rather than the header's byte lengths, matching what the decoder reads back. Writers emit a non-zero `repetition_levels_byte_length` for columns that cannot repeat, and those bytes were being misread as the definition levels, failing with `decode RLE values: EOF`.
- **Level byte length overflow** (pre-existing on `main`). The two i32 level lengths were summed as `int32` before being bounds-checked, so a pair near `math.MaxInt32` wrapped negative, slipped past the check, and reached `make()` — panicking with `makeslice: len out of range`. Now summed as `int64`.

No public API changes, and files this library writes are unchanged.

`make all` passes. Coverage is 95.4383% versus 95.4149% on `main`.

The LZ4 fix here is read-only. #383 proposes the matching write-side change, so files written with the deprecated `LZ4` codec become readable by parquet-mr too.
