### PR TITLE
fix(schema): guard root name getters on Infos, not SchemaElements

### DIFF
--- a/schema/schemahandler.go
+++ b/schema/schemahandler.go
@@ -268,16 +268,17 @@ func (sh *SchemaHandler) ConvertToInPathStr(pathStr string) (string, error) {
 	return "", fmt.Errorf("path not found: %v", pathStr)
 }
 
-// Get root name from the schema handler
+// GetRootInName returns the root element's internal name, or "" if there is none.
 func (sh *SchemaHandler) GetRootInName() string {
-	if len(sh.SchemaElements) <= 0 {
+	if len(sh.Infos) == 0 || sh.Infos[0] == nil {
 		return ""
 	}
 	return sh.Infos[0].InName
 }
 
+// GetRootExName returns the root element's external name, or "" if there is none.
 func (sh *SchemaHandler) GetRootExName() string {
-	if len(sh.SchemaElements) <= 0 {
+	if len(sh.Infos) == 0 || sh.Infos[0] == nil {
 		return ""
 	}
 	return sh.Infos[0].ExName

--- a/schema/schemahandler_test.go
+++ b/schema/schemahandler_test.go
@@ -54,7 +54,7 @@ func TestSchemaHandler_GetRepetitionLevelIndex(t *testing.T) {
 	require.NotNil(t, err)
 }
 
-func TestSchemaHandler_GetRootExName(t *testing.T) {
+func TestSchemaHandler_GetRootName(t *testing.T) {
 	// Create a schema with various field types
 	schema, err := NewSchemaHandlerFromStruct(new(struct {
 		SimpleField  string `parquet:"name=simple_field, type=BYTE_ARRAY, convertedtype=UTF8"`
@@ -65,21 +65,40 @@ func TestSchemaHandler_GetRootExName(t *testing.T) {
 	}))
 	require.Nil(t, err)
 
-	// Test getting root external name (this function takes no parameters)
-	rootName := schema.GetRootExName()
-	require.NotEmpty(t, rootName)
-
-	// The root ExName should be the external name of the root element
-	// For struct schemas, this is typically the root name (case-sensitive)
-	require.Equal(t, common.ParGoRootExName, rootName)
-
-	// Test with empty schema
-	emptySchema := &SchemaHandler{
-		SchemaElements: []*parquet.SchemaElement{},
-		Infos:          []*common.Tag{},
+	// A handler carrying only Infos is enough to name the root, and one carrying
+	// only SchemaElements must not index into an empty Infos.
+	infosOnly := &SchemaHandler{
+		Infos: []*common.Tag{{InName: "Custom_root", ExName: "custom_root"}},
 	}
-	emptyRootName := emptySchema.GetRootExName()
-	require.Equal(t, "", emptyRootName)
+	elementsOnly := &SchemaHandler{
+		SchemaElements: []*parquet.SchemaElement{{Name: "custom_root"}},
+	}
+	// SchemaElements is populated so the nil tag is reached rather than
+	// short-circuited by an emptiness check on the wrong slice.
+	nilInfo := &SchemaHandler{
+		SchemaElements: []*parquet.SchemaElement{{Name: "custom_root"}},
+		Infos:          []*common.Tag{nil},
+	}
+
+	testCases := []struct {
+		name     string
+		handler  *SchemaHandler
+		expectIn string
+		expectEx string
+	}{
+		{"from-struct", schema, common.ParGoRootInName, common.ParGoRootExName},
+		{"empty", &SchemaHandler{}, "", ""},
+		{"infos-only", infosOnly, "Custom_root", "custom_root"},
+		{"elements-only", elementsOnly, "", ""},
+		{"nil-info", nilInfo, "", ""},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expectIn, tc.handler.GetRootInName())
+			require.Equal(t, tc.expectEx, tc.handler.GetRootExName())
+		})
+	}
 }
 
 func TestSchemaHandler_MaxDefinitionLevel(t *testing.T) {


### PR DESCRIPTION
`GetRootInName` and `GetRootExName` index `Infos[0]` but bounds-checked `SchemaElements`. The two slices are built in parallel by every constructor, so the mismatch is invisible in practice, but a hand-built `SchemaHandler` hits it two ways: one carrying only `Infos` silently returned `""`, and one carrying only `SchemaElements` panicked on the nil index.

Both getters now guard the slice they actually read, including a nil check on the first element.

## Compatibility

No constructor is affected — `NewSchemaHandlerFromStruct`, `...FromSchemaList`, `...FromSchemaHandler`, `...FromArrow`, `...FromJSON` and `...FromMetadata` all populate `Infos` alongside `SchemaElements`, so every handler they produce returns exactly what it did before.

`SchemaHandler` is publicly constructible, though, so one observable change is worth calling out: a hand-built handler carrying only `Infos` used to return `""` and now returns the names from `Infos[0]`. That is the intended correction, since `Infos` is the sole source of both values, but it is a behavior change rather than a pure bug fix for anyone assembling the struct directly.

## Testing

`TestSchemaHandler_GetRootExName` is renamed to `TestSchemaHandler_GetRootName` and converted to a table now that it covers both getters: schema built from a struct, empty handler, infos-only, elements-only, and a handler with populated `SchemaElements` whose first `Infos` entry is nil. That last fixture carries schema elements deliberately, so it nil-derefs against the pre-fix implementation instead of being short-circuited by the emptiness check on the wrong slice.

Both functions are at 100% statement coverage; `make all` passes with a repo total of 95.5%.
