### PR TITLE
fix(reader): tag missing footer key with ErrColumnKeyRequired

### DIFF
--- a/reader/encryption.go
+++ b/reader/encryption.go
@@ -18,8 +18,8 @@ import (
 	"github.com/hangxie/parquet-go/v3/source"
 )
 
-// ErrColumnKeyRequired reports an encrypted column without a direct,
-// retrieved, or footer-key match. Match with errors.Is.
+// ErrColumnKeyRequired reports encrypted data, either a column or the file
+// footer, with no configured or retrievable key. Match with errors.Is.
 var ErrColumnKeyRequired = errors.New("decryption key required")
 
 func (pr *ParquetReader) readEncryptedFooter(size uint32) error {
@@ -148,7 +148,7 @@ func (pr *ParquetReader) resolveFooterKeyFromMetadata(keyMetadata []byte) ([]byt
 			return key, nil
 		}
 	}
-	return nil, fmt.Errorf("decryption key required for footer")
+	return nil, fmt.Errorf("%w for footer", ErrColumnKeyRequired)
 }
 
 // resolveOptionalFooterKeyFromMetadata returns the footer key if one is

--- a/reader/encryption_test.go
+++ b/reader/encryption_test.go
@@ -1516,6 +1516,16 @@ func TestEncryptionHelperErrors(t *testing.T) {
 		},
 	})
 	require.ErrorContains(t, err, "decryption key required")
+	require.ErrorIs(t, err, ErrColumnKeyRequired)
+
+	// A footer-key column reports the same condition, so it carries the same sentinel.
+	_, err = pr.resolveColumnKey(&parquet.ColumnChunk{
+		CryptoMetadata: &parquet.ColumnCryptoMetaData{
+			ENCRYPTION_WITH_FOOTER_KEY: parquet.NewEncryptionWithFooterKey(),
+		},
+	})
+	require.ErrorContains(t, err, "decryption key required for footer")
+	require.ErrorIs(t, err, ErrColumnKeyRequired)
 
 	retrieverErr := fmt.Errorf("kms failure")
 	pr = &ParquetReader{}


### PR DESCRIPTION
A column encrypted with `ENCRYPTION_WITH_FOOTER_KEY` reported a missing key as a bare `fmt.Errorf` in `resolveFooterKeyFromMetadata`, while a column encrypted with its own key reported the same condition wrapped in `ErrColumnKeyRequired`. Callers could handle one gracefully and had to match on the error string for the other.

`resolveFooterKeyFromMetadata` now wraps the same sentinel. The message text is unchanged (`decryption key required for footer`), so string matching keeps working, and `errors.Is(err, reader.ErrColumnKeyRequired)` now succeeds for both encryption modes.

The sentinel is shared rather than duplicated, so callers need one check instead of two; its doc comment now states that it covers a column or the file footer. Note that `resolveFooterKeyFromMetadata` is also on the file-open path, so opening a file with an encrypted footer and no key matches the sentinel too.

`make all` passes.